### PR TITLE
Remove by default `conditions` values in config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -666,7 +666,7 @@ occurrence of matching event types. The columns indicating the event types
 will be named with a ``last_`` instead of a ``first_`` prefix.
 """
 
-conditions: Union[Iterable[str], Dict[str, str]] = ['left', 'right']
+conditions: Union[Iterable[str], Dict[str, str]] = []
 """
 The time-locked events based on which to create evoked responses.
 This can either be name of the experimental condition as specified in the


### PR DESCRIPTION
Maybe we could remove the by default `conditions` names, without knowing the real event names in the data it's a bit risky to set them at random?

### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
