### PR TITLE
[tests] update eeg_matchingpennies location

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright © 2019-2021, authors of MNE-BIDS-Pipeline
+Copyright © 2019-2022, authors of MNE-BIDS-Pipeline
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/tests/datasets.py
+++ b/tests/datasets.py
@@ -27,9 +27,9 @@ DATASET_OPTIONS: Dict[str, DATASET_OPTIONS_T] = {
         'exclude': []
     },
     'eeg_matchingpennies': {
-        'git': 'https://github.com/sappelhoff/eeg_matchingpennies',
+        'git': 'https://gin.g-node.org/sappelhoff/eeg_matchingpennies',
         'openneuro': '',
-        'osf': '',
+        'osf': '',  # original dataset: 'cj2dr'
         'web': '',
         'include': ['sub-05'],
         'exclude': []


### PR DESCRIPTION
closes #507 

- I updated the data in https://github.com/bids-standard/bids-examples/pull/265
- I tried pushing to OSF, then noticed that they have a new 5GB limitation, which I exceeded (EDIT: the cap might be [50GB](https://help.osf.io/hc/en-us/articles/360054528874-OSF-Storage-Caps) for *public* repos, maybe this step and the one below occurred in opposite order)
- in the process, [my OSF project](https://osf.io/cj2dr/) got marked as SPAM :-) (meaning they automatically set it to _private_ ... I need to discuss with their support now)
- Now trying to do it via [GIN](https://gin.g-node.org/sappelhoff/eeg_matchingpennies)
- If that doesn't work, I'll upload a small archive to the MNE OSF account as the easiest solution