### PR TITLE
BUG: Use patch information in computing normals

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -239,6 +239,9 @@ authors:
   [`report_evoked_n_time_points`][config.report_evoked_n_time_points] and
   [`report_stc_n_time_points`][config.report_stc_n_time_points], respectively.
   ({{ gh(542) }} by {{ authors.agramfort }})
+- Patch information is now incorporated when computing surface source spaces,
+  which should slightly improve the surface normals
+  ({{ gh(588) }} by {{ authors.larsoner }})
 
 ### Code health
 

--- a/scripts/source/_02_make_forward.py
+++ b/scripts/source/_02_make_forward.py
@@ -54,7 +54,7 @@ def _prepare_forward_template(cfg, fname_info):
     src = mne.setup_source_space(subject=cfg.fs_subject,
                                  subjects_dir=cfg.fs_subjects_dir,
                                  spacing=cfg.spacing,
-                                 add_dist=False)
+                                 add_dist='patch')
     return src, trans, bem_sol
 
 


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

`add_dist='patch'` doesn't add much time, but it improves the source space normal definitions by using the average normal in a surface patch (i.e., of all high-res verts for which the given source space vert is the closest source space vert)