### PR TITLE
Fix bug when eeg_reference is a string

### DIFF
--- a/config.py
+++ b/config.py
@@ -2588,6 +2588,15 @@ def _find_breaks_func(
     raw.set_annotations(raw.annotations + break_annots)  # add to existing
 
 
+def get_eeg_reference() -> Union[Literal['average'], Iterable[str]]:
+    if eeg_reference == 'average':
+        return eeg_reference
+    elif isinstance(eeg_reference, str):
+        return [eeg_reference]
+    else:
+        return eeg_reference
+
+
 # # Leave this here for reference for now
 #
 # _preproc_funcs_path = (pathlib.Path(__file__).parent / 'scripts' /

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -140,5 +140,5 @@ authors:
   toolkit we are using, Fire.
   ({{ gh(375) }} by {{ authors.hoechenberger }})
 - Setting [`eeg_reference`][config.eeg_reference] to a string (name of the
-  reference channel) didn't work.
+  reference channel) caused us to crash.
   ({{ gh(391) }} by {{ authors.hoechenberger }})

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -139,3 +139,6 @@ authors:
   double-quoted and hence converted to strings by the command-line interface
   toolkit we are using, Fire.
   ({{ gh(375) }} by {{ authors.hoechenberger }})
+- Setting [`eeg_reference`][config.eeg_reference] to a string (name of the
+  reference channel) didn't work.
+  ({{ gh(391) }} by {{ authors.hoechenberger }})

--- a/scripts/preprocessing/03-make_epochs.py
+++ b/scripts/preprocessing/03-make_epochs.py
@@ -135,7 +135,7 @@ def get_config(
         event_repeated=config.event_repeated,
         decim=config.decim,
         ch_types=config.ch_types,
-        eeg_reference=config.eeg_reference
+        eeg_reference=config.get_eeg_reference()
     )
     return cfg
 

--- a/scripts/preprocessing/04a-run_ica.py
+++ b/scripts/preprocessing/04a-run_ica.py
@@ -467,7 +467,7 @@ def get_config(
         event_repeated=config.event_repeated,
         epochs_tmin=config.epochs_tmin,
         epochs_tmax=config.epochs_tmax,
-        eeg_reference=config.eeg_reference,
+        eeg_reference=config.get_eeg_reference(),
         eog_channels=config.eog_channels
     )
     return cfg

--- a/scripts/sensor/02-sliding_estimator.py
+++ b/scripts/sensor/02-sliding_estimator.py
@@ -133,7 +133,7 @@ def get_config(
         random_state=config.random_state,
         analyze_channels=config.analyze_channels,
         ch_types=config.ch_types,
-        eeg_reference=config.eeg_reference,
+        eeg_reference=config.get_eeg_reference(),
         N_JOBS=config.N_JOBS
     )
     return cfg

--- a/scripts/sensor/03-time_frequency.py
+++ b/scripts/sensor/03-time_frequency.py
@@ -94,7 +94,7 @@ def get_config(
         analyze_channels=config.analyze_channels,
         spatial_filter=config.spatial_filter,
         ch_types=config.ch_types,
-        eeg_reference=config.eeg_reference,
+        eeg_reference=config.get_eeg_reference(),
         time_frequency_freq_min=config.time_frequency_freq_min,
         time_frequency_freq_max=config.time_frequency_freq_max
     )

--- a/scripts/sensor/04-group_average.py
+++ b/scripts/sensor/04-group_average.py
@@ -200,7 +200,7 @@ def get_config(
         analyze_channels=config.analyze_channels,
         interpolate_bads_grand_average=config.interpolate_bads_grand_average,
         ch_types=config.ch_types,
-        eeg_reference=config.eeg_reference,
+        eeg_reference=config.get_eeg_reference(),
         interactive=config.interactive
     )
     return cfg


### PR DESCRIPTION
When `eeg_reference` is a string other than `'average'`, we currently crash
on `main`. This problem was discovered when working with @dnacombo

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
