### PR TITLE
Fix bug in make_epochs()

### DIFF
--- a/config.py
+++ b/config.py
@@ -2470,10 +2470,10 @@ def make_epochs(
             stop=stop)
         event_id = dict(rest=3000)
     else:  # Events for task runs
-        events, event_id_from_annotations = mne.events_from_annotations(raw)
+        if event_id is None:
+            event_id = 'auto'
 
-    if event_id is None:
-        event_id = event_id_from_annotations
+        events, event_id = mne.events_from_annotations(raw, event_id=event_id)
 
     # Construct metadata from the epochs
     if metadata_tmin is None:

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -226,3 +226,9 @@ authors:
   ({{ gh(427) }} by {{ authors.agramfort }})
 - Generated derivative epochs split files now follow the BIDS naming scheme.
   ({{ gh(463)}} by {{ authors.dengemann }})
+- Report tags are now better sanitized.
+  ({{ gh(471) }} by {{ authors.hoechenberger }})
+- When creating epochs, we now ensure that the trigger codes provided via the
+  [`event_id`][config.event_id] setting are retained; previously, new trigger
+  codes were generated in certain situations.
+  ({{ gh(471) }} by {{ authors.hoechenberger }})

--- a/run.py
+++ b/run.py
@@ -4,11 +4,12 @@ import os
 import sys
 import pathlib
 import logging
-from typing import Union, Optional, Tuple
+from typing import Union, Optional, Tuple, List, Dict
 if sys.version_info >= (3, 8):
     from typing import Literal
 else:
     from typing_extensions import Literal
+from types import ModuleType
 
 import fire
 import coloredlogs
@@ -32,8 +33,17 @@ coloredlogs.install(
 PathLike = Union[str, pathlib.Path]
 
 
-def _get_script_modules(*, config, root_dir, subject, session, task, run,
-                        interactive, n_jobs):
+def _get_script_modules(
+    *,
+    config: PathLike,
+    root_dir: Optional[PathLike] = None,
+    subject: Optional[str] = None,
+    session: Optional[str] = None,
+    task: Optional[str] = None,
+    run: Optional[str] = None,
+    interactive: Optional[str] = None,
+    n_jobs: Optional[str] = None
+) -> Dict[str, Tuple[ModuleType]]:
     env = os.environ
     env['MNE_BIDS_STUDY_CONFIG'] = str(pathlib.Path(config).expanduser())
 
@@ -194,7 +204,7 @@ def process(
         n_jobs=n_jobs,
     )
 
-    script_modules = []
+    script_modules: List[ModuleType] = []
     for stage, step in zip(processing_stages, processing_steps):
         if stage not in SCRIPT_MODULES.keys():
             raise ValueError(
@@ -229,9 +239,9 @@ def process(
     for script_module in script_modules:
         script_path = pathlib.Path(script_module.__file__)
         step_name = f'{script_path.parent.name}/{script_path.name}'
-        logger.info(f'🚀 Now running script: {script_module} 👇')
+        logger.info(f'🚀 Now running script: {script_module.__name__} 👇')
         script_module.main()
-        logger.info(f'🎉 Done running script: {step_name} 👆')
+        logger.info(f'🎉 Done running script: {script_module.__name__} 👆')
 
 
 if __name__ == '__main__':

--- a/run.py
+++ b/run.py
@@ -237,8 +237,6 @@ def process(
     )
 
     for script_module in script_modules:
-        script_path = pathlib.Path(script_module.__file__)
-        step_name = f'{script_path.parent.name}/{script_path.name}'
         logger.info(f'🚀 Now running script: {script_module.__name__} 👇')
         script_module.main()
         logger.info(f'🎉 Done running script: {script_module.__name__} 👆')

--- a/scripts/report/_01_make_reports.py
+++ b/scripts/report/_01_make_reports.py
@@ -573,13 +573,17 @@ def run_report_average(*, cfg, subject: str, session: str) -> None:
     for condition, evoked in zip(conditions, evokeds):
         if condition in cfg.conditions:
             title = f'Average: {condition}'
-            tags = ('evoked', config.sanitize_cond_name(condition))
+            tags = (
+                'evoked',
+                config.sanitize_cond_name(condition).lower().replace(' ', '')
+            )
         else:  # It's a contrast of two conditions.
             title = f'Average Contrast: {condition[0]} – {condition[1]}'
             tags = (
                 'evoked',
                 f'{config.sanitize_cond_name(condition[0])} – '
                 f'{config.sanitize_cond_name(condition[1])}'
+                .lower().replace(' ', '')
             )
 
         rep.add_evokeds(
@@ -623,7 +627,9 @@ def run_report_average(*, cfg, subject: str, session: str) -> None:
                     'decoding',
                     'contrast',
                     f'{config.sanitize_cond_name(cond_1)} – '
-                    f'{config.sanitize_cond_name(cond_2)}')
+                    f'{config.sanitize_cond_name(cond_2)}'
+                    .lower().replace(' ', '-')
+                )
             )
             plt.close(fig)
             del decoding_data, cond_1, cond_2, caption, title


### PR DESCRIPTION
We didn't make use of provided `event_id` when generating events from annotations. This could lead to inconsistent event code <> event name mappings across
runs or participants.

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
