### PR TITLE
STY: Fix doc table line height

### DIFF
--- a/docs/source/css/extra.css
+++ b/docs/source/css/extra.css
@@ -13,7 +13,6 @@ p {
 .md-typeset table td,
 .md-typeset table th {
   font-size: 0.7rem;
-  line-height: 0.5;
 }
 
 /* Larger font in code, example, info, warning blocks */

--- a/docs/source/css/extra.css
+++ b/docs/source/css/extra.css
@@ -13,6 +13,7 @@ p {
 .md-typeset table td,
 .md-typeset table th {
   font-size: 0.7rem;
+  padding: .5em 1.25em !important;
 }
 
 /* Larger font in code, example, info, warning blocks */


### PR DESCRIPTION
Closes #575

@hoechenberger you added this in #543 where I see:

> Reduce table row height in example docs

Do you want to try pushing a different fix that doesn't cause the problem in #575, or just live with this revert?