### PR TITLE
Expand sliding window documentation description

### DIFF
--- a/config.py
+++ b/config.py
@@ -943,15 +943,16 @@ Whether to perform decoding (MVPA) on the contrasts specified above as
 
 decoding_metric: str = 'roc_auc'
 """
-The metric to use for cross-validation. It can be `'roc_auc'` or `'accuracy'`
-or any other metric supported by `scikit-learn`.
+The metric to use for estimating classification performance. It can be
+`'roc_auc'` or `'accuracy'` – or any other metric supported by `scikit-learn`.
 
-With AUC, chance level is the same regardless of class balance.
+With ROC AUC, chance level is the same regardless of class balance, that is,
+you don't need to be worried about **exactly** balancing class sizes.
 """
 
 decoding_n_splits: int = 5
 """
-The number of folds (a.k.a. splits) to use in the cross-validation.
+The number of folds (a.k.a. "splits") to use in the cross-validation scheme.
 """
 
 n_boot: int = 5000

--- a/docs/source/features/steps.md
+++ b/docs/source/features/steps.md
@@ -25,7 +25,7 @@ Sensor-level analysis
 |:-------------------------------|:------------|
 | `sensor`                       | Run all sensor-level analysis scripts. |
 | `sensor/make_evoked`           | Extract evoked data for each condition. |
-| `sensor/sliding_estimator`     | Running a time-by-time decoder with sliding window. |
+| `sensor/sliding_estimator`     | Running a time-by-time decoder with sliding window. This is achieved by standardising the features, applying a logistic regression classifier, then applying the sliding estimator. The returned scores are generated using a stratified k-folds validator. The subject level report presents the decoding performance across epochs. The average subject report presents the average performance across the subjects. |
 | `sensor/time_frequency`        | Running a time-frequency analysis. |
 | `sensor/group_average_sensors` | Make a group average of the time domain data. |
 

--- a/docs/source/features/steps.md
+++ b/docs/source/features/steps.md
@@ -25,7 +25,7 @@ Sensor-level analysis
 |:-------------------------------|:------------|
 | `sensor`                       | Run all sensor-level analysis scripts. |
 | `sensor/make_evoked`           | Extract evoked data for each condition. |
-| `sensor/sliding_estimator`     | Running a time-by-time decoder with sliding window. This is achieved by standardising the features, applying a logistic regression classifier, then applying the sliding estimator. The returned scores are generated using a stratified k-folds validator. The subject level report presents the decoding performance across epochs. The average subject report presents the average performance across the subjects. |
+| `sensor/sliding_estimator`     | Running a time-by-time decoder with sliding window. This is achieved by standardising the features, applying a logistic-regression classifier, then applying the sliding estimator. The returned scores are generated using a stratified k-folds validator. The subject-level report presents the decoding performance across epochs. The average-subject report presents the mean performance across subjects. |
 | `sensor/time_frequency`        | Running a time-frequency analysis. |
 | `sensor/group_average_sensors` | Make a group average of the time domain data. |
 

--- a/docs/source/features/steps.md
+++ b/docs/source/features/steps.md
@@ -25,7 +25,7 @@ Sensor-level analysis
 |:-------------------------------|:------------|
 | `sensor`                       | Run all sensor-level analysis scripts. |
 | `sensor/make_evoked`           | Extract evoked data for each condition. |
-| `sensor/sliding_estimator`     | Running a time-by-time decoder with sliding window. This is achieved by standardising the features, applying a logistic-regression classifier, then applying the sliding estimator. The returned scores are generated using a stratified k-folds validator. The subject-level report presents the decoding performance across epochs. The average-subject report presents the mean performance across subjects. |
+| `sensor/sliding_estimator`     | Running a time-by-time decoder with sliding window. This is achieved by standardizing the "features" (i.e., the input data is centered and scaled to have a mean of zero and a standard deviation of 1), fitting a separate logistic-regression classifier for each time point, and estimating its performance before moving to the next time point (hence the term "sliding estimator"). The returned scores are generated using a stratified k-fold cross-validation scheme. The subject-level report presents the decoding performance across epochs. The `average`-subject report presents the mean performance across subjects. |
 | `sensor/time_frequency`        | Running a time-frequency analysis. |
 | `sensor/group_average_sensors` | Make a group average of the time domain data. |
 

--- a/docs/source/features/steps.md
+++ b/docs/source/features/steps.md
@@ -25,7 +25,7 @@ Sensor-level analysis
 |:-------------------------------|:------------|
 | `sensor`                       | Run all sensor-level analysis scripts. |
 | `sensor/make_evoked`           | Extract evoked data for each condition. |
-| `sensor/sliding_estimator`     | Running a time-by-time decoder with sliding window. This is achieved by standardizing the "features" (i.e., the input data is centered and scaled to have a mean of zero and a standard deviation of 1), fitting a separate logistic-regression classifier for each time point, and estimating its performance before moving to the next time point (hence the term "sliding estimator"). The returned scores are generated using a stratified k-fold cross-validation scheme. The subject-level report presents the decoding performance across epochs. The `average`-subject report presents the mean performance across subjects. |
+| `sensor/sliding_estimator`     | Running a time-by-time decoder with sliding window. This is achieved by standardizing the "features" (i.e., the input data is centered and scaled to have a mean of zero and a standard deviation of 1), fitting a separate logistic-regression classifier for each time point, and estimating its [performance][config.decoding_metric] before moving to the next time point (hence the term "sliding estimator"). The returned scores are generated using a stratified [k-fold cross-validation scheme][config.decoding_n_splits]. The subject-level report presents the decoding performance across epochs. The `average`-subject report presents the mean performance across subjects. |
 | `sensor/time_frequency`        | Running a time-frequency analysis. |
 | `sensor/group_average_sensors` | Make a group average of the time domain data. |
 

--- a/docs/source/getting_started/basic_usage.md
+++ b/docs/source/getting_started/basic_usage.md
@@ -50,7 +50,7 @@ You need to **create a copy** of that configuration file and adjust all
 parameters that are relevant to your data processing and analysis.
 
 !!! warning "Avoid modifying the scripts"
-    You should **only** need to touch the configuration file.
+    You should **only** need to modify the copy of the configuration file.
     None of the scripts should be edited.
 
 Run the pipeline


### PR DESCRIPTION
You can probably tell by my flurry of PRs that I love this package! One thing that I have noticed is that to understand what is happening you need to dig in to the code, and I can see this issue is already being discussed in #350. To improve the onboarding of new users I have suggested some more description for the documentation.

I found the package easy to setup and get running. But I had trouble interpreting the `sliding_estimator` section of the report. To me it was unclear what the applied pipeline was and what the plots illustrated. Specifically I was unsure how to interpret the average subject report, I was not sure if the results were simply the mean of the individual results, or if the script was training on a subset of subjects and testing on previously unseen subjects. This may be obvious to people in the field, but not to an outsider. So I dug through the code and added my understanding of the script to the docs.

I am not sure if this is the best place for this information in the docs. Please let me know if I should move it.

Have I interpreted the script and described it correctly? I am new to this decoding business, so my fundamental understanding and terminology may be WAY OFF. If you correct my understanding I can update the docs.


### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
