### PR TITLE
BUG: Fix bug with freq filt caching

### DIFF
--- a/scripts/preprocessing/_02_frequency_filter.py
+++ b/scripts/preprocessing/_02_frequency_filter.py
@@ -81,32 +81,29 @@ def get_input_fnames_frequency_filter(**kwargs):
     in_files = dict()
     in_files[f'raw_run-{run}'] = bids_path_in
 
-    # TODO: No need to process empty room (I guess?)
-    if config.noise_cov not in ('rest', 'emptyroom'):
-        return in_files
-
-    noise_task = "rest" if config.noise_cov == "rest" else "noise"
-    if cfg.use_maxwell_filter:
-        raw_noise_fname_in = bids_path_in.copy().update(
-            run=None, task=noise_task
-        )
-        if raw_noise_fname_in.copy().update(split='01').fpath.exists():
-            raw_noise_fname_in.update(split='01')
-        in_files["raw_noise"] = raw_noise_fname_in
-    else:
-        if config.noise_cov == 'rest':
-            in_files["raw_rest"] = bids_path_in.copy().update(run=None,
-                                                              task=noise_task)
-        else:
-            assert config.noise_cov == 'noise'
-            ref_bids_path = bids_path_in.copy().update(
-                run=cfg.mf_reference_run,
-                extension='.fif',
-                suffix='meg',
-                root=cfg.bids_root,
-                check=True
+    if (cfg.process_er or config.noise_cov == 'rest') and run == cfg.runs[0]:
+        noise_task = "rest" if config.noise_cov == "rest" else "noise"
+        if cfg.use_maxwell_filter:
+            raw_noise_fname_in = bids_path_in.copy().update(
+                run=None, task=noise_task
             )
-            in_files["raw_er"] = ref_bids_path.find_empty_room()
+            if raw_noise_fname_in.copy().update(split='01').fpath.exists():
+                raw_noise_fname_in.update(split='01')
+            in_files["raw_noise"] = raw_noise_fname_in
+        else:
+            if config.noise_cov == 'rest':
+                in_files["raw_rest"] = bids_path_in.copy().update(
+                    run=None, task=noise_task)
+            else:
+                assert config.noise_cov == 'noise'
+                ref_bids_path = bids_path_in.copy().update(
+                    run=cfg.mf_reference_run,
+                    extension='.fif',
+                    suffix='meg',
+                    root=cfg.bids_root,
+                    check=True
+                )
+                in_files["raw_er"] = ref_bids_path.find_empty_room()
 
     return in_files
 

--- a/tests/configs/config_ds000248.py
+++ b/tests/configs/config_ds000248.py
@@ -23,7 +23,7 @@ mf_reference_run = '01'
 find_flat_channels_meg = True
 find_noisy_channels_meg = True
 use_maxwell_filter = True
-process_er = False
+process_er = True
 
 
 def noise_cov(bp):


### PR DESCRIPTION
### Before merging …

If you use maxwell filtering, baseline noise cov, and `process_er=True`, you get an error:
```
  File "/home/larsoner/python/mne-bids-pipeline/scripts/preprocessing/_02_frequency_filter.py", line 221, in filter_data
    bids_path_noise = in_files["raw_noise"]
KeyError: 'raw_noise'
```
The first commit should hopefully expose this problem (true TDD!). The second should hopefully fix it.

No changelog update necessary I think because it's a within-release fix. This was introduced in #563
