### PR TITLE
minor typo in comment

### DIFF
--- a/config.py
+++ b/config.py
@@ -653,7 +653,7 @@ aggregation will take place and no new columns will be created.
 
     You may also specify a grouping for multiple event types:
     ```python
-    keep_first=['response', 'stimulus'].
+    epochs_metadata_keep_first=['response', 'stimulus'].
     ```
     This will add the columns ``response``, ``first_response``, ``stimulus``,
     and ``first_stimulus``.

--- a/config.py
+++ b/config.py
@@ -653,7 +653,7 @@ aggregation will take place and no new columns will be created.
 
     You may also specify a grouping for multiple event types:
     ```python
-    epochs_metadata_keep_first=['response', 'stimulus'].
+    epochs_metadata_keep_first = ['response', 'stimulus']
     ```
     This will add the columns ``response``, ``first_response``, ``stimulus``,
     and ``first_stimulus``.

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -3,6 +3,7 @@ authors:
   MerlinDemeur: "[Merlin Dumeur](https://github.com/MerlinDumeur)"
   agramfort: "[Alex Gramfort](https://github.com/agramfort)"
   hoechenberger: "[Richard Höchenberger](https://github.com/hoechenberger)"
+  guiomar: "[Julia Guiomar Niso Galán](https://github.com/guiomar)"
 ---
 
 


### PR DESCRIPTION
minor typo in comment of epochs_metadata_keep_first

### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
