### PR TITLE
Add getter functions for {bids,deriv}_root

### DIFF
--- a/scripts/freesurfer/recon_all.py
+++ b/scripts/freesurfer/recon_all.py
@@ -84,7 +84,7 @@ def main() -> None:
     logger.info('Running FreeSurfer')
 
     subjects = config.get_subjects()
-    root_dir = config.bids_root
+    root_dir = config.get_bids_root()
     subjects_dir = _get_subjects_dir(root_dir)
     subjects_dir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/init/00-init_derivatives_dir.py
+++ b/scripts/init/00-init_derivatives_dir.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import logging
 import itertools
 from typing import Optional

--- a/scripts/init/00-init_derivatives_dir.py
+++ b/scripts/init/00-init_derivatives_dir.py
@@ -19,7 +19,7 @@ def init_dataset() -> None:
     msg = "Initializing output directories."
     logger.info(gen_log_message(step=1, message=msg))
 
-    deriv_root = Path(config.deriv_root)
+    deriv_root = config.get_deriv_root()
     deriv_root.mkdir(exist_ok=True, parents=True)
 
     # Write a dataset_description.json for the pipeline
@@ -46,7 +46,7 @@ def init_subject_dirs(
 ) -> None:
     """Create processing data output directories for individual participants.
     """
-    deriv_root = Path(config.deriv_root)
+    deriv_root = config.get_deriv_root()
     datatype = config.get_datatype()
 
     out_dir = deriv_root / f'sub-{subject}'

--- a/scripts/preprocessing/01-import_and_maxfilter.py
+++ b/scripts/preprocessing/01-import_and_maxfilter.py
@@ -50,11 +50,12 @@ logger = logging.getLogger('mne-bids-pipeline')
 
 def get_mf_cal_fname(subject, session):
     if config.mf_cal_fname is None:
-        mf_cal_fpath = BIDSPath(subject=subject,
-                                session=session,
-                                suffix='meg',
-                                datatype='meg',
-                                root=config.bids_root).meg_calibration_fpath
+        mf_cal_fpath = (BIDSPath(subject=subject,
+                                 session=session,
+                                 suffix='meg',
+                                 datatype='meg',
+                                 root=config.get_bids_root())
+                        .meg_calibration_fpath)
         if mf_cal_fpath is None:
             raise ValueError('Could not find Maxwell Filter Calibration '
                              'file.')
@@ -69,11 +70,12 @@ def get_mf_cal_fname(subject, session):
 
 def get_mf_ctc_fname(subject, session):
     if config.mf_ctc_fname is None:
-        mf_ctc_fpath = BIDSPath(subject=subject,
-                                session=session,
-                                suffix='meg',
-                                datatype='meg',
-                                root=config.bids_root).meg_crosstalk_fpath
+        mf_ctc_fpath = (BIDSPath(subject=subject,
+                                 session=session,
+                                 suffix='meg',
+                                 datatype='meg',
+                                 root=config.get_bids_root())
+                        .meg_crosstalk_fpath)
         if mf_ctc_fpath is None:
             raise ValueError('Could not find Maxwell Filter cross-talk '
                              'file.')
@@ -142,7 +144,7 @@ def find_bad_channels(raw, subject, session, task, run):
                          space=config.space,
                          suffix=config.get_datatype(),
                          datatype=config.get_datatype(),
-                         root=config.deriv_root)
+                         root=config.get_deriv_root())
 
     auto_noisy_chs, auto_flat_chs, auto_scores = find_bad_channels_maxwell(
         raw=raw,
@@ -306,9 +308,9 @@ def run_maxwell_filter(subject, session=None):
                             space=config.space,
                             suffix=config.get_datatype(),
                             datatype=config.get_datatype(),
-                            root=config.bids_root)
+                            root=config.get_bids_root())
     bids_path_out = bids_path_in.copy().update(suffix='raw',
-                                               root=config.deriv_root,
+                                               root=config.get_deriv_root(),
                                                check=False)
 
     # Load dev_head_t and digitization points from MaxFilter reference run.

--- a/scripts/preprocessing/02-frequency_filter.py
+++ b/scripts/preprocessing/02-frequency_filter.py
@@ -48,7 +48,7 @@ def run_filter(subject, run=None, session=None):
                          suffix='raw',
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     # Prepare a name to save the data

--- a/scripts/preprocessing/03-make_epochs.py
+++ b/scripts/preprocessing/03-make_epochs.py
@@ -35,7 +35,7 @@ def run_epochs(subject, session=None):
                          space=config.space,
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root)
+                         root=config.get_deriv_root())
 
     for run in config.get_runs():
         # Prepare a name to save the data

--- a/scripts/preprocessing/04a-run_ica.py
+++ b/scripts/preprocessing/04a-run_ica.py
@@ -240,7 +240,7 @@ def run_ica(subject, session=None):
                              recording=config.rec,
                              space=config.space,
                              datatype=config.get_datatype(),
-                             root=config.deriv_root,
+                             root=config.get_deriv_root(),
                              check=False)
 
     ica_fname = bids_basename.copy().update(suffix='ica', extension='.fif')

--- a/scripts/preprocessing/04b-run_ssp.py
+++ b/scripts/preprocessing/04b-run_ssp.py
@@ -33,7 +33,7 @@ def run_ssp(subject, session=None):
                          space=config.space,
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root)
+                         root=config.get_deriv_root())
 
     # Prepare a name to save the data
     raw_fname_in = bids_path.copy().update(processing='filt', suffix='raw',

--- a/scripts/preprocessing/05a-apply_ica.py
+++ b/scripts/preprocessing/05a-apply_ica.py
@@ -43,7 +43,7 @@ def apply_ica(subject, session):
                              recording=config.rec,
                              space=config.space,
                              datatype=config.get_datatype(),
-                             root=config.deriv_root,
+                             root=config.get_deriv_root(),
                              check=False)
 
     fname_epo_in = bids_basename.copy().update(suffix='epo', extension='.fif')

--- a/scripts/preprocessing/05b-apply_ssp.py
+++ b/scripts/preprocessing/05b-apply_ssp.py
@@ -35,7 +35,7 @@ def apply_ssp(subject, session=None):
                          space=config.space,
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root)
+                         root=config.get_deriv_root())
 
     fname_in = bids_path.copy().update(suffix='epo', check=False)
     fname_out = bids_path.copy().update(processing='ssp', suffix='epo',

--- a/scripts/preprocessing/06-ptp_reject.py
+++ b/scripts/preprocessing/06-ptp_reject.py
@@ -33,7 +33,7 @@ def drop_ptp(subject, session=None):
                          suffix='epo',
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     infile_processing = config.spatial_filter

--- a/scripts/report/01-make_reports.py
+++ b/scripts/report/01-make_reports.py
@@ -43,7 +43,7 @@ def plot_events(subject, session):
                          suffix='raw',
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     for run in config.get_runs():
@@ -78,7 +78,7 @@ def plot_er_psd(subject, session):
                          suffix='raw',
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     extra_params = dict()
@@ -112,7 +112,7 @@ def plot_auto_scores(subject, session):
                             suffix='scores',
                             extension='.json',
                             datatype=config.get_datatype(),
-                            root=config.deriv_root,
+                            root=config.get_deriv_root(),
                             check=False)
 
     all_figs = []
@@ -211,7 +211,7 @@ def run_report(subject, session=None):
                          space=config.space,
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     fname_ave = bids_path.copy().update(suffix='ave')
@@ -448,7 +448,7 @@ def add_event_counts(*,
                      session: str,
                      report: mne.Report) -> None:
     try:
-        df_events = count_events(BIDSPath(root=config.bids_root,
+        df_events = count_events(BIDSPath(root=config.get_bids_root(),
                                           session=session))
     except ValueError:
         logger.warning('Could not read events.')
@@ -491,7 +491,7 @@ def add_event_counts(*,
 #                             suffix='epo',
 #                             extension='.fif',
 #                             datatype=config.get_datatype(),
-#                             root=config.deriv_root,
+#                             root=config.get_deriv_root(),
 #                             check=False)
 
 #     for subject in config.get_subjects():
@@ -515,7 +515,7 @@ def run_report_average(session: str) -> None:
                             suffix='ave',
                             extension='.fif',
                             datatype=config.get_datatype(),
-                            root=config.deriv_root,
+                            root=config.get_deriv_root(),
                             check=False)
 
     title = f'sub-{subject}'

--- a/scripts/sensor/01-make_evoked.py
+++ b/scripts/sensor/01-make_evoked.py
@@ -31,7 +31,7 @@ def run_evoked(subject, session=None):
                          space=config.space,
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root)
+                         root=config.get_deriv_root())
 
     processing = None
     if config.spatial_filter is not None:

--- a/scripts/sensor/02-sliding_estimator.py
+++ b/scripts/sensor/02-sliding_estimator.py
@@ -47,7 +47,7 @@ def run_time_decoding(subject, condition1, condition2, session=None):
                             suffix='epo',
                             extension='.fif',
                             datatype=config.get_datatype(),
-                            root=config.deriv_root,
+                            root=config.get_deriv_root(),
                             check=False)
 
     epochs = mne.read_epochs(fname_epochs)

--- a/scripts/sensor/03-time_frequency.py
+++ b/scripts/sensor/03-time_frequency.py
@@ -37,7 +37,7 @@ def run_time_frequency(subject, session=None):
                          recording=config.rec,
                          space=config.space,
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     processing = None

--- a/scripts/sensor/04-group_average.py
+++ b/scripts/sensor/04-group_average.py
@@ -43,7 +43,7 @@ def average_evokeds(session):
                             suffix='ave',
                             extension='.fif',
                             datatype=config.get_datatype(),
-                            root=config.deriv_root,
+                            root=config.get_deriv_root(),
                             check=False)
 
         msg = f'Input: {fname_in}'
@@ -71,7 +71,7 @@ def average_evokeds(session):
                          suffix='ave',
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     if not fname_out.fpath.parent.exists():
@@ -97,7 +97,7 @@ def average_decoding(session):
                          suffix='epo',
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
     epochs = mne.read_epochs(fname_epo)
     times = epochs.times
@@ -135,7 +135,7 @@ def average_decoding(session):
                                  suffix='decoding',
                                  extension='.mat',
                                  datatype=config.get_datatype(),
-                                 root=config.deriv_root,
+                                 root=config.get_deriv_root(),
                                  check=False)
 
             decoding_data = loadmat(fname_mat)

--- a/scripts/source/02-make_forward.py
+++ b/scripts/source/02-make_forward.py
@@ -31,7 +31,7 @@ def run_forward(subject, session=None):
                          space=config.space,
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     fname_evoked = bids_path.copy().update(suffix='ave')
@@ -46,7 +46,7 @@ def run_forward(subject, session=None):
     else:
         t1_bids_path = BIDSPath(subject=bids_path.subject,
                                 session=bids_path.session,
-                                root=config.bids_root)
+                                root=config.get_bids_root())
         t1_bids_path = config.mri_t1_path_generator(t1_bids_path.copy())
         if t1_bids_path.suffix is None:
             t1_bids_path.update(suffix='T1w')
@@ -59,7 +59,7 @@ def run_forward(subject, session=None):
 
     trans = get_head_mri_trans(
         bids_path.copy().update(run=config.get_runs()[0],
-                                root=config.bids_root),
+                                root=config.get_bids_root()),
         t1_bids_path=t1_bids_path)
     mne.write_trans(fname_trans, trans)
 
@@ -95,8 +95,8 @@ def run_forward(subject, session=None):
         message = ("Could not make BEM model due to a missing file. \n"
                    "Can be solved by setting recreate_bem=True in the config "
                    "to force recreation of the BEM model, or by deleting the\n"
-                   f" {config.bids_root}/derivatives/freesurfer/subjects/"
-                   f"sub-{subject}/bem/ folder")
+                   f" {config.get_bids_root()}/derivatives/freesurfer/"
+                   f"subjects/sub-{subject}/bem/ folder")
         raise FileNotFoundError(message)
 
     bem_sol = mne.make_bem_solution(bem_model)

--- a/scripts/source/03-make_cov.py
+++ b/scripts/source/03-make_cov.py
@@ -30,7 +30,7 @@ def compute_cov_from_epochs(subject, session, tmin, tmax):
                          space=config.space,
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     processing = None
@@ -61,7 +61,7 @@ def compute_cov_from_empty_room(subject, session):
                          space=config.space,
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     raw_er_fname = bids_path.copy().update(processing='filt', task='noise',

--- a/scripts/source/04-make_inverse.py
+++ b/scripts/source/04-make_inverse.py
@@ -32,7 +32,7 @@ def run_inverse(subject, session=None):
                          space=config.space,
                          extension='.fif',
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     fname_ave = bids_path.copy().update(suffix='ave')

--- a/scripts/source/05-group_average.py
+++ b/scripts/source/05-group_average.py
@@ -29,7 +29,7 @@ def morph_stc(subject, session=None):
                          recording=config.rec,
                          space=config.space,
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     fs_subject = config.get_fs_subject(subject)
@@ -105,7 +105,7 @@ def main():
                          recording=config.rec,
                          space=config.space,
                          datatype=config.get_datatype(),
-                         root=config.deriv_root,
+                         root=config.get_deriv_root(),
                          check=False)
 
     if isinstance(config.conditions, dict):


### PR DESCRIPTION
### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)


This ensures that the documentation for both parameters shows up correctly in the rendered output. In `main`, that's not the case, because we re-defined both variables in `config.py` after their first introduction with a corresponding docstring. The re-definition, however, nixes the docstring. The getter functions solve this issue.

No changelog entry needed as only a documentation change to users.