### PR TITLE
ENH: Allow to exclude specific channels when applying rejection thresholds to epochs

### DIFF
--- a/config.py
+++ b/config.py
@@ -613,6 +613,23 @@ with the last time point.
     ```
 """
 
+reject_exclusions: Iterable[str] = []
+"""
+Names of channels to exclude when applying rejection thresholds. For example,
+in an EEG recording you might want to set a global rejection threshold to
+100 µV, but electrodes close to the eyes – like `Fp1` and `Fp2` – would then
+lead to the rejection of many epochs. In this situation, you could set
+`reject_exclusions = ['Fp1', 'Fp2']` to disregard those channels when it comes
+to exclusion based on peak-to-peak amplitude.
+
+???+ example "Example"
+    ```python
+    reject_exclusions = ['Fp1', 'Fp2']  # exclude Fp1 and Fp2
+    reject_exclusions = ['Fpz']  # exclude Fpz
+    ```
+"""
+
+
 ###############################################################################
 # RENAME EXPERIMENTAL EVENTS
 # --------------------------

--- a/config.py
+++ b/config.py
@@ -620,12 +620,12 @@ in an EEG recording you might want to set a global rejection threshold to
 100 µV, but electrodes close to the eyes – like `Fp1` and `Fp2` – would then
 lead to the rejection of many epochs. In this situation, you could set
 `reject_exclusions = ['Fp1', 'Fp2']` to disregard those channels when it comes
-to exclusion based on peak-to-peak amplitude.
+to epochs rejection based on peak-to-peak amplitude.
 
 ???+ example "Example"
     ```python
     reject_exclusions = ['Fp1', 'Fp2']  # exclude Fp1 and Fp2
-    reject_exclusions = ['Fpz']  # exclude Fpz
+    reject_exclusions = ['Fpz']  # exclude a single channel (Fpz)
     ```
 """
 

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -10,7 +10,9 @@ authors:
 
 ### New features & enhancements
 
-- ...
+- New configuration option `reject_exclusions` to exclude specific channels
+  when applying rejection thresholds to epochs ({{ gh(xxx) }} by
+  {{ authors.hoechenberger}})
 
 ### Bug fixes
 

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -11,7 +11,7 @@ authors:
 ### New features & enhancements
 
 - New configuration option `reject_exclusions` to exclude specific channels
-  when applying rejection thresholds to epochs ({{ gh(xxx) }} by
+  when applying rejection thresholds to epochs ({{ gh(300) }} by
   {{ authors.hoechenberger}})
 
 ### Bug fixes

--- a/docs/source/settings/preprocessing/artifacts.md
+++ b/docs/source/settings/preprocessing/artifacts.md
@@ -7,3 +7,4 @@
 ::: config.reject
 ::: config.reject_tmin
 ::: config.reject_tmax
+::: config.reject_exclusions

--- a/tests/configs/config_ERP_CORE.py
+++ b/tests/configs/config_ERP_CORE.py
@@ -33,7 +33,6 @@ sessions = [task]
 
 subjects = ['015', '016', '017', '018', '019']
 
-
 ch_types = ['eeg']
 interactive = False
 
@@ -44,6 +43,9 @@ eeg_bipolar_channels = {'HEOG': ('HEOG_left', 'HEOG_right'),
                         'VEOG': ('VEOG_lower', 'FP2')}
 drop_channels = ['HEOG_left', 'HEOG_right', 'VEOG_lower']
 eog_channels = ['HEOG', 'VEOG']
+
+reject =  {'eeg': 250e-6}
+reject_exclusions = ['FP1', 'FP2']
 
 l_freq = 0.1
 h_freq = None


### PR DESCRIPTION
This allows us to re-enable the `reject` dictionary for ERP CORE: we can now simply exclude the electrodes close to the eyes from rejection 👌