### PR TITLE
Drastically reduce memory usage during epoching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/source/examples/*
 !docs/source/examples/examples.md
 .pytest_cache/
 __pycache__/
+mprofile_*.dat

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -110,6 +110,8 @@ authors:
 - The [`noise_cov`][config.noise_cov] can now be set to `ad-hoc` to use a fixed   
   and data-independent diagonal noise covariance matrix for source imaging.
   ({{ gh(460) }} by {{ authors.agramfort }} and  {{ authors.apmellot }})
+- Drastically reduce memory usage during the epoching and ICA steps.
+  ({{ gh(477) }} by {{ authors.hoechenberger }} and {{ authors.agramfort }})
 
 ### Behavior changes
 

--- a/scripts/preprocessing/_04a_run_ica.py
+++ b/scripts/preprocessing/_04a_run_ica.py
@@ -116,8 +116,8 @@ def make_ecg_epochs(
         ecg_dur_per_run = total_ecg_dur / n_runs
         t_mid = (raw.times[-1] - raw.times[0]) / 2
         raw = raw.crop(
-            tmin=t_mid - 1/2 * ecg_dur_per_run,
-            tmax=t_mid + 1/2 * ecg_dur_per_run
+            tmin=max(t_mid - 1/2 * ecg_dur_per_run, 0),
+            tmax=min(t_mid + 1/2 * ecg_dur_per_run, raw.times[-1])
         ).load_data()
 
         ecg_epochs = create_ecg_epochs(raw,

--- a/scripts/preprocessing/_04a_run_ica.py
+++ b/scripts/preprocessing/_04a_run_ica.py
@@ -114,7 +114,7 @@ def make_ecg_epochs(
         # (across all runs)
         total_ecg_dur = 5 * 60
         ecg_dur_per_run = total_ecg_dur / n_runs
-        t_mid = (raw.times[-1] - raw.times[0]) / 2
+        t_mid = (raw.times[-1] + raw.times[0]) / 2
         raw = raw.crop(
             tmin=max(t_mid - 1/2 * ecg_dur_per_run, 0),
             tmax=min(t_mid + 1/2 * ecg_dur_per_run, raw.times[-1])


### PR DESCRIPTION
Peak memory consumption during epoching reduced by more than 50%!
And we're also faster now!


# Benchmarks

## Epochs creation during `make_epochs` script

### `main`
<img width="819" alt="Screen Shot 2021-11-26 at 10 24 14" src="https://user-images.githubusercontent.com/2046265/143557993-7392ad06-89d6-4335-a0de-23ae510c8ce2.png">

### this branch

<img width="827" alt="Screen Shot 2021-11-26 at 10 24 32" src="https://user-images.githubusercontent.com/2046265/143558103-1bce1762-979b-4cc0-a897-9d25ae74c0d7.png">

## Epochs creation during `run_ica` script

### `main`

<img width="835" alt="Screen Shot 2021-11-26 at 10 24 53" src="https://user-images.githubusercontent.com/2046265/143558176-71beb130-611e-4f46-813a-aa9ee909624a.png">

### this branch

<img width="835" alt="Screen Shot 2021-11-26 at 10 25 20" src="https://user-images.githubusercontent.com/2046265/143558215-2f5685ee-f33a-4eec-9f18-54da6d9c96d9.png">

# How this was achieved

- We preload epochs so we can remove the respective raw from memory
- Instead of creating a list of all epochs for all runs before concatenation and then concatenating them all at once, we now concatenate epochs immediately after they were created. This further reduced peak memory usage significantly (although I don't fully understand why!)
- During ICA epochs generation, we now drop all epochs that are not in `config.conditions`. In `main`, we create epochs from ALL events, often creating uselessly huge numbers of epochs, increasing memory footprint and massively slowing down ICA decomposition.
- We now only keep a max of 300 EOG and ECG epochs (hardcoded limit)

# Further ideas

We may be able to further reduce peak memory consumption at the cost of I/O and processing speed.

- For example, currently we're creating EOG and ECG epochs in the same loop as the "task" epochs. If we split this into separate loops, peak memory consumption could be lower.
- Currently, EOG and ECG epochs are reduced to 300 elements only AFTER the bloated epochs objects have been created. Instead, one could first only extract EOG and ECG **events**, subset those to get 300, and only then create the epochs.



### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
