### PR TITLE
Reject bad epochs in apply_ica diagnostic plot

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -120,7 +120,7 @@ authors:
 - `epochs_tmin` and `epochs_tmax` were named incorrectly in some test config
   files.
   ({{ gh(340) }} by {{ authors.crsegerie }})
-- We now reject bad epochs by using `ica_reject` before plotting the 
-  figures in the `proc-ica_report`.
-  ({{ gh(?) }} by {{ authors.hoechenberger }}), {{ authors.agramfort }} and 
-  {{ authors.crsegerie }})
+- We now reject bad epochs by using [`ica_reject`][config.ica_reject] before 
+  producing the "overlay" plots that show the evoked data before and after 
+  ICA cleaning. in the `proc-ica_report`.
+  ({{ gh(385) }} by {{ authors.crsegerie }}).

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -122,5 +122,5 @@ authors:
   ({{ gh(340) }} by {{ authors.crsegerie }})
 - We now reject bad epochs by using [`ica_reject`][config.ica_reject] before 
   producing the "overlay" plots that show the evoked data before and after 
-  ICA cleaning. in the `proc-ica_report`.
+  ICA cleaning in the `proc-ica_report`.
   ({{ gh(385) }} by {{ authors.crsegerie }}).

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -120,3 +120,7 @@ authors:
 - `epochs_tmin` and `epochs_tmax` were named incorrectly in some test config
   files.
   ({{ gh(340) }} by {{ authors.crsegerie }})
+- We now reject bad epochs trespassing `ica_reject` before plotting the 
+  figures in the `proc-ica_report`.
+  ({{ gh(?) }} by {{ authors.hoechenberger }}), {{ authors.agramfort }} and 
+  {{ authors.crsegerie }})

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -120,7 +120,7 @@ authors:
 - `epochs_tmin` and `epochs_tmax` were named incorrectly in some test config
   files.
   ({{ gh(340) }} by {{ authors.crsegerie }})
-- We now reject bad epochs trespassing `ica_reject` before plotting the 
+- We now reject bad epochs by using `ica_reject` before plotting the 
   figures in the `proc-ica_report`.
   ({{ gh(?) }} by {{ authors.hoechenberger }}), {{ authors.agramfort }} and 
   {{ authors.crsegerie }})

--- a/scripts/preprocessing/05a-apply_ica.py
+++ b/scripts/preprocessing/05a-apply_ica.py
@@ -57,6 +57,8 @@ def apply_ica(cfg, subject, session):
     # Load epochs to reject ICA components.
     epochs = mne.read_epochs(fname_epo_in, preload=True)
 
+    epochs.drop_bad(cfg.ica_reject)
+
     msg = f'Input: {fname_epo_in}, Output: {fname_epo_out}'
     logger.info(gen_log_message(message=msg, step=5, subject=subject,
                                 session=session))
@@ -138,6 +140,7 @@ def get_config(
         deriv_root=config.get_deriv_root(),
         interactive=config.interactive,
         baseline=config.baseline,
+        ica_reject=config.ica_reject,
     )
     return cfg
 

--- a/tests/configs/config_ERP_CORE.py
+++ b/tests/configs/config_ERP_CORE.py
@@ -52,6 +52,9 @@ decode = True
 
 ica_reject = dict(eeg=350e-6, eog=500e-6)
 reject = dict(eeg=150e-6)
+# Work around https://github.com/mne-tools/mne-python/issues/9483
+# Once resolved, remove the following line
+reject['eog'] = ica_reject['eog']
 
 spatial_filter = 'ica'
 ica_max_iterations = 1000

--- a/tests/configs/config_ERP_CORE.py
+++ b/tests/configs/config_ERP_CORE.py
@@ -52,9 +52,6 @@ decode = True
 
 ica_reject = dict(eeg=350e-6, eog=500e-6)
 reject = dict(eeg=150e-6)
-# Work around https://github.com/mne-tools/mne-python/issues/9483
-# Once resolved, remove the following line
-reject['eog'] = ica_reject['eog']
 
 spatial_filter = 'ica'
 ica_max_iterations = 1000

--- a/tests/configs/config_ds000248_ica.py
+++ b/tests/configs/config_ds000248_ica.py
@@ -19,9 +19,8 @@ conditions = ['Auditory/Left',
 epochs_tmin = -0.2
 epochs_tmax = 0.5
 baseline = (None, 0)
-reject = dict(mag=3000e-15,
-              grad=3000e-13)
-
+ica_reject = dict(mag=3000e-15,
+                  grad=3000e-13)
 
 spatial_filter = 'ica'
 ica_algorithm = 'extended_infomax'


### PR DESCRIPTION
Following a discussion with @agramfort, @SophieHerbst and @hoechenberger, there were indeed some inconsistencies between the calculation of the ica and the plotting of the correction of the ica in the short ica report.

See, for this case study, before:

![image](https://user-images.githubusercontent.com/38733898/122374152-6bf69980-cf62-11eb-9b09-8b3d3925d487.png)

and after:

![image](https://user-images.githubusercontent.com/38733898/122374302-8b8dc200-cf62-11eb-8eb9-b5ed271729d7.png)


### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
