### PR TITLE
Remove name clash introduced by PR #537

### DIFF
--- a/scripts/sensor/_01_make_evoked.py
+++ b/scripts/sensor/_01_make_evoked.py
@@ -69,8 +69,8 @@ def run_evoked(*, cfg, subject, session=None):
                                      session=session))
 
         for contrast in cfg.contrasts:
-            all_evoked = [epochs[x].average() for x in contrast["conditions"]]
-            evoked_diff = mne.combine_evoked(all_evoked,
+            evoked_list = [epochs[x].average() for x in contrast["conditions"]]
+            evoked_diff = mne.combine_evoked(evoked_list,
                                              weights=contrast["weights"])
             all_evoked[contrast["name"]] = evoked_diff
 


### PR DESCRIPTION
When I renamed that variable to follow `mne`'s name I didn't realize that it clashed with the dict used all over the place in that code block... Sorry about that!
