### PR TITLE
Prevent n_jobs in recon_all to be changed by positional arguments

### DIFF
--- a/scripts/freesurfer/recon_all.py
+++ b/scripts/freesurfer/recon_all.py
@@ -60,7 +60,7 @@ def run_recon(root_dir, subject, fs_bids_app) -> None:
     run_subprocess(cmd, env=env, verbose=logger.level)
 
 
-def main(n_jobs: int = 1) -> None:
+def main(*, n_jobs: int = 1) -> None:
     """Run freesurfer recon-all command on BIDS dataset.
 
     The command allows to run the freesurfer recon-all


### PR DESCRIPTION
Fixes #287

The recon_all main script should not use positional arguments anymore.

The fix was actually quite simple.
@agramfort  I'm not sure whether I should change any of the tests, so please let me know if I need to.