### PR TITLE
Infant

### DIFF
--- a/scripts/freesurfer/_01_recon_all.py
+++ b/scripts/freesurfer/_01_recon_all.py
@@ -18,9 +18,6 @@ fs_bids_app = Path(__file__).parent / 'contrib' / 'run.py'
 
 
 def run_recon(root_dir, subject, fs_bids_app) -> None:
-    logger.info(f"Running recon-all on subject {subject}. This will take "
-                f"a LONG time – it's a good idea to let it run over night.")
-
     subjects_dir = Path(config.get_fs_subjects_dir())
     subj_dir = subjects_dir / f"sub-{subject}"
 
@@ -28,6 +25,8 @@ def run_recon(root_dir, subject, fs_bids_app) -> None:
         logger.info(f"Subject {subject} is already present. Please delete the "
                     f"directory if you want to recompute.")
         return
+    logger.info(f"Running recon-all on subject {subject}. This will take "
+                f"a LONG time – it's a good idea to let it run over night.")
 
     env = os.environ
     if 'FREESURFER_HOME' not in env:

--- a/scripts/freesurfer/_02_coreg_surfaces.py
+++ b/scripts/freesurfer/_02_coreg_surfaces.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import mne.bem
 
 import config
-from config import parallel_func
+from config import parallel_func, on_error, failsafe_run
 
 PathLike = Union[str, Path]
 logger = logging.getLogger('mne-bids-pipeline')
@@ -42,6 +42,7 @@ def get_config() -> SimpleNamespace:
     return cfg
 
 
+@failsafe_run(on_error=on_error, script_path=__file__)
 def main():
     # Ensure we're also processing fsaverage if present
     subjects = config.get_subjects()


### PR DESCRIPTION
### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)

Two small tweaks:

1. Only emit the "freesurfer takes forever" message if we *don't* emit the "subject already found, skipping" message
2. Use `failsafe_run` for the `mkheadsurf` step. It helped me debug the failure and find out that my `sub-007` recon was interrupted so never produced the `T1.mgz`

For (2) at some point we might want to come up with some "did recon-all actually complete" check at some point. But for now this at least makes it easier to see it