### PR TITLE
Add epochs_metadata_excludes

### DIFF
--- a/config.py
+++ b/config.py
@@ -821,7 +821,7 @@ will be named with a ``last_`` instead of a ``first_`` prefix.
 epochs_metadata_excludes: Iterable[str] = []
 """
 [Metadata queries][https://mne.tools/stable/auto_tutorials/epochs/30_epochs_metadata.html]
-specifying which epochs to exclude from analysis. If a metadata query fails
+specifying which epochs to exclude from analysis. If a query fails
 because it refers to an unknown metadata column, a warning will be emitted.
 
 ???+ example "Example"

--- a/config.py
+++ b/config.py
@@ -818,6 +818,19 @@ occurrence of matching event types. The columns indicating the event types
 will be named with a ``last_`` instead of a ``first_`` prefix.
 """
 
+epochs_metadata_excludes: Iterable[str] = []
+"""
+[Metadata queries][https://mne.tools/dev/auto_tutorials/epochs/30_epochs_metadata.html]
+specifying which epochs to exclude from analysis. If a metadata query doesn't
+yield any epochs, a warning will be emitted.
+
+???+ example "Example"
+    Exclude all epochs with a `response_missing` event:
+    ```python
+    epochs_metadata_excludes = ['response_missing.notna()']
+    ```
+"""
+
 conditions: Optional[Union[Iterable[str], Dict[str, str]]] = None
 """
 The time-locked events based on which to create evoked responses.

--- a/config.py
+++ b/config.py
@@ -820,9 +820,9 @@ will be named with a ``last_`` instead of a ``first_`` prefix.
 
 epochs_metadata_excludes: Iterable[str] = []
 """
-[Metadata queries][https://mne.tools/dev/auto_tutorials/epochs/30_epochs_metadata.html]
-specifying which epochs to exclude from analysis. If a metadata query doesn't
-yield any epochs, a warning will be emitted.
+[Metadata queries][https://mne.tools/stable/auto_tutorials/epochs/30_epochs_metadata.html]
+specifying which epochs to exclude from analysis. If a metadata query fails
+because it refers to an unknown metadata column, a warning will be emitted.
 
 ???+ example "Example"
     Exclude all epochs with a `response_missing` event:

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -117,6 +117,9 @@ authors:
   ({{ gh(482) }} by {{ authors.hoechenberger }})
 - Speed up report generation.
   ({{ gh(487) }} by {{ authors.hoechenberger }})
+- The new [`epochs_metadata_excludes][config.epochs_metadata_excludes] setting
+  allows for the exclusion of epochs based on metadata query strings.
+  ({{ gh(495) }} by {{ authors.hoechenberger }})
 
 ### Behavior changes
 

--- a/docs/source/settings/preprocessing/epochs.md
+++ b/docs/source/settings/preprocessing/epochs.md
@@ -8,5 +8,6 @@
 ::: config.epochs_metadata_tmax
 ::: config.epochs_metadata_keep_first
 ::: config.epochs_metadata_keep_last
+::: config.epochs_metadata_exclude
 ::: config.rest_epochs_duration
 ::: config.rest_epochs_overlap

--- a/docs/source/settings/preprocessing/epochs.md
+++ b/docs/source/settings/preprocessing/epochs.md
@@ -8,6 +8,6 @@
 ::: config.epochs_metadata_tmax
 ::: config.epochs_metadata_keep_first
 ::: config.epochs_metadata_keep_last
-::: config.epochs_metadata_exclude
+::: config.epochs_metadata_excludes
 ::: config.rest_epochs_duration
 ::: config.rest_epochs_overlap

--- a/scripts/preprocessing/_03_make_epochs.py
+++ b/scripts/preprocessing/_03_make_epochs.py
@@ -128,7 +128,7 @@ def run_epochs(*, cfg, subject, session=None):
 
     # Lastly, exclude epochs based on metadata.
     if cfg.epochs_metadata_excludes:
-        msg = f'Excluding epochs based on metadata queries …'
+        msg = 'Excluding epochs based on metadata queries …'
         logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                      session=session))
 
@@ -145,7 +145,7 @@ def run_epochs(*, cfg, subject, session=None):
         n_epochs_after = len(epochs)
         n_epochs_diff = n_epochs_before - n_epochs_after
         msg = (f'Removed {n_epochs_diff} epochs matching metadata query: '
-                f'{exclude}')
+               f'{exclude}')
         logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                      session=session))
 


### PR DESCRIPTION
This new setting allows for the exclusion of epochs based on metadata.

In theory this is already possible via `conditions`, but especially with lots of nested event names, this becomes very cumbersome very quickly, because the auto-generated metadata dataframe currently does not create columns for such event groupings. That is, if you have e.g. the following events:

```python
stim/1
stim/2
stim/3
stim/4
stim/5
bad_response
```
and you want to analyze all `stim` trials but exclude all epochs that have a `bad_response` event in the metadata. You cannot simply specify:
```python
conditions = {'stim': 'stim.notna() and bad_response.isna()'}
```
because there won't be a column `'stim'` in the auto-generated metadata. Instead, you'd have to add each event name explicitly, and use backticks to make the forward slashes work:
```python
conditions = {
    'stim':
        '(`stim/1`.notna() or '
        ' `stim/2`.notna() or '
        ' `stim/3`.notna() or '
        ' `stim/4`.notna() or '
        ' `stim/5`.notna()) and'
        'bad_response.isna()'
}
```
Now imagine doing this with even more conditions … This is not very user friendly.
 
Also there might be experiments where **all** participants get to be presented with a `stim`, but you might have groups that only get to see `stim/1` and `stim/2`, while others only get to see `stim/3` and `stim/4`. You'd have to produce different `conditions` for each group, as the columns corresponding to the not-presented stimuli would simply be missing, and the query would fail, complaining about missing columns.

With this PR, the above situation can be addressed by simply specifying:

```python
epochs_metadata_excludes = ['bad_response.notna()']
conditions = ['stim']
```

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
