### PR TITLE
bug in the sanity check after maxfilters.

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -66,4 +66,4 @@ authors:
   ICA.
   ({{ gh(320) }} by {{ authors.hoechenberger }})
 - The sanity check comparing the rank of the experimental data and the rank of the empty-room after Maxwell-filtering did not use the maxfiltered data
-  (by {{ authors.agramfort }}, {{ authors.hoechenberger }} and {{ crsegerie }}).
+  (by {{ authors.agramfort }}, {{ authors.hoechenberger }}, and {{ crsegerie }}).

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -65,5 +65,5 @@ authors:
 - The summary report didn't use the cleaned epochs for showing the effects of
   ICA.
   ({{ gh(320) }} by {{ authors.hoechenberger }})
-- The sanity check comparing the rank of the experimental data and the rank of the empty-room after the maxfilter did not use the maxfiltered matrices
+- The sanity check comparing the rank of the experimental data and the rank of the empty-room after the maxfilter did not use the maxfiltered data
   (by {{ authors.agramfort }}, {{ authors.hoechenberger }} and {{ crsegerie }}).

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -65,3 +65,5 @@ authors:
 - The summary report didn't use the cleaned epochs for showing the effects of
   ICA.
   ({{ gh(320) }} by {{ authors.hoechenberger }})
+- The sanity check computing comparing the rank of the expterimental data and the rank of the empty-room after the maxfilter did not use the maxfiltered matrices
+  (by {{ authors.agramfort }}, {{ authors.hoechenberger }} and {{ crsegerie }}).

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -65,5 +65,5 @@ authors:
 - The summary report didn't use the cleaned epochs for showing the effects of
   ICA.
   ({{ gh(320) }} by {{ authors.hoechenberger }})
-- The sanity check computing comparing the rank of the expterimental data and the rank of the empty-room after the maxfilter did not use the maxfiltered matrices
+- The sanity check comparing the rank of the experimental data and the rank of the empty-room after the maxfilter did not use the maxfiltered matrices
   (by {{ authors.agramfort }}, {{ authors.hoechenberger }} and {{ crsegerie }}).

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -65,5 +65,5 @@ authors:
 - The summary report didn't use the cleaned epochs for showing the effects of
   ICA.
   ({{ gh(320) }} by {{ authors.hoechenberger }})
-- The sanity check comparing the rank of the experimental data and the rank of the empty-room after the maxfilter did not use the maxfiltered data
+- The sanity check comparing the rank of the experimental data and the rank of the empty-room after Maxwell-filtering did not use the maxfiltered data
   (by {{ authors.agramfort }}, {{ authors.hoechenberger }} and {{ crsegerie }}).

--- a/scripts/preprocessing/01-import_and_maxfilter.py
+++ b/scripts/preprocessing/01-import_and_maxfilter.py
@@ -434,8 +434,8 @@ def run_maxwell_filter(subject, session=None):
 
                 # Perform a sanity check: empty-room rank should match the
                 # experimental data rank after Maxwell filtering.
-                rank_exp = mne.compute_rank(raw, rank='info')['meg']
-                rank_er = mne.compute_rank(raw_er, rank='info')['meg']
+                rank_exp = mne.compute_rank(raw_sss, rank='info')['meg']
+                rank_er = mne.compute_rank(raw_er_sss, rank='info')['meg']
                 if not np.isclose(rank_exp, rank_er):
                     msg = (f'Experimental data rank {rank_exp:.1f} does not '
                            f'match empty-room data rank {rank_er:.1f} after '


### PR DESCRIPTION
The sanity check comparing the rank of the experimental data and the rank of the empty-room after the maxfilter did not use the maxfiltered matrices

### Before merging …

-  [x] Changelog has been updated (`docs/source/changes.md`)
