### PR TITLE
Add docker file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM continuumio/miniconda3 as base
+# FROM python:3.9
+
+RUN git clone --depth 1 https://github.com/mne-tools/mne-bids-pipeline /mne-bids-pipeline
+
+# Setup user and working directories
+# RUN groupadd -r user && useradd -r -g user mne-user
+RUN mkdir -p /work /data
+# RUN chown mne-user /work /data
+
+WORKDIR /work
+VOLUME ["/work", "/data"]
+
+# Create the environment:
+RUN conda create --name=mnenv --channel=conda-forge mne
+RUN conda install -n mnenv pip
+
+# Activate conda environment
+SHELL ["conda", "run", "-n", "mnenv", "/bin/bash", "-c"]
+RUN python -c "import mne; mne.sys_info()"
+
+# Install requirements for MNE-BIDS-Pipeline
+RUN pip install -r https://raw.githubusercontent.com/mne-tools/mne-bids-pipeline/main/requirements.txt
+
+# Environment variables: Replace PIPELINE_CONFIG for your own pipeline config
+ENV PIPELINE_ROOT=/mne-bids-pipeline
+ENV PIPELINE_CONFIG=/work/config.py
+
+RUN echo -e '#!/bin/bash\nconda run -n mnenv python /mne-bids-pipeline/run.py --config=$PIPELINE_CONFIG' > /usr/bin/run && \
+    chmod +x /usr/bin/run
+
+# USER mne-user
+# ENTRYPOINT sh
+ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "mnenv", "/bin/bash"]
+# ENTRYPOINT run
+
+# FROM base as test
+# CMD ["cd", "/mne-bids-pipeline"]
+# CMD ["conda", "run", "--no-capture-output", "-n", "mnenv", "make", "check"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,49 @@
+# Containers
+
+The MNE-BIDS-Pipeline can be run as a docker container. The file `docker/Dockerfile` is such an example.
+After [installing docker](https://docs.docker.com/get-docker/), open a terminal in the `docker` folder and build the image:
+
+```
+sudo docker build -t mne .
+```
+
+In this example, two environment variables are available, and two volumes:
+
+```dockerfile
+# Exposed volumes:
+# `work`: workspace
+# `data`: available to mount data volumes independently
+VOLUME ["/work", "/data"]
+
+# ...
+
+# Environment variables: Replace PIPELINE_CONFIG for your own pipeline config
+ENV PIPELINE_ROOT=/mne-bids-pipeline
+ENV PIPELINE_CONFIG=/work/config.py
+```
+
+A pipeline can be run from a configuration file on the current folder of the host machine (`./config.py`) as follows:
+
+```
+sudo docker run --rm -v .:/work -v /host/data/:/data --name mne-pipeline mne run
+```
+Details:
+ - `sudo`: give docker admin permissions.
+ - `docker`: Call the docker program that will run the containerized app.
+ - `run`: Take an image (specified at the end) and run a container from it.
+ - `--rm`: When the container is finished, remove it.
+ - `-v`: Mount a folder from the host machine to the guest container. The directories `/work` and `/data` are made to hold the configuration and data for the pieline.
+ - `--name`: give the container a name. This will allow you to control it easily from the docker CLI.
+ - `mne`: this is the name of the image built in the last step. It instructs docker to run the container with those instructions.
+ - `run`: An container's internal alias to run the pipeline with the configuration file in `/work/config.py`
+
+To run an interactive session, you can add the flags `-it` and don't call the `run` parameter:
+```
+sudo docker run --rm -it -v /host/work:/work -v /host/data/:/data --name mne-pipeline mne
+```
+
+This last command wil land you in a bash root session inside the container. The python binary and requirements are installed.
+
+In your configuration file, your `bids_root` should start with '/data/', so the containerized pipeline might find it in the mounted volume.
+
+You might imagine how you could run many containers on a [docker swarm](https://docs.docker.com/engine/swarm/) to explore different pipelines making use of some distributed computing.


### PR DESCRIPTION
Hi,

This is related to #591. Back I talked with @hoechenberger about parallel distributed usage of the pipeline. He mentioned there were some attempts at dask, but we concluded it might be easier to just containerize the project and run it as docker swarm. 

In #591 I suggested a dockerfile from the python image, with the config file and data are the only variables of the container.

@hoechenberger suggested: 
- [X] Using the official installation of MNE:

  I changed the base image to miniconda then, to be able to install MNE through conda, as suggested in the documentation.

- [X] Pulling the repo:

  Since dockerfiles are commonly already inside a repository, it is uncommon to pull that same repository when building the image, but I have followed your suggestion. I think it might be a good example for someone trying to build their own images.

I documented basic usage in `docker/README.md`, but you can test the image like this:
```sh 
sudo docker build -t mne . && sudo docker run --rm -it -v /host/work:/work -v /host/data/:/data --name mne-pipeline mne
```

Also, I added these changes in a new folder: `docker`. This is because I consider these examples, rather than the one and only Dockerfile for the repo (generally stored in `./Dockerfile`). One could be made with build and test targets, though: There is a tiny example comment on this Dockerfile. I don't really know how the test are run for this repo, so I didn't test it myself.

The following points are missing:

- [ ] Changelog has been updated (`docs/source/changes.md`): 
      Should I just add a new line at the top with the date and a comment on what I did?
- [ ] Many libraries are not installed with "default" installation, as seen by the output of `mne.sys_info()`.

**Output of `mne.sys_info()`**:
```

Platform:         Linux-5.15.60-1-MANJARO-x86_64-with-glibc2.31
Python:           3.10.6 | packaged by conda-forge | (main, Aug 22 2022, 20:35:26) [GCC 10.4.0]
Executable:       /opt/conda/envs/mnenv/bin/python
CPU:              : 12 cores
Memory:           47.0 GB

mne:              1.1.1
numpy:            1.22.4 {blas=NO_ATLAS_INFO, lapack=lapack}
scipy:            1.9.1
matplotlib:       3.5.3 {backend=agg}

sklearn:          1.1.2
numba:            0.55.2
nibabel:          4.0.2
nilearn:          0.9.2
dipy:             1.5.0
cupy:             Not found
pandas:           1.4.4
pyvista:          Not found
pyvistaqt:        Not found
ipyvtklink:       0.2.2
vtk:              Not found
qtpy:             2.2.0 {PyQt5=5.15.4}
ipympl:           Not found
pyqtgraph:        Not found
pooch:            v1.6.0

mne_bids:         Not found
mne_nirs:         Not found
mne_features:     Not found
mne_qt_browser:   0.3.2
mne_connectivity: Not found
mne_icalabel:     Not found
```
I think `mne_bids` should be installed, shouldn't it?

Best,

Alberto


