### PR TITLE
Stronger decimation for MRI & BEM plotting

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -168,6 +168,12 @@ authors:
 - Enabling interactive mode by setting [`interactive`][config.interactive] to
   `True` now deactivates parallel processing.
   ({{ gh(473) }} by {{ authors.hoechenberger }})
+- The resolution of the MRI slices for BEM visualalization has been reduced to
+  256 by 256 pixels (was 512 by 512 before), we now only plot every 8th slice
+  (was ever 2nd before). This greatly speeds up BEM rendering and reduces the
+  size of the generated report, while maintaining a sufficiently detailed
+  visualization.
+  ({{ gh(488) }} by {{ authors.hoechenberger }})
 
 ### Code health
 

--- a/scripts/report/_01_make_reports.py
+++ b/scripts/report/_01_make_reports.py
@@ -639,14 +639,20 @@ def run_report_source(
         has_trans = fname_trans.fpath.exists()
 
     if has_trans:
+        msg = 'Rendering MRI slices with BEM contours.'
+        logger.info(**gen_log_kwargs(message=msg,
+                                     subject=subject, session=session))
+
         report.add_bem(
             subject=cfg.fs_subject,
             subjects_dir=cfg.fs_subjects_dir,
-            title='BEM'
+            title='BEM',
+            width=256,
+            decim=8
         )
 
         for condition in conditions:
-            msg = f'Rendering inverse solution for {condition} …'
+            msg = f'Rendering inverse solution for {condition}'
             logger.info(**gen_log_kwargs(message=msg,
                                          subject=subject, session=session))
 


### PR DESCRIPTION
Tested source report rendering with some real-world data.

MRI/BEM rendering was sped up by ~80%
Souce-space report became 20% smaller
(still way too big though, but we're slowly getting there!)

```
main:
report size: 114 MB
BEM rendering duration: 49 sec

PR:
report size: 91 MB 
BEM rendering duration: 10 sec
```


### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
