### PR TITLE
Make type imports work on Python <3.8

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,12 +11,12 @@ import traceback
 import sys
 import copy
 import logging
+
+from typing import Optional, Union, Iterable, List, Tuple, Dict, Callable
 if sys.version_info >= (3, 8):
-    from typing import (Optional, Union, Iterable, List, Tuple, Dict, Literal,
-                        Callable)
+    from typing import Literal
 else:
-    from typing_extensions import (Optional, Union, Iterable, List, Tuple,
-                                   Dict, Literal, Callable)
+    from typing_extensions import Literal
 
 import coloredlogs
 import numpy as np

--- a/docs/source/getting_started/install.md
+++ b/docs/source/getting_started/install.md
@@ -17,7 +17,7 @@ required to run the pipeline.
 ??? example "Install for older Python versions"
     Run in your terminal:
     ```shell
-    pip install mne-bids coloredlogs tqdm pandas json_tricks scikit-learn fire typing_extension
+    pip install mne-bids coloredlogs tqdm pandas json_tricks scikit-learn fire typing_extensions
     ```
 
 ??? info "Detailed list of dependencies"

--- a/run.py
+++ b/run.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python
 
-import fire
 import os
+import sys
 import runpy
 import pathlib
 import logging
-import coloredlogs
 from typing import Union, Optional, Tuple
-try:
+if sys.version_info >= (3, 8):
     from typing import Literal
-except ImportError:  # Python <3.8
+else:
     from typing_extensions import Literal
+
+import fire
+import coloredlogs
 
 logger = logging.getLogger(__name__)
 coloredlogs.install(fmt='%(asctime)s %(levelname)s %(message)s', logger=logger)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -4,10 +4,11 @@ import os
 from pathlib import Path
 import argparse
 import runpy
+from typing import Collection, Dict
 if sys.version_info >= (3, 8):
-    from typing import TypedDict, Collection, Dict
+    from typing import TypedDict
 else:
-    from typing_extensions import TypedDict, Collection, Dict
+    from typing_extensions import TypedDict
 
 
 # Add the pipelines dir to the PATH


### PR DESCRIPTION
We don't test this in CI, so … let's wait for users to complain, I guess ;)

Fixes #288