### PR TITLE
DNM: Add support for fNIRS data

### DIFF
--- a/config.py
+++ b/config.py
@@ -1341,7 +1341,7 @@ elif 'eeg' in ch_types and len(ch_types) > 1:  # EEG + some other channel types
     msg = ('EEG data can only be analyzed separately from other channel '
            'types. Please adjust `ch_types` in your configuration.')
     raise ValueError(msg)
-elif any([ch_type not in ('meg', 'mag', 'grad') for ch_type in ch_types]):
+elif any([ch_type not in ('meg', 'mag', 'grad', 'nirs') for ch_type in ch_types]):
     msg = ('Invalid channel type passed. Please adjust `ch_types` in your '
            'configuration.')
     raise ValueError(msg)
@@ -1649,13 +1649,15 @@ def get_task() -> Optional[str]:
         return task
 
 
-def get_datatype() -> Literal['meg', 'eeg']:
+def get_datatype() -> Literal['meg', 'eeg', 'nirs']:
     # Content of ch_types should be sanitized already, so we don't need any
     # extra sanity checks here.
     if data_type is not None:
         return data_type
     elif data_type is None and ch_types == ['eeg']:
         return 'eeg'
+    elif data_type is None and ch_types == ['nirs']:
+        return 'nirs'
     elif data_type is None and any([t in ['meg', 'mag', 'grad']
                                     for t in ch_types]):
         return 'meg'
@@ -1824,6 +1826,9 @@ def get_channels_to_analyze(info) -> List[str]:
     elif ch_types == ['eeg']:
         pick_idx = mne.pick_types(info, meg=False, eeg=True, eog=True,
                                   ecg=True, exclude=[])
+    elif ch_types == ['nirs']:
+        pick_idx = mne.pick_types(info, meg=False, eeg=False, eog=False,
+                                  ecg=False, fnirs=True, exclude=[])
     else:
         raise RuntimeError('Something unexpected happened. Please contact '
                            'the mne-bids-pipeline developers. Thank you.')


### PR DESCRIPTION
Hi, would you like to add support for fNIRS to mne-bids-pipeline?

This is an issue as PR. And allowed me to understand this package and determine what would be needed for it to run well with fNIRS data. It has the following issues to be addressed before a review is appropriate:

- [ ] This PR relies on allowing snirf support in `mne.Report`. See https://github.com/mne-tools/mne-python/pull/9443
- [ ] This PR uses functions from MNE-NIRS. Is this undesirable? If so, then the convenience functions (e.g. `get_short_channels`) could be easily reimplemented, they are trivial. And we could either remove the signal enhancement functions or move them to MNE (they aren't 100% stable yet, so probably just best to remove them from here).
- [ ] Wait for the fNIRS BIDS spec to be accepted. See progress here: https://github.com/bids-standard/bids-specification/pull/802 
