### PR TITLE
Add epochs to the report. Add plot_psd_for_runs setting.

### DIFF
--- a/config.py
+++ b/config.py
@@ -158,6 +158,14 @@ space: Optional[str] = None
 The BIDS `space` entity.
 """
 
+plot_psd_for_runs: Union[Literal['all'], Iterable[str]] = 'all'
+"""
+For which runs to add a power spectral density (PSD) plot to the generated
+report. This can take a considerable amount of time if you have many long
+runs. In this case, specify the runs, or pass an empty list to disable raw PSD
+plotting.
+"""
+
 subjects: Union[Iterable[str], Literal['all']] = 'all'
 """
 Subjects to analyze. If ``'all'``, include all subjects. To only

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -114,7 +114,7 @@ authors:
   ({{ gh(477) }} by {{ authors.hoechenberger }} and {{ authors.agramfort }})
 - The new [`plot_psd_for_runs`][config.plot_psd_for_runs] setting can be used
   to control for which runs to add PSD plots of the raw data to the reports.
-  ({{ gh(459) }} by {{ authors.hoechenberger }})
+  ({{ gh(482) }} by {{ authors.hoechenberger }})
 
 ### Behavior changes
 

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -112,6 +112,9 @@ authors:
   ({{ gh(460) }} by {{ authors.agramfort }} and  {{ authors.apmellot }})
 - Drastically reduce memory usage during the epoching and ICA steps.
   ({{ gh(477) }} by {{ authors.hoechenberger }} and {{ authors.agramfort }})
+- The new [`plot_psd_for_runs`][config.plot_psd_for_runs] setting can be used
+  to control for which runs to add PSD plots of the raw data to the reports.
+  ({{ gh(459) }} by {{ authors.hoechenberger }})
 
 ### Behavior changes
 

--- a/docs/source/settings/general.md
+++ b/docs/source/settings/general.md
@@ -23,3 +23,4 @@
 ::: config.eeg_template_montage
 ::: config.drop_channels
 ::: config.analyze_channels
+::: config.plot_psd_for_runs

--- a/scripts/report/_01_make_reports.py
+++ b/scripts/report/_01_make_reports.py
@@ -246,10 +246,10 @@ def run_report(*, cfg, subject, session=None):
 
     rep = mne.Report(title=title, raw_psd=True)
 
-    for idx, fname in enumerate(fnames_raw_filt):
+    for fname in fnames_raw_filt:
         title = 'Raw'
         if fname.run is not None:
-            title += f'run {fname.run}'
+            title += f', run {fname.run}'
 
         if (
             cfg.plot_psd_for_runs == 'all' or


### PR DESCRIPTION
Previously we'd only plot the PSD of raw data for the first run to speed up report generation. Working with @SophieHerbst we discovered that this is not a good choice for us, so this PR:

- changes the default behavior such that we get a PSD plot for each run
- add a new config option, `plot_psd_for_runs`, allowing users to control this behavior

Also, we now add epochs to the report. It appears I simply forgot about them when transitioning to the new MNE Report API.


### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
