### PR TITLE
Add psutil dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 typing_extensions
+psutil
 numpy
 scipy
 scikit-learn

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,7 @@
 setuptools
 pip
 typing_extensions
+psutil
 datalad
 numpy
 scipy


### PR DESCRIPTION
joblib has some built-in memory leak detection that requires `psutil` to function. I think it therefore makes sense to add `psutil` to our list of dependencies.

https://joblib.readthedocs.io/en/latest/developing.html#release-0-12-2
