### PR TITLE
Adds `ica_reject` to `cfg` during `get_config` in `scripts/report/_01_make_reports.py`, fixes `no attribute` error

### DIFF
--- a/scripts/report/_01_make_reports.py
+++ b/scripts/report/_01_make_reports.py
@@ -1007,7 +1007,8 @@ def get_config(
         bids_root=config.get_bids_root(),
         use_template_mri=config.use_template_mri,
         interactive=config.interactive,
-        plot_psd_for_runs=config.plot_psd_for_runs
+        plot_psd_for_runs=config.plot_psd_for_runs,
+        ica_reject=config.ica_reject
     )
     return cfg
 


### PR DESCRIPTION
Reports were erroring with `'BunchConst' object has no attribute 'ica_reject'`, presumably following commit e6d7d7a20cfbf099b0ade7ad432dbf482d70db81.
This change straightforwardly pulls `ica_reject` from `config` and adds it to `cfg` in `get_config`.

### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
