### PR TITLE
ENH: Add --debug to run_tests.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -2601,6 +2601,14 @@ def get_n_jobs() -> int:
     return n_jobs
 
 
+def get_on_error() -> int:
+    if interactive:
+        this_on_error = 'debug'
+    else:
+        this_on_error = os.getenv('MNE_BIDS_STUDY_ON_ERROR', on_error)
+    return this_on_error
+
+
 dask_client = None
 
 
@@ -2836,10 +2844,10 @@ def get_decoding_contrasts() -> Iterable[Tuple[str, str]]:
 
 
 def failsafe_run(
-    on_error: OnErrorT,
     script_path: PathLike,
     get_input_fnames: Optional[Callable] = None,
 ):
+    on_error = get_on_error()
     if memory_location is None or \
             memory_location is False or \
             get_input_fnames is None:

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -359,3 +359,6 @@ authors:
   ({{ gh(572) }} by {{ authors.hoechenberger }})
 - Fix bug with handling of split files during preprocessing
   ({{ gh(597) }} by {{ authors.larsoner }})
+- Fix bug where wrong command-line arguments to ``run.py`` were just ignored
+  instead of raising an error
+  ({{ gh(605) }}) by {{ authors.larsoner }}

--- a/run.py
+++ b/run.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-import functools
-import inspect
 import os
 import sys
 import pathlib

--- a/run.py
+++ b/run.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+import functools
+import inspect
 import os
 import sys
 import pathlib
@@ -46,7 +48,8 @@ def _get_script_modules(
     task: Optional[str] = None,
     run: Optional[str] = None,
     interactive: Optional[str] = None,
-    n_jobs: Optional[str] = None
+    n_jobs: Optional[str] = None,
+    on_error: Optional[str] = None,
 ) -> Dict[str, Tuple[ModuleType]]:
     env = os.environ
     env['MNE_BIDS_STUDY_CONFIG'] = str(pathlib.Path(config).expanduser())
@@ -71,6 +74,9 @@ def _get_script_modules(
 
     if n_jobs:
         env['MNE_BIDS_STUDY_NJOBS'] = n_jobs
+
+    if on_error:
+        env['MNE_BIDS_STUDY_ON_ERROR'] = on_error
 
     from scripts import init
     from scripts import preprocessing
@@ -123,7 +129,9 @@ def process(
     task: Optional[str] = None,
     run: Optional[str] = None,
     interactive: Optional[str] = None,
-    n_jobs: Optional[str] = None
+    n_jobs: Optional[str] = None,
+    debug: Optional[str] = None,
+    **kwargs: Optional[dict],
 ):
     """Run the BIDS pipeline.
 
@@ -153,7 +161,13 @@ def process(
         Whether or not to enable "interactive" mode.
     n_jobs
         The number of parallel processes to execute.
+    debug
+        Whether or not to force on_error='debug'.
+    **kwargs
+        Should not be used. Only used to detect invalid arguments.
     """
+    if kwargs:
+        raise ValueError(f"Unknown argument(s) to run.py: {list(kwargs)}")
     if steps is None:
         steps = ('all',)
     elif isinstance(steps, str) and ',' in steps:
@@ -183,6 +197,7 @@ def process(
         interactive = '1' if interactive in ['1', 'True', True] else '0'
     if n_jobs is not None:
         n_jobs = str(n_jobs)
+    on_error = 'debug' if debug is not None else debug
 
     processing_stages = []
     processing_steps = []
@@ -206,6 +221,7 @@ def process(
         run=run,
         interactive=interactive,
         n_jobs=n_jobs,
+        on_error=on_error,
     )
 
     script_modules: List[ModuleType] = []

--- a/scripts/freesurfer/_02_coreg_surfaces.py
+++ b/scripts/freesurfer/_02_coreg_surfaces.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import mne.bem
 
 import config
-from config import parallel_func, on_error, failsafe_run
+from config import parallel_func, failsafe_run
 
 PathLike = Union[str, Path]
 logger = logging.getLogger('mne-bids-pipeline')
@@ -42,7 +42,7 @@ def get_config() -> SimpleNamespace:
     return cfg
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def main():
     # Ensure we're also processing fsaverage if present
     subjects = config.get_subjects()

--- a/scripts/init/_00_init_derivatives_dir.py
+++ b/scripts/init/_00_init_derivatives_dir.py
@@ -15,7 +15,7 @@ from mne_bids.config import BIDS_VERSION
 from mne_bids.utils import _write_json
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run
+from config import gen_log_kwargs, failsafe_run
 from config import parallel_func
 
 logger = logging.getLogger('mne-bids-pipeline')
@@ -76,7 +76,7 @@ def get_config(
     return cfg
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def main():
     """Initialize the output directories."""
     with config.get_parallel_backend():

--- a/scripts/preprocessing/_01_maxfilter.py
+++ b/scripts/preprocessing/_01_maxfilter.py
@@ -27,7 +27,7 @@ import mne
 from mne_bids import BIDSPath, read_raw_bids
 
 import config
-from config import (gen_log_kwargs, on_error, failsafe_run,
+from config import (gen_log_kwargs, failsafe_run,
                     import_experimental_data, import_er_data, import_rest_data,
                     _update_for_splits)
 from config import parallel_func
@@ -75,7 +75,7 @@ def get_input_fnames_maxwell_filter(**kwargs):
     return in_files
 
 
-@failsafe_run(on_error=on_error, script_path=__file__,
+@failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_maxwell_filter)
 def run_maxwell_filter(*, cfg, subject, session=None, run=None, in_files=None):
     if cfg.proc and 'sss' in cfg.proc and cfg.use_maxwell_filter:

--- a/scripts/preprocessing/_02_frequency_filter.py
+++ b/scripts/preprocessing/_02_frequency_filter.py
@@ -34,7 +34,7 @@ import mne
 from mne_bids import BIDSPath
 
 import config
-from config import (gen_log_kwargs, on_error, failsafe_run,
+from config import (gen_log_kwargs, failsafe_run,
                     import_experimental_data, import_er_data, import_rest_data,
                     _update_for_splits)
 from config import parallel_func
@@ -161,7 +161,7 @@ def resample(
     raw.resample(sfreq, npad='auto')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__,
+@failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_frequency_filter)
 def filter_data(
     *,

--- a/scripts/preprocessing/_03_make_epochs.py
+++ b/scripts/preprocessing/_03_make_epochs.py
@@ -19,13 +19,13 @@ import mne
 from mne_bids import BIDSPath
 
 import config
-from config import make_epochs, gen_log_kwargs, on_error, failsafe_run
+from config import make_epochs, gen_log_kwargs, failsafe_run
 from config import parallel_func, _update_for_splits
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_epochs(*, cfg, subject, session=None):
     """Extract epochs for one subject."""
     bids_path = BIDSPath(subject=subject,

--- a/scripts/preprocessing/_04a_run_ica.py
+++ b/scripts/preprocessing/_04a_run_ica.py
@@ -32,7 +32,7 @@ from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
 from mne_bids import BIDSPath
 
 import config
-from config import (make_epochs, gen_log_kwargs, on_error, failsafe_run,
+from config import (make_epochs, gen_log_kwargs, failsafe_run,
                     annotations_to_events, _update_for_splits)
 from config import parallel_func
 
@@ -232,7 +232,7 @@ def detect_bad_components(
     return inds, scores
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_ica(*, cfg, subject, session=None):
     """Run ICA."""
     bids_basename = BIDSPath(subject=subject,

--- a/scripts/preprocessing/_04b_run_ssp.py
+++ b/scripts/preprocessing/_04b_run_ssp.py
@@ -17,14 +17,14 @@ from mne.preprocessing import compute_proj_ecg, compute_proj_eog
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run
+from config import gen_log_kwargs, failsafe_run
 from config import parallel_func, _update_for_splits
 
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_ssp(*, cfg, subject, session=None):
     # compute SSP on first run of raw
     bids_path = BIDSPath(subject=subject,

--- a/scripts/preprocessing/_05a_apply_ica.py
+++ b/scripts/preprocessing/_05a_apply_ica.py
@@ -27,14 +27,14 @@ from mne.report import Report
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run
+from config import gen_log_kwargs, failsafe_run
 from config import parallel_func
 
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def apply_ica(*, cfg, subject, session):
     bids_basename = BIDSPath(subject=subject,
                              session=session,

--- a/scripts/preprocessing/_05b_apply_ssp.py
+++ b/scripts/preprocessing/_05b_apply_ssp.py
@@ -17,14 +17,14 @@ import mne
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run
+from config import gen_log_kwargs, failsafe_run
 from config import parallel_func
 
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def apply_ssp(*, cfg, subject, session=None):
     # load epochs to reject ICA components
     # compute SSP on first run of raw

--- a/scripts/preprocessing/_06_ptp_reject.py
+++ b/scripts/preprocessing/_06_ptp_reject.py
@@ -20,14 +20,14 @@ import mne
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run
+from config import gen_log_kwargs, failsafe_run
 from config import parallel_func
 
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def drop_ptp(*, cfg, subject, session=None):
     bids_path = BIDSPath(subject=subject,
                          session=session,

--- a/scripts/report/_01_make_reports.py
+++ b/scripts/report/_01_make_reports.py
@@ -266,7 +266,6 @@ def _plot_time_by_time_decoding_scores_gavg(*, cfg, decoding_data):
     """Plot the grand-averaged decoding scores.
     """
     import matplotlib.pyplot as plt  # nested import to help joblib
-    raise RuntimeError
 
     # We squeeze() to make Matplotlib happy.
     times = decoding_data['times'].squeeze()

--- a/scripts/report/_01_make_reports.py
+++ b/scripts/report/_01_make_reports.py
@@ -25,7 +25,7 @@ from mne_bids.stats import count_events
 
 import config
 from config import (
-    gen_log_kwargs, on_error, failsafe_run, parallel_func,
+    gen_log_kwargs, failsafe_run, parallel_func,
     get_noise_cov_bids_path, _update_for_splits,
 )
 
@@ -266,6 +266,7 @@ def _plot_time_by_time_decoding_scores_gavg(*, cfg, decoding_data):
     """Plot the grand-averaged decoding scores.
     """
     import matplotlib.pyplot as plt  # nested import to help joblib
+    raise RuntimeError
 
     # We squeeze() to make Matplotlib happy.
     times = decoding_data['times'].squeeze()
@@ -1113,7 +1114,7 @@ def run_report_source(
     return report
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_report(
     *,
     cfg: SimpleNamespace,
@@ -1208,7 +1209,7 @@ def add_system_info(report: mne.Report):
     report.add_sys_info(title='System information')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_report_average(*, cfg, subject: str, session: str) -> None:
     # Group report
     import matplotlib.pyplot as plt  # nested import to help joblib

--- a/scripts/sensor/_01_make_evoked.py
+++ b/scripts/sensor/_01_make_evoked.py
@@ -15,14 +15,14 @@ import mne
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run
+from config import gen_log_kwargs, failsafe_run
 from config import parallel_func
 
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_evoked(*, cfg, subject, session=None):
     bids_path = BIDSPath(subject=subject,
                          session=session,

--- a/scripts/sensor/_02_decoding_full_epochs.py
+++ b/scripts/sensor/_02_decoding_full_epochs.py
@@ -30,13 +30,13 @@ from mne.decoding import Scaler, Vectorizer
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run, LogReg
+from config import gen_log_kwargs, failsafe_run, LogReg
 
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_epochs_decoding(*, cfg, subject, condition1, condition2, session=None):
     msg = f'Contrasting conditions: {condition1} – {condition2}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,

--- a/scripts/sensor/_03_decoding_time_by_time.py
+++ b/scripts/sensor/_03_decoding_time_by_time.py
@@ -37,7 +37,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import StratifiedKFold
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run
+from config import gen_log_kwargs, failsafe_run
 
 
 logger = logging.getLogger('mne-bids-pipeline')
@@ -52,7 +52,7 @@ class LogReg(LogisticRegression):
             return super().fit(*args, **kwargs)
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_time_decoding(*, cfg, subject, condition1, condition2, session=None):
     msg = f'Contrasting conditions: {condition1} – {condition2}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,

--- a/scripts/sensor/_04_time_frequency.py
+++ b/scripts/sensor/_04_time_frequency.py
@@ -19,14 +19,14 @@ import mne
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run, sanitize_cond_name
+from config import gen_log_kwargs, failsafe_run, sanitize_cond_name
 from config import parallel_func
 
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_time_frequency(*, cfg, subject, session=None):
     bids_path = BIDSPath(subject=subject,
                          session=session,

--- a/scripts/sensor/_99_group_average.py
+++ b/scripts/sensor/_99_group_average.py
@@ -21,7 +21,7 @@ import mne
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run
+from config import gen_log_kwargs, failsafe_run
 
 logger = logging.getLogger('mne-bids-pipeline')
 
@@ -410,7 +410,7 @@ def get_config(
 
 
 # pass 'average' subject for logging
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_group_average_sensor(*, cfg, subject='average'):
     if cfg.task_is_rest:
         msg = '    … skipping: for "rest" task.'

--- a/scripts/source/_01_make_bem_surfaces.py
+++ b/scripts/source/_01_make_bem_surfaces.py
@@ -18,7 +18,7 @@ from types import SimpleNamespace
 import mne
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run
+from config import gen_log_kwargs, failsafe_run
 from config import parallel_func
 
 logger = logging.getLogger('mne-bids-pipeline')
@@ -119,7 +119,7 @@ def get_config(
     return cfg
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def make_bem_and_scalp_surface(*, cfg, subject):
     make_bem(cfg=cfg, subject=subject)
     make_scalp_surface(cfg=cfg, subject=subject)

--- a/scripts/source/_02_make_forward.py
+++ b/scripts/source/_02_make_forward.py
@@ -17,7 +17,7 @@ from mne.coreg import Coregistration
 from mne_bids import BIDSPath, get_head_mri_trans
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run
+from config import gen_log_kwargs, failsafe_run
 from config import parallel_func
 
 logger = logging.getLogger('mne-bids-pipeline')
@@ -137,7 +137,7 @@ def _prepare_forward(cfg, bids_path, fname_trans):
     return src, trans, bem_sol
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_forward(*, cfg, subject, session=None):
     bids_path = BIDSPath(subject=subject,
                          session=session,

--- a/scripts/source/_03_make_cov.py
+++ b/scripts/source/_03_make_cov.py
@@ -16,7 +16,7 @@ from mne_bids import BIDSPath
 
 import config
 from config import (
-    gen_log_kwargs, on_error, failsafe_run, parallel_func,
+    gen_log_kwargs, failsafe_run, parallel_func,
     get_noise_cov_bids_path
 )
 
@@ -143,7 +143,7 @@ def retrieve_custom_cov(
     cov.save(cov_fname, overwrite=True)
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_covariance(*, cfg, subject, session=None, custom_func=None):
     if callable(config.noise_cov):
         retrieve_custom_cov(

--- a/scripts/source/_04_make_inverse.py
+++ b/scripts/source/_04_make_inverse.py
@@ -18,14 +18,14 @@ from mne_bids import BIDSPath
 
 import config
 from config import (
-    gen_log_kwargs, on_error, failsafe_run, sanitize_cond_name, parallel_func,
+    gen_log_kwargs, failsafe_run, sanitize_cond_name, parallel_func,
     get_noise_cov_bids_path
 )
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_inverse(*, cfg, subject, session=None):
     bids_path = BIDSPath(subject=subject,
                          session=session,

--- a/scripts/source/_99_group_average.py
+++ b/scripts/source/_99_group_average.py
@@ -16,7 +16,7 @@ import mne
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, on_error, failsafe_run, sanitize_cond_name
+from config import gen_log_kwargs, failsafe_run, sanitize_cond_name
 from config import parallel_func
 
 logger = logging.getLogger('mne-bids-pipeline')
@@ -119,7 +119,7 @@ def get_config() -> SimpleNamespace:
 
 
 # pass 'average' subject for logging
-@failsafe_run(on_error=on_error, script_path=__file__)
+@failsafe_run(script_path=__file__)
 def run_group_average_source(*, cfg, subject='average'):
     """Run group average in source space"""
 


### PR DESCRIPTION
### Before merging …

- [x] Factor `on_error` out of the decorator
- [x] Check that all command-line arguments are consumed in `run.py` instead of dangerously/silently allowing them (which `fire.Fire` does) by using `**kwargs` and making sure it's empty
- [x] Change default for "download" to be zero/off
- [x] Add support for `--download` to mean "yes download"
- [x] Add support for `--debug` to mean "run in debug mode" (along with `--debug=[0|1]` for consistency)
- [x] Changelog has been updated (`docs/source/changes.md`)

Closes #578
