### PR TITLE
Fix error occuring when there are not enough ecg or eog epochs for autoreject

### DIFF
--- a/config.py
+++ b/config.py
@@ -934,6 +934,17 @@ order to remove the artifacts. The ICA procedure can be configured in various
 ways using the configuration options you can find below.
 """
 
+min_ecg_epochs: int = 5
+"""
+Minimal number of ECG epochs needed to compute SSP or ICA rejection with autoreject.
+"""
+
+min_eog_epochs: int = 5
+"""
+Minimal number of EOG epochs needed to compute SSP or ICA rejection with autoreject.
+"""
+
+
 # Rejection based on SSP
 # ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/config.py
+++ b/config.py
@@ -936,12 +936,12 @@ ways using the configuration options you can find below.
 
 min_ecg_epochs: int = 5
 """
-Minimal number of ECG epochs needed to compute SSP or ICA rejection with autoreject.
+Minimal number of ECG epochs needed to compute SSP or ICA rejection.
 """
 
 min_eog_epochs: int = 5
 """
-Minimal number of EOG epochs needed to compute SSP or ICA rejection with autoreject.
+Minimal number of EOG epochs needed to compute SSP or ICA rejection.
 """
 
 

--- a/scripts/preprocessing/04b-run_ssp.py
+++ b/scripts/preprocessing/04b-run_ssp.py
@@ -78,7 +78,8 @@ def run_ssp(*, cfg, subject, session=None):
                                             **cfg.n_proj_ecg)
 
     if not ecg_projs:
-        msg = 'No ECG events could be found. No ECG projectors computed.'
+        msg = ('Not enough ECG events could be found. No ECG projectors are '
+               'computed.')
         logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                      session=session))
 
@@ -112,7 +113,8 @@ def run_ssp(*, cfg, subject, session=None):
                                             **cfg.n_proj_eog)
 
     if not eog_projs:
-        msg = 'Not enough EOG events could be found. No EOG projectors computed.'
+        msg = ('Not enough EOG events could be found. No EOG projectors are '
+               'computed.')
         logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                      session=session))
 

--- a/scripts/preprocessing/04b-run_ssp.py
+++ b/scripts/preprocessing/04b-run_ssp.py
@@ -57,10 +57,13 @@ def run_ssp(*, cfg, subject, session=None):
     logger.debug(**gen_log_kwargs(message=msg, subject=subject,
                                   session=session))
 
-    reject_ecg_ = config.get_ssp_reject(
-        ssp_type='ecg',
-        epochs=(create_ecg_epochs(raw)
-                if cfg.ssp_reject_ecg == 'autoreject_global' else None))
+    reject_ecg_ = None
+    ecg_epochs = (create_ecg_epochs(raw)
+                  if cfg.ssp_reject_ecg == 'autoreject_global' else None)
+    if len(ecg_epochs) >= 5:
+        reject_ecg_ = config.get_ssp_reject(
+            ssp_type='ecg',
+            epochs=ecg_epochs)
     ecg_projs, _ = compute_proj_ecg(raw,
                                     average=cfg.ecg_proj_from_average,
                                     reject=reject_ecg_,
@@ -79,10 +82,15 @@ def run_ssp(*, cfg, subject, session=None):
     else:
         ch_names = None
 
-    reject_eog_ = config.get_ssp_reject(
-        ssp_type='eog',
-        epochs=(create_eog_epochs(raw)
-                if cfg.ssp_reject_eog == 'autoreject_global' else None))
+    reject_eog_ = None
+    eog_epochs = (create_eog_epochs(raw)
+                  if cfg.ssp_reject_eog == 'autoreject_global' else None)
+
+    if len(eog_epochs) >= 5:
+        reject_eog_ = config.get_ssp_reject(
+            ssp_type='eog',
+            epochs=eog_epochs)
+
     eog_projs, _ = compute_proj_eog(raw, ch_name=ch_names,
                                     average=cfg.eog_proj_from_average,
                                     reject=reject_eog_,

--- a/scripts/preprocessing/04b-run_ssp.py
+++ b/scripts/preprocessing/04b-run_ssp.py
@@ -58,12 +58,13 @@ def run_ssp(*, cfg, subject, session=None):
                                   session=session))
 
     reject_ecg_ = None
-    ecg_epochs = (create_ecg_epochs(raw)
-                  if cfg.ssp_reject_ecg == 'autoreject_global' else None)
-    if len(ecg_epochs) >= 5:
-        reject_ecg_ = config.get_ssp_reject(
-            ssp_type='ecg',
-            epochs=ecg_epochs)
+    ecg_epochs = None
+    if cfg.ssp_reject_ecg == 'autoreject_global':
+        ecg_epochs = create_ecg_epochs(raw)
+        if len(ecg_epochs) >= 5:
+            reject_ecg_ = config.get_ssp_reject(
+                ssp_type='ecg',
+                epochs=ecg_epochs)
     ecg_projs, _ = compute_proj_ecg(raw,
                                     average=cfg.ecg_proj_from_average,
                                     reject=reject_ecg_,
@@ -83,13 +84,13 @@ def run_ssp(*, cfg, subject, session=None):
         ch_names = None
 
     reject_eog_ = None
-    eog_epochs = (create_eog_epochs(raw)
-                  if cfg.ssp_reject_eog == 'autoreject_global' else None)
-
-    if len(eog_epochs) >= 5:
-        reject_eog_ = config.get_ssp_reject(
-            ssp_type='eog',
-            epochs=eog_epochs)
+    eog_epochs = None
+    if cfg.ssp_reject_eog == 'autoreject_global':
+        eog_epochs = create_eog_epochs(raw)
+        if len(eog_epochs) >= 5:
+            reject_eog_ = config.get_ssp_reject(
+                ssp_type='eog',
+                epochs=eog_epochs)
 
     eog_projs, _ = compute_proj_eog(raw, ch_name=ch_names,
                                     average=cfg.eog_proj_from_average,

--- a/scripts/preprocessing/04b-run_ssp.py
+++ b/scripts/preprocessing/04b-run_ssp.py
@@ -57,18 +57,25 @@ def run_ssp(*, cfg, subject, session=None):
     logger.debug(**gen_log_kwargs(message=msg, subject=subject,
                                   session=session))
 
-    reject_ecg_ = None
-    ecg_epochs = None
     if cfg.ssp_reject_ecg == 'autoreject_global':
         ecg_epochs = create_ecg_epochs(raw)
-        if len(ecg_epochs) >= 5:
+        if len(ecg_epochs) >= config.min_ecg_epochs:
             reject_ecg_ = config.get_ssp_reject(
                 ssp_type='ecg',
                 epochs=ecg_epochs)
-    ecg_projs, _ = compute_proj_ecg(raw,
-                                    average=cfg.ecg_proj_from_average,
-                                    reject=reject_ecg_,
-                                    **cfg.n_proj_ecg)
+            ecg_projs, _ = compute_proj_ecg(raw,
+                                            average=cfg.ecg_proj_from_average,
+                                            reject=reject_ecg_,
+                                            **cfg.n_proj_ecg)
+    else:
+        reject_ecg_ = config.get_ssp_reject(
+                ssp_type='ecg',
+                epochs=None)
+        ecg_projs, _ = compute_proj_ecg(raw,
+                                        average=cfg.ecg_proj_from_average,
+                                        reject=reject_ecg_,
+                                        **cfg.n_proj_ecg)
+
     if not ecg_projs:
         msg = 'No ECG events could be found. No ECG projectors computed.'
         logger.info(**gen_log_kwargs(message=msg, subject=subject,
@@ -83,19 +90,24 @@ def run_ssp(*, cfg, subject, session=None):
     else:
         ch_names = None
 
-    reject_eog_ = None
-    eog_epochs = None
     if cfg.ssp_reject_eog == 'autoreject_global':
         eog_epochs = create_eog_epochs(raw)
-        if len(eog_epochs) >= 5:
+        if len(eog_epochs) >= config.min_eog_epochs:
             reject_eog_ = config.get_ssp_reject(
                 ssp_type='eog',
                 epochs=eog_epochs)
-
-    eog_projs, _ = compute_proj_eog(raw, ch_name=ch_names,
-                                    average=cfg.eog_proj_from_average,
-                                    reject=reject_eog_,
-                                    **cfg.n_proj_eog)
+            eog_projs, _ = compute_proj_eog(raw,
+                                            average=cfg.eog_proj_from_average,
+                                            reject=reject_eog_,
+                                            **cfg.n_proj_eog)
+    else:
+        reject_eog_ = config.get_ssp_reject(
+                ssp_type='eog',
+                epochs=None)
+        eog_projs, _ = compute_proj_eog(raw,
+                                        average=cfg.eog_proj_from_average,
+                                        reject=reject_eog_,
+                                        **cfg.n_proj_eog)
 
     if not eog_projs:
         msg = 'No EOG events could be found. No EOG projectors computed.'

--- a/scripts/preprocessing/04b-run_ssp.py
+++ b/scripts/preprocessing/04b-run_ssp.py
@@ -57,6 +57,7 @@ def run_ssp(*, cfg, subject, session=None):
     logger.debug(**gen_log_kwargs(message=msg, subject=subject,
                                   session=session))
 
+    ecg_projs = []
     if cfg.ssp_reject_ecg == 'autoreject_global':
         ecg_epochs = create_ecg_epochs(raw)
         if len(ecg_epochs) >= config.min_ecg_epochs:
@@ -90,6 +91,7 @@ def run_ssp(*, cfg, subject, session=None):
     else:
         ch_names = None
 
+    eog_projs = []
     if cfg.ssp_reject_eog == 'autoreject_global':
         eog_epochs = create_eog_epochs(raw)
         if len(eog_epochs) >= config.min_eog_epochs:

--- a/scripts/preprocessing/04b-run_ssp.py
+++ b/scripts/preprocessing/04b-run_ssp.py
@@ -58,9 +58,9 @@ def run_ssp(*, cfg, subject, session=None):
                                   session=session))
 
     ecg_projs = []
-    if cfg.ssp_reject_ecg == 'autoreject_global':
-        ecg_epochs = create_ecg_epochs(raw)
-        if len(ecg_epochs) >= config.min_ecg_epochs:
+    ecg_epochs = create_ecg_epochs(raw)
+    if len(ecg_epochs) >= config.min_ecg_epochs:
+        if cfg.ssp_reject_ecg == 'autoreject_global':
             reject_ecg_ = config.get_ssp_reject(
                 ssp_type='ecg',
                 epochs=ecg_epochs)
@@ -68,14 +68,14 @@ def run_ssp(*, cfg, subject, session=None):
                                             average=cfg.ecg_proj_from_average,
                                             reject=reject_ecg_,
                                             **cfg.n_proj_ecg)
-    else:
-        reject_ecg_ = config.get_ssp_reject(
-                ssp_type='ecg',
-                epochs=None)
-        ecg_projs, _ = compute_proj_ecg(raw,
-                                        average=cfg.ecg_proj_from_average,
-                                        reject=reject_ecg_,
-                                        **cfg.n_proj_ecg)
+        else:
+            reject_ecg_ = config.get_ssp_reject(
+                    ssp_type='ecg',
+                    epochs=None)
+            ecg_projs, _ = compute_proj_ecg(raw,
+                                            average=cfg.ecg_proj_from_average,
+                                            reject=reject_ecg_,
+                                            **cfg.n_proj_ecg)
 
     if not ecg_projs:
         msg = 'No ECG events could be found. No ECG projectors computed.'
@@ -92,9 +92,9 @@ def run_ssp(*, cfg, subject, session=None):
         ch_names = None
 
     eog_projs = []
-    if cfg.ssp_reject_eog == 'autoreject_global':
-        eog_epochs = create_eog_epochs(raw)
-        if len(eog_epochs) >= config.min_eog_epochs:
+    eog_epochs = create_eog_epochs(raw)
+    if len(eog_epochs) >= config.min_eog_epochs:
+        if cfg.ssp_reject_eog == 'autoreject_global':
             reject_eog_ = config.get_ssp_reject(
                 ssp_type='eog',
                 epochs=eog_epochs)
@@ -102,17 +102,17 @@ def run_ssp(*, cfg, subject, session=None):
                                             average=cfg.eog_proj_from_average,
                                             reject=reject_eog_,
                                             **cfg.n_proj_eog)
-    else:
-        reject_eog_ = config.get_ssp_reject(
-                ssp_type='eog',
-                epochs=None)
-        eog_projs, _ = compute_proj_eog(raw,
-                                        average=cfg.eog_proj_from_average,
-                                        reject=reject_eog_,
-                                        **cfg.n_proj_eog)
+        else:
+            reject_eog_ = config.get_ssp_reject(
+                    ssp_type='eog',
+                    epochs=None)
+            eog_projs, _ = compute_proj_eog(raw,
+                                            average=cfg.eog_proj_from_average,
+                                            reject=reject_eog_,
+                                            **cfg.n_proj_eog)
 
     if not eog_projs:
-        msg = 'No EOG events could be found. No EOG projectors computed.'
+        msg = 'Not enough EOG events could be found. No EOG projectors computed.'
         logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                      session=session))
 


### PR DESCRIPTION
In order to work autoreject needs at least 5 epochs. Here, if there are not enough ecg or eog epochs the rejection threshold is set to None.
I tested it on a few subjects and it seems to work :ok_hand: 