### PR TITLE
fix of typing object for python < 3.9

### DIFF
--- a/config.py
+++ b/config.py
@@ -2030,7 +2030,7 @@ if bem_mri_images not in ('FLASH', 'T1', 'auto'):
 
 try:
     _keys_arbitrary_contrast = set(ArbitraryContrast.__required_keys__)
-except:
+except Exception:
     _keys_arbitrary_contrast = set(ArbitraryContrast.__annotations__.keys())
 
 

--- a/config.py
+++ b/config.py
@@ -2028,7 +2028,10 @@ if bem_mri_images not in ('FLASH', 'T1', 'auto'):
     raise ValueError(msg)
 
 
-_keys_arbitrary_contrast = set(ArbitraryContrast.__required_keys__)
+try:
+    _keys_arbitrary_contrast = set(ArbitraryContrast.__required_keys__)
+except:
+    _keys_arbitrary_contrast = set(ArbitraryContrast.__annotations__.keys())
 
 
 def _validate_contrasts(contrasts):

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -8,7 +8,7 @@ authors:
   crsegerie: "[Charbel-Raphaël Segerie](https://github.com/crsegerie)"
   dengemann: "[Denis A. Engemann](https://github.com/dengemann)"
   apmellot: "[Apolline Mellot](https://github.com/apmellot)"
-  mathias-sm: "[Mathias Sablé-Meyer](https://github.com/mathias-sm)"
+  mathiassm: "[Mathias Sablé-Meyer](https://github.com/mathias-sm)"
 ---
 
 
@@ -147,7 +147,7 @@ authors:
   dicts specifying a name, a condition list and a weights list to use to
   `combine_evoked`. Decoding steps ignores contrasts with more than two
   elements.
-  ({{ gh(536) }} by {{ authors.mathias-sm }}
+  ({{ gh(536) }} by {{ authors.mathiassm }}
 
 ### Behavior changes
 

--- a/tests/configs/config_ds000248.py
+++ b/tests/configs/config_ds000248.py
@@ -46,6 +46,7 @@ recreate_scalp_surface = True
 
 N_JOBS = 2
 
+
 def mri_t1_path_generator(bids_path):
     # don't really do any modifications – just for testing!
     return bids_path

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,3 +10,4 @@ livereload
 openneuro-py
 httpx >= 0.20
 tqdm
+Pygments <= 2.11.2


### PR DESCRIPTION
### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
