### PR TITLE
Enforce specification of subjects_dir if deriv_root is set

### DIFF
--- a/config.py
+++ b/config.py
@@ -2049,8 +2049,9 @@ def get_ica_reject() -> Dict[str, float]:
 
 def get_fs_subjects_dir():
     if not subjects_dir and deriv_root is not None:
-        # We do this check here to avoid an error message when a user doesn't
-        # intend to run the source analysis steps anyway.
+        # We do this check here (and not in our regular checks section) to
+        # avoid an error message when a user doesn't intend to run the source
+        # analysis steps anyway.
         raise ValueError(
             'When specifying a "deriv_root", you must also supply a '
             '"subjects_dir".'

--- a/config.py
+++ b/config.py
@@ -59,6 +59,10 @@ deriv_root: Optional[PathLike] = None
 The root of the derivatives directory in which the pipeline will store
 the processing results. If ``None``, this will be
 ``derivatives/mne-bids-pipeline`` inside the BIDS root.
+
+Note: Note
+    If specified and you wish to run the source analysis steps, you must
+    set [`subjects_dir`][config.subjects_dir] as well.
 """
 
 subjects_dir: Optional[PathLike] = None
@@ -70,7 +74,11 @@ parcellations from anatomical scans in the BIDS dataset, the output will be
 stored in this directory.
 
 If ``None``, this will default
-to [`deriv_root`][config.deriv_root]`/freesurfer/subjects`.
+to [`bids_root`][config.bids_root_root]`/freesurfer/subjects`.
+
+Note: Note
+    This setting is required if you specify [`deriv_root`][config.deriv_root]
+    and want to run the source analysis steps.
 """
 
 interactive: bool = False

--- a/config.py
+++ b/config.py
@@ -2040,8 +2040,14 @@ def get_ica_reject() -> Dict[str, float]:
 
 
 def get_fs_subjects_dir():
+    if not subjects_dir and deriv_root is not None:
+        raise ValueError(
+            'When specifying a "deriv_root", you must also supply a '
+            '"subjects_dir".'
+        )
+
     if not subjects_dir:
-        return get_deriv_root() / 'freesurfer' / 'subjects'
+            return get_bids_root() / 'derivatives' / 'freesurfer' / 'subjects'
     else:
         return subjects_dir
 

--- a/config.py
+++ b/config.py
@@ -2049,6 +2049,8 @@ def get_ica_reject() -> Dict[str, float]:
 
 def get_fs_subjects_dir():
     if not subjects_dir and deriv_root is not None:
+        # We do this check here to avoid an error message when a user doesn't
+        # intend to run the source analysis steps anyway.
         raise ValueError(
             'When specifying a "deriv_root", you must also supply a '
             '"subjects_dir".'

--- a/config.py
+++ b/config.py
@@ -2047,7 +2047,7 @@ def get_fs_subjects_dir():
         )
 
     if not subjects_dir:
-            return get_bids_root() / 'derivatives' / 'freesurfer' / 'subjects'
+        return get_bids_root() / 'derivatives' / 'freesurfer' / 'subjects'
     else:
         return subjects_dir
 

--- a/config.py
+++ b/config.py
@@ -2057,7 +2057,9 @@ def get_fs_subjects_dir():
     if not subjects_dir:
         return get_bids_root() / 'derivatives' / 'freesurfer' / 'subjects'
     else:
-        return subjects_dir
+        return (pathlib.Path(subjects_dir)
+                .expanduser()
+                .resolve())
 
 
 def gen_log_message(message, step=None, subject=None, session=None,

--- a/config.py
+++ b/config.py
@@ -67,14 +67,18 @@ Note: Note
 
 subjects_dir: Optional[PathLike] = None
 """
-Path to the directory that contains the FreeSurfer parcellations of all
+Path to the directory that contains the FreeSurfer reconstructions of all
 subjects. Specifically, this defines the ``SUBJECTS_DIR`` that is used by
-FreeSurfer. When running the ``freesurfer`` processing step to create the
-parcellations from anatomical scans in the BIDS dataset, the output will be
-stored in this directory.
+FreeSurfer.
 
-If ``None``, this will default
-to [`bids_root`][config.bids_root_root]`/derivatives/freesurfer/subjects`.
+- When running the ``freesurfer`` processing step to create the
+  reconstructions from anatomical scans in the BIDS dataset, the
+  output will be stored in this directory.
+- When running the source analysis steps, we will look for the surfaces in this
+  directory and also store the BEM surfaces there.
+
+If ``None``, this will default to
+[`bids_root`][config.bids_root_root]`/derivatives/freesurfer/subjects`.
 
 Note: Note
     This setting is required if you specify [`deriv_root`][config.deriv_root]

--- a/config.py
+++ b/config.py
@@ -63,9 +63,14 @@ the processing results. If ``None``, this will be
 
 subjects_dir: Optional[PathLike] = None
 """
-Path to the directory that contains the MRI data files and their
-derivativesfor all subjects. Specifically, the ``subjects_dir`` is the
-$SUBJECTS_DIR used by the Freesurfer software.
+Path to the directory that contains the FreeSurfer parcellations of all
+subjects. Specifically, this defines the ``SUBJECTS_DIR`` that is used by
+FreeSurfer. When running the ``freesurfer`` processing step to create the
+parcellations from anatomical scans in the BIDS dataset, the output will be
+stored in this directory.
+
+If ``None``, this will default
+to [`deriv_root`][config.deriv_root]`/freesurfer/subjects`.
 """
 
 interactive: bool = False
@@ -2036,7 +2041,7 @@ def get_ica_reject() -> Dict[str, float]:
 
 def get_fs_subjects_dir():
     if not subjects_dir:
-        return get_bids_root() / 'derivatives' / 'freesurfer' / 'subjects'
+        return get_deriv_root() / 'freesurfer' / 'subjects'
     else:
         return subjects_dir
 

--- a/config.py
+++ b/config.py
@@ -74,7 +74,7 @@ parcellations from anatomical scans in the BIDS dataset, the output will be
 stored in this directory.
 
 If ``None``, this will default
-to [`bids_root`][config.bids_root_root]`/freesurfer/subjects`.
+to [`bids_root`][config.bids_root_root]`/derivatives/freesurfer/subjects`.
 
 Note: Note
     This setting is required if you specify [`deriv_root`][config.deriv_root]

--- a/scripts/freesurfer/recon_all.py
+++ b/scripts/freesurfer/recon_all.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('mne-bids-pipeline')
 fs_bids_app = Path(__file__).parent / 'contrib' / 'run.py'
 
 
-def run_recon(root_dir, subject, fs_bids_app) -> None:
+def run_recon(bids_root, subject, fs_bids_app) -> None:
     logger.info(f"Running recon-all on subject {subject}. This will take "
                 f"a LONG time – it's a good idea to let it run over night.")
 
@@ -39,12 +39,21 @@ def run_recon(root_dir, subject, fs_bids_app) -> None:
     if not license_file.exists():
         raise RuntimeError("FreeSurfer license file not found.")
 
+    env['SUBJECTS_DIR'] = str(subjects_dir)
+
+    output_dir = (config.get_deriv_root() / 'derivatives' / 'freesurfer' /
+                  'subjects')
+    output_dir.mkdir(exist_ok=True, parents=True)
+
     cmd = [
         f"{sys.executable}",
         f"{fs_bids_app}",
-        f"{root_dir}",
-        f"{subjects_dir}", "participant",
-        "--n_cpus=2", "--stages=all", "--skip_bids_validator",
+        f"{bids_root}",
+        f"{output_dir}",
+        "participant",  # analysis level
+        "--n_cpus=2",
+        "--stages=all",
+        "--skip_bids_validator",
         f"--license_file={license_file}",
         f"--participant_label={subject}"
     ]
@@ -78,13 +87,13 @@ def main() -> None:
     logger.info('Running FreeSurfer')
 
     subjects = config.get_subjects()
-    root_dir = config.get_bids_root()
+    bids_root = config.get_bids_root()
     subjects_dir = Path(config.get_fs_subjects_dir())
     subjects_dir.mkdir(parents=True, exist_ok=True)
 
     n_jobs = config.get_n_jobs()
     parallel, run_func, _ = parallel_func(run_recon, n_jobs=n_jobs)
-    parallel(run_func(root_dir, subject, fs_bids_app)
+    parallel(run_func(bids_root, subject, fs_bids_app)
              for subject in subjects)
 
     # Handle fsaverage

--- a/tests/configs/config_ds000246.py
+++ b/tests/configs/config_ds000246.py
@@ -5,6 +5,7 @@ Auditory MEG
 study_name = 'ds000246'
 bids_root = '~/mne_data/ds000246'
 deriv_root = '~/mne_data/ds000246/derivatives/mne-bids-pipeline'
+subjects_dir = '~/mne_data/ds000246/derivatives/freesurfer/subjects'
 runs = ['01']
 l_freq = .3
 h_freq = 100.


### PR DESCRIPTION
Didn't work properly before: recon-all output was always written to `SUBJECTS_DIR/`.

Fixes #404

### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
