### PR TITLE
Adds tqdm to the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ pyvistaqt
 autoreject
 openpyxl
 pooch
+tqdm
 mne @ https://api.github.com/repos/mne-tools/mne-python/zipball/main
 mne-bids @ https://api.github.com/repos/mne-tools/mne-bids/zipball/main


### PR DESCRIPTION
Required to get started as tqdm is imported in `mne-bids-pipeline/scripts/sensor/04-group_average.py` so on a fresh install, just running the pipeline crashes immediately. See https://github.com/mne-tools/mne-bids-pipeline/blob/3bd255f390aaabd73c9fa5ac3382a7719a19136f/scripts/sensor/04-group_average.py#L156 as well as the "install.md" file here https://github.com/mne-tools/mne-bids-pipeline/blob/3bd255f390aaabd73c9fa5ac3382a7719a19136f/docs/source/getting_started/install.md

Otherwise we could remove the use of `tqdm` there, I'll let the maintainers decide.

### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
