### PR TITLE
ENH: Add more step caches

### DIFF
--- a/config.py
+++ b/config.py
@@ -1684,7 +1684,7 @@ which is typically the pre-stimulus period.
 
 If ``'emptyroom'``, the noise covariance matrix will be estimated from an
 empty-room MEG recording. The empty-room recording will be automatically
-selected based on recording date and time.
+selected based on recording date and time. This cannot be used with EEG data.
 
 If ``''rest'``, the noise covariance will be estimated from a resting-state
 recording (i.e., a recording with `task-rest` and without a `run` in the

--- a/config.py
+++ b/config.py
@@ -2015,7 +2015,7 @@ def gen_log_kwargs(
     step_name = f'{script_path.parent.name}/{script_path.stem}'
 
     extra = {
-        'step': f'📊 {step_name}'
+        'step': f'⏳️ {step_name}'
     }
     if subject:
         extra['subject'] = subject

--- a/config.py
+++ b/config.py
@@ -2051,10 +2051,7 @@ _epochs_split_size = '2GB'
 if "MNE_BIDS_STUDY_CONFIG" in os.environ:
     cfg_path = pathlib.Path(os.environ['MNE_BIDS_STUDY_CONFIG'])
 
-    if cfg_path.exists():
-        msg = f'Using custom configuration: {cfg_path}'
-        logger.info(**gen_log_kwargs(message=msg))
-    else:
+    if not cfg_path.exists():
         msg = ('The custom configuration file specified in the '
                'MNE_BIDS_STUDY_CONFIG environment variable could not be '
                'found: {cfg_path}'.format(cfg_path=cfg_path))
@@ -2975,17 +2972,11 @@ class StepMemory():
 
             out_files = self.memory.cache(func)(*args, **kwargs)
             # backward compat, but ideally this would eventually just be dict
-            assert isinstance(out_files, (dict, list))
-            if isinstance(out_files, dict):
-                out_files_missing_msg = '\n'.join(
-                    f'- {key}={fname}' for key, fname in out_files.items()
-                    if not pathlib.Path(fname).exists()
-                )
-            else:
-                out_files_missing_msg = '\n'.join(
-                    f'- {fname}' for fname in out_files
-                    if not pathlib.Path(fname).exists()
-                )
+            assert isinstance(out_files, dict), type(out_files)
+            out_files_missing_msg = '\n'.join(
+                f'- {key}={fname}' for key, fname in out_files.items()
+                if not pathlib.Path(fname).exists()
+            )
             if out_files_missing_msg:
                 raise ValueError('Missing at least one output file: \n'
                                  + out_files_missing_msg + '\n' +

--- a/config.py
+++ b/config.py
@@ -1925,7 +1925,10 @@ os.environ['MNE_BIDS_STUDY_SCRIPT_PATH'] = str(__file__)
 logger = logging.getLogger('mne-bids-pipeline')
 
 log_fmt = '[%(asctime)s] %(step)s%(subject)s%(session)s%(run)s%(message)s'
-log_date_fmt = coloredlogs.DEFAULT_DATE_FORMAT = '%H:%M:%S'
+log_date_fmt = '%H:%M:%S'
+# TODO:
+# This does not persist across threads, probably due to relead of coloredlogs?
+# coloredlogs.DEFAULT_DATE_FORMAT = log_date_fmt
 log_level_styles = {
     'warning': {
         'color': 202,

--- a/config.py
+++ b/config.py
@@ -2015,7 +2015,7 @@ def gen_log_kwargs(
     step_name = f'{script_path.parent.name}/{script_path.stem}'
 
     extra = {
-        'step': step_name
+        'step': f'📊 {step_name}'
     }
     if subject:
         extra['subject'] = subject

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -171,17 +171,15 @@ authors:
 - Generalization across time additional decimation can be configured using
   [`decoding_time_generalization_decim`][config.decoding_time_generalization_decim].
   ({{ gh(603) }} by {{ authors.larsoner }})
-- Caching of early pipeline steps (maxwell filtering, frequency filtering)
-  enabled by default using [`memory_location=True'`][config.memory_location]
-  ({{ gh(563) }} by {{ authors.agramfort }} and {{ authors.larsoner }})
+- Caching of pipeline enabled by default using
+  [`memory_location=True'`][config.memory_location]
+  ({{ gh(563) }}, {{ gh (600)  }} by {{ authors.agramfort }} and {{ authors.larsoner }})
 - Basic testing of infant MEG data with movement was added to CI testing
   ({{ gh(582) }} by {{ authors.larsoner }})
 - The `loose` and `depth` configuration parameters were re-enabled
   ({{ gh(592) }}) by {{ authors.larsoner }}
 - Add the example [MIND DATA dataset (ds004107)](https://openneuro.org/datasets/ds004107)
   ({{ gh(600) }}) by {{ authors.larsoner }}
-- Add caching for epoching, SSP, ICA
-  ({{ gh(607) }} by {{ authors.larsoner }})
 
 ### Behavior changes
 

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -180,6 +180,8 @@ authors:
   ({{ gh(592) }}) by {{ authors.larsoner }}
 - Add the example [MIND DATA dataset (ds004107)](https://openneuro.org/datasets/ds004107)
   ({{ gh(600) }}) by {{ authors.larsoner }}
+- Add caching for epoching, SSP, ICA
+  ({{ gh(607) }} by {{ authors.larsoner }})
 
 ### Behavior changes
 
@@ -361,4 +363,6 @@ authors:
   ({{ gh(597) }} by {{ authors.larsoner }})
 - Fix bug where wrong command-line arguments to ``run.py`` were just ignored
   instead of raising an error
-  ({{ gh(605) }}) by {{ authors.larsoner }}
+  ({{ gh(605) }}) by {{ authors.larsoner }})
+- Fix bug where only the first run was used to compute SSP
+  ({{ gh(607) }} by {{ authors.larsoner }})

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -171,8 +171,8 @@ authors:
 - Generalization across time additional decimation can be configured using
   [`decoding_time_generalization_decim`][config.decoding_time_generalization_decim].
   ({{ gh(603) }} by {{ authors.larsoner }})
-- Caching of pipeline enabled by default using
-  [`memory_location=True'`][config.memory_location]
+- Caching of pipeline enabled (up to/including the decoding steps) by default
+  using [`memory_location=True'`][config.memory_location]
   ({{ gh(563) }}, {{ gh (600)  }} by {{ authors.agramfort }} and {{ authors.larsoner }})
 - Basic testing of infant MEG data with movement was added to CI testing
   ({{ gh(582) }} by {{ authors.larsoner }})

--- a/run.py
+++ b/run.py
@@ -50,7 +50,7 @@ def _get_script_modules(
     on_error: Optional[str] = None,
 ) -> Dict[str, Tuple[ModuleType]]:
     env = os.environ
-    env['MNE_BIDS_STUDY_CONFIG'] = str(pathlib.Path(config).expanduser())
+    env['MNE_BIDS_STUDY_CONFIG'] = config
 
     if root_dir:
         env['BIDS_ROOT'] = str(pathlib.Path(root_dir).expanduser())
@@ -210,6 +210,7 @@ def process(
             processing_stages.append(steps_)
             processing_steps.append(None)
 
+    config = str(pathlib.Path(config).expanduser())
     SCRIPT_MODULES = _get_script_modules(
         config=config,
         root_dir=root_dir,
@@ -251,7 +252,10 @@ def process(
         script_modules = [*SCRIPT_MODULES['init'], *script_modules]
 
     logger.info(
-        "👋 Welcome aboard the MNE BIDS Pipeline!\n"
+        "👋 Welcome aboard the MNE BIDS Pipeline!"
+    )
+    logger.info(
+        f"👋 Using configuration: {config}\n"
     )
 
     for script_module in script_modules:

--- a/run.py
+++ b/run.py
@@ -48,6 +48,7 @@ def _get_script_modules(
     interactive: Optional[str] = None,
     n_jobs: Optional[str] = None,
     on_error: Optional[str] = None,
+    cache: Optional[str] = None,
 ) -> Dict[str, Tuple[ModuleType]]:
     env = os.environ
     env['MNE_BIDS_STUDY_CONFIG'] = config
@@ -75,6 +76,9 @@ def _get_script_modules(
 
     if on_error:
         env['MNE_BIDS_STUDY_ON_ERROR'] = on_error
+
+    if cache:
+        env['MNE_BIDS_STUDY_USE_CACHE'] = cache
 
     from scripts import init
     from scripts import preprocessing
@@ -129,6 +133,7 @@ def process(
     interactive: Optional[str] = None,
     n_jobs: Optional[str] = None,
     debug: Optional[str] = None,
+    cache: Optional[str] = None,
     **kwargs: Optional[dict],
 ):
     """Run the BIDS pipeline.
@@ -161,6 +166,8 @@ def process(
         The number of parallel processes to execute.
     debug
         Whether or not to force on_error='debug'.
+    cache
+        Whether or not to use caching.
     **kwargs
         Should not be used. Only used to detect invalid arguments.
     """
@@ -196,6 +203,7 @@ def process(
     if n_jobs is not None:
         n_jobs = str(n_jobs)
     on_error = 'debug' if debug is not None else debug
+    cache = '1' if cache != 0 else '0'
 
     processing_stages = []
     processing_steps = []
@@ -221,6 +229,7 @@ def process(
         interactive=interactive,
         n_jobs=n_jobs,
         on_error=on_error,
+        cache=cache,
     )
 
     script_modules: List[ModuleType] = []
@@ -255,11 +264,11 @@ def process(
         "👋 Welcome aboard the MNE BIDS Pipeline!"
     )
     logger.info(
-        f"👋 Using configuration: {config}\n"
+        f"🧾 Using configuration: {config}"
     )
 
     for script_module in script_modules:
-        logger.info(f'🚀 Now running script: {script_module.__name__} 👇')
+        logger.info(f'🚀 Now running script:  {script_module.__name__} 👇')
         script_module.main()
         logger.info(f'🎉 Done running script: {script_module.__name__} 👆')
 

--- a/run.py
+++ b/run.py
@@ -268,7 +268,7 @@ def process(
     )
 
     for script_module in script_modules:
-        logger.info(f'🚀 Now running script:  {script_module.__name__} 👇')
+        logger.info(f'🚀 Now running script: {script_module.__name__} 👇')
         script_module.main()
         logger.info(f'🎉 Done running script: {script_module.__name__} 👆')
 

--- a/scripts/init/_00_init_derivatives_dir.py
+++ b/scripts/init/_00_init_derivatives_dir.py
@@ -24,6 +24,9 @@ logger = logging.getLogger('mne-bids-pipeline')
 def init_dataset(cfg) -> None:
     """Prepare the pipeline directory in /derivatives.
     """
+    fname_json = cfg.deriv_root / 'dataset_description.json'
+    if fname_json.is_file():
+        return  # already exists
     msg = "Initializing output directories."
     logger.info(**gen_log_kwargs(message=msg))
 
@@ -42,8 +45,7 @@ def init_dataset(cfg) -> None:
         'URL': 'n/a',
     }
 
-    fname = cfg.deriv_root / 'dataset_description.json'
-    _write_json(fname, ds_json, overwrite=True)
+    _write_json(fname_json, ds_json, overwrite=True)
 
 
 def init_subject_dirs(

--- a/scripts/preprocessing/_01_maxfilter.py
+++ b/scripts/preprocessing/_01_maxfilter.py
@@ -37,10 +37,12 @@ logger = logging.getLogger('mne-bids-pipeline')
 
 def get_input_fnames_maxwell_filter(**kwargs):
     """Get paths of files required by maxwell_filter function."""
-    cfg = kwargs['cfg']
-    subject = kwargs['subject']
-    session = kwargs['session']
-    run = kwargs['run']
+    cfg = kwargs.pop('cfg')
+    subject = kwargs.pop('subject')
+    session = kwargs.pop('session')
+    run = kwargs.pop('run')
+    assert len(kwargs) == 0, kwargs.keys()
+    del kwargs
 
     bids_path_in = BIDSPath(subject=subject,
                             session=session,

--- a/scripts/preprocessing/_01_maxfilter.py
+++ b/scripts/preprocessing/_01_maxfilter.py
@@ -79,7 +79,7 @@ def get_input_fnames_maxwell_filter(**kwargs):
 
 @failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_maxwell_filter)
-def run_maxwell_filter(*, cfg, subject, session=None, run=None, in_files=None):
+def run_maxwell_filter(*, cfg, subject, session=None, run=None, in_files):
     if cfg.proc and 'sss' in cfg.proc and cfg.use_maxwell_filter:
         raise ValueError(f'You cannot set use_maxwell_filter to True '
                          f'if data have already processed with Maxwell-filter.'

--- a/scripts/preprocessing/_01_maxfilter.py
+++ b/scripts/preprocessing/_01_maxfilter.py
@@ -79,7 +79,7 @@ def get_input_fnames_maxwell_filter(**kwargs):
 
 @failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_maxwell_filter)
-def run_maxwell_filter(*, cfg, subject, session=None, run=None, in_files):
+def run_maxwell_filter(*, cfg, subject, session, run, in_files):
     if cfg.proc and 'sss' in cfg.proc and cfg.use_maxwell_filter:
         raise ValueError(f'You cannot set use_maxwell_filter to True '
                          f'if data have already processed with Maxwell-filter.'

--- a/scripts/preprocessing/_02_frequency_filter.py
+++ b/scripts/preprocessing/_02_frequency_filter.py
@@ -45,10 +45,12 @@ logger = logging.getLogger('mne-bids-pipeline')
 
 def get_input_fnames_frequency_filter(**kwargs):
     """Get paths of files required by filter_data function."""
-    cfg = kwargs['cfg']
-    subject = kwargs['subject']
-    session = kwargs['session']
-    run = kwargs['run']
+    cfg = kwargs.pop('cfg')
+    subject = kwargs.pop('subject')
+    session = kwargs.pop('session')
+    run = kwargs.pop('run')
+    assert len(kwargs) == 0, kwargs.keys()
+    del kwargs
 
     # Construct the basenames of the files we wish to load, and of the empty-
     # room recording we wish to save.

--- a/scripts/preprocessing/_02_frequency_filter.py
+++ b/scripts/preprocessing/_02_frequency_filter.py
@@ -171,7 +171,7 @@ def filter_data(
     subject: str,
     session: Optional[str] = None,
     run: Optional[str] = None,
-    in_files: Optional[dict] = None
+    in_files: dict,
 ) -> None:
     """Filter data from a single subject."""
 

--- a/scripts/preprocessing/_03_make_epochs.py
+++ b/scripts/preprocessing/_03_make_epochs.py
@@ -69,7 +69,8 @@ def get_input_fnames_epochs(**kwargs):
 def run_epochs(*, cfg, subject, session=None, in_files):
     """Extract epochs for one subject."""
     raw_fnames = [in_files[f'raw_run-{run}'] for run in cfg.runs]
-    bids_path_in = raw_fnames[0].copy().update(processing=None, run=None)
+    bids_path_in = raw_fnames[0].copy().update(
+        processing=None, run=None, split=None)
 
     # Generate a unique event name -> event code mapping that can be used
     # across all runs.

--- a/scripts/preprocessing/_03_make_epochs.py
+++ b/scripts/preprocessing/_03_make_epochs.py
@@ -66,7 +66,7 @@ def get_input_fnames_epochs(**kwargs):
 
 @failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_epochs)
-def run_epochs(*, cfg, subject, session=None, in_files):
+def run_epochs(*, cfg, subject, session, in_files):
     """Extract epochs for one subject."""
     raw_fnames = [in_files[f'raw_run-{run}'] for run in cfg.runs]
     bids_path_in = raw_fnames[0].copy().update(
@@ -198,24 +198,28 @@ def run_epochs(*, cfg, subject, session=None, in_files):
     n_epochs_before_metadata_query = len(epochs.drop_log)
 
     msg = (f'Created {n_epochs_before_metadata_query} epochs with time '
-           f'interval: {epochs.tmin} – {epochs.tmax} sec.\n'
-           f'Selected {len(epochs)} epochs via metadata query: '
-           f'{cfg.epochs_metadata_query}\n'
-           f'Writing {len(epochs)} epochs to disk.')
+           f'interval: {epochs.tmin} – {epochs.tmax} sec.')
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
-    out_fnames = dict()
-    out_fnames['epochs'] = bids_path_in.copy().update(
+    msg = (f'Selected {len(epochs)} epochs via metadata query: '
+           f'{cfg.epochs_metadata_query}')
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = (f'Writing {len(epochs)} epochs to disk.')
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    out_files = dict()
+    out_files['epochs'] = bids_path_in.copy().update(
         suffix='epo', processing=None, check=False)
     epochs.save(
-        out_fnames['epochs'], overwrite=True, split_naming='bids',
+        out_files['epochs'], overwrite=True, split_naming='bids',
         split_size=cfg._epochs_split_size)
-    # _update_for_splits(out_files, 'epochs')
+    _update_for_splits(out_files, 'epochs')
 
     if cfg.interactive:
         epochs.plot()
         epochs.plot_image(combine='gfp', sigma=2., cmap='YlGnBu_r')
-    return out_fnames
+    return out_files
 
 
 def get_config(

--- a/scripts/preprocessing/_03_make_epochs.py
+++ b/scripts/preprocessing/_03_make_epochs.py
@@ -90,8 +90,7 @@ def run_epochs(*, cfg, subject, session, in_files):
     for idx, (run, raw_fname) in enumerate(
         zip(cfg.runs, raw_fnames)
     ):
-        msg = (f'Loading filtered raw data from {raw_fname.basename} '
-               f'and creating epochs')
+        msg = (f'Loading filtered raw data from {raw_fname.basename}')
         logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                      session=session, run=run))
         raw = mne.io.read_raw_fif(raw_fname, preload=True)

--- a/scripts/preprocessing/_04a_run_ica.py
+++ b/scripts/preprocessing/_04a_run_ica.py
@@ -261,7 +261,8 @@ def get_input_fnames_run_ica(**kwargs):
 def run_ica(*, cfg, subject, session, in_files):
     """Run ICA."""
     raw_fnames = [in_files[f'raw_run-{run}'] for run in cfg.runs]
-    bids_basename = raw_fnames[0].copy().update(processing=None, split=None)
+    bids_basename = raw_fnames[0].copy().update(
+        processing=None, split=None, run=None)
     out_files = dict()
     out_files['ica'] = bids_basename.copy().update(
         suffix='ica', extension='.fif')
@@ -285,8 +286,7 @@ def run_ica(*, cfg, subject, session, in_files):
     for idx, (run, raw_fname) in enumerate(
         zip(cfg.runs, raw_fnames)
     ):
-        msg = (f'Loading filtered raw data from {raw_fname.basename} and '
-               f'creating epochs')
+        msg = f'Loading filtered raw data from {raw_fname.basename}'
         logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                      session=session, run=run))
 

--- a/scripts/preprocessing/_04a_run_ica.py
+++ b/scripts/preprocessing/_04a_run_ica.py
@@ -232,9 +232,12 @@ def detect_bad_components(
     return inds, scores
 
 
-@failsafe_run(script_path=__file__)
-def run_ica(*, cfg, subject, session=None):
-    """Run ICA."""
+def get_input_fnames_run_ica(**kwargs):
+    cfg = kwargs.pop('cfg')
+    subject = kwargs.pop('subject')
+    session = kwargs.pop('session')
+    assert len(kwargs) == 0, kwargs.keys()
+    del kwargs
     bids_basename = BIDSPath(subject=subject,
                              session=session,
                              task=cfg.task,
@@ -244,23 +247,32 @@ def run_ica(*, cfg, subject, session=None):
                              datatype=cfg.datatype,
                              root=cfg.deriv_root,
                              check=False)
+    in_files = dict()
+    for run in cfg.runs:
+        key = f'raw_run-{run}'
+        in_files[key] = bids_basename.copy().update(
+            run=run, processing='filt', suffix='raw')
+        _update_for_splits(in_files, key, single=True)
+    return in_files
 
-    raw_fname = bids_basename.copy().update(processing='filt', suffix='raw')
-    ica_fname = bids_basename.copy().update(suffix='ica', extension='.fif')
-    ica_components_fname = bids_basename.copy().update(processing='ica',
-                                                       suffix='components',
-                                                       extension='.tsv')
-    report_fname = bids_basename.copy().update(processing='ica+components',
-                                               suffix='report',
-                                               extension='.html')
+
+@failsafe_run(script_path=__file__,
+              get_input_fnames=get_input_fnames_run_ica)
+def run_ica(*, cfg, subject, session=None, in_files):
+    """Run ICA."""
+    raw_fnames = [in_files[f'raw_run-{run}'] for run in cfg.runs]
+    bids_basename = raw_fnames[0].copy().update(processing=None, split=None)
+    out_files = dict()
+    out_files['ica'] = bids_basename.copy().update(
+        suffix='ica', extension='.fif')
+    out_files['components'] = bids_basename.copy().update(
+        processing='ica', suffix='components', extension='.tsv')
+    out_files['report'] = bids_basename.copy().update(
+        processing='ica+components', suffix='report', extension='.html')
+    del bids_basename
 
     # Generate a list of raw data paths (i.e., paths of individual runs)
     # we want to create epochs from.
-    raw_fnames = []
-    for run in cfg.runs:
-        raw_fname.update(run=run)
-        raw_fname = _update_for_splits(raw_fname, None, single=True)
-        raw_fnames.append(raw_fname.copy())
 
     # Generate a unique event name -> event code mapping that can be used
     # across all runs.
@@ -428,7 +440,7 @@ def run_ica(*, cfg, subject, session=None):
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
     ica.exclude = sorted(set(ecg_ics + eog_ics))
-    ica.save(ica_fname, overwrite=True)
+    ica.save(out_files['ica'], overwrite=True)
 
     # Create TSV.
     tsv_data = pd.DataFrame(
@@ -450,7 +462,7 @@ def run_ica(*, cfg, subject, session=None):
         tsv_data.loc[row_idx,
                      'status_description'] = 'Auto-detected EOG artifact'
 
-    tsv_data.to_csv(ica_components_fname, sep='\t', index=False)
+    tsv_data.to_csv(out_files['components'], sep='\t', index=False)
 
     # Lastly, add info about the epochs used for the ICA fit, and plot all ICs
     # for manual inspection.
@@ -481,12 +493,16 @@ def run_ica(*, cfg, subject, session=None):
     )
 
     msg = (f"ICA completed. Please carefully review the extracted ICs in the "
-           f"report {report_fname.basename}, and mark all components you wish "
-           f"to reject as 'bad' in {ica_components_fname.basename}")
+           f"report {out_files['report'].basename}, and mark all components "
+           f"you wish to reject as 'bad' in "
+           f"{out_files['components'].basename}")
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 
-    report.save(report_fname, overwrite=True, open_browser=cfg.interactive)
+    report.save(
+        out_files['report'], overwrite=True, open_browser=cfg.interactive)
+
+    return out_files
 
 
 def get_config(

--- a/scripts/preprocessing/_04a_run_ica.py
+++ b/scripts/preprocessing/_04a_run_ica.py
@@ -258,7 +258,7 @@ def get_input_fnames_run_ica(**kwargs):
 
 @failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_run_ica)
-def run_ica(*, cfg, subject, session=None, in_files):
+def run_ica(*, cfg, subject, session, in_files):
     """Run ICA."""
     raw_fnames = [in_files[f'raw_run-{run}'] for run in cfg.runs]
     bids_basename = raw_fnames[0].copy().update(processing=None, split=None)
@@ -441,6 +441,7 @@ def run_ica(*, cfg, subject, session=None, in_files):
                                  session=session))
     ica.exclude = sorted(set(ecg_ics + eog_ics))
     ica.save(out_files['ica'], overwrite=True)
+    _update_for_splits(out_files, 'ica')
 
     # Create TSV.
     tsv_data = pd.DataFrame(

--- a/scripts/preprocessing/_04b_run_ssp.py
+++ b/scripts/preprocessing/_04b_run_ssp.py
@@ -62,8 +62,10 @@ def run_ssp(*, cfg, subject, session, in_files):
         run=None, suffix='proj', split=None, processing=None, check=False)
 
     msg = (f'Input{_pl(raw_fnames)} ({len(raw_fnames)}): '
-           f'{raw_fnames[0].basename}{_pl(raw_fnames, pl=" ...")}, '
-           f'Output: {out_files["proj"].basename}')
+           f'{raw_fnames[0].basename}{_pl(raw_fnames, pl=" ...")}, ')
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = (f'Output: {out_files["proj"].basename}')
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 

--- a/scripts/preprocessing/_04b_run_ssp.py
+++ b/scripts/preprocessing/_04b_run_ssp.py
@@ -137,7 +137,7 @@ def run_ssp(*, cfg, subject, session=None, in_files):
                                      session=session))
 
     mne.write_proj(out_files['proj'], eog_projs + ecg_projs, overwrite=True)
-    # TOOD: Write the epochs as well for nice joint plots
+    # TODO: Write the epochs as well for nice joint plots
 
     return out_files
 

--- a/scripts/preprocessing/_04b_run_ssp.py
+++ b/scripts/preprocessing/_04b_run_ssp.py
@@ -15,6 +15,7 @@ import mne
 from mne.preprocessing import create_eog_epochs, create_ecg_epochs
 from mne.preprocessing import compute_proj_ecg, compute_proj_eog
 from mne_bids import BIDSPath
+from mne.utils import _pl
 
 import config
 from config import gen_log_kwargs, failsafe_run
@@ -38,6 +39,7 @@ def get_input_fnames_run_ssp(**kwargs):
                              space=cfg.space,
                              datatype=cfg.datatype,
                              root=cfg.deriv_root,
+                             extension='.fif',
                              check=False)
     in_files = dict()
     for run in cfg.runs:
@@ -50,7 +52,7 @@ def get_input_fnames_run_ssp(**kwargs):
 
 @failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_run_ssp)
-def run_ssp(*, cfg, subject, session=None, in_files):
+def run_ssp(*, cfg, subject, session, in_files):
     # compute SSP on first run of raw
     raw_fnames = [in_files[f'raw_run-{run}'] for run in cfg.runs]
 
@@ -59,7 +61,8 @@ def run_ssp(*, cfg, subject, session=None, in_files):
     out_files['proj'] = raw_fnames[0].copy().update(
         run=None, suffix='proj', split=None, processing=None, check=False)
 
-    msg = (f'Input: {raw_fnames[0].basename}, '
+    msg = (f'Input{_pl(raw_fnames)} ({len(raw_fnames)}): '
+           f'{raw_fnames[0].basename}{_pl(raw_fnames, pl=" ...")}, '
            f'Output: {out_files["proj"].basename}')
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))

--- a/scripts/preprocessing/_05a_apply_ica.py
+++ b/scripts/preprocessing/_05a_apply_ica.py
@@ -27,36 +27,46 @@ from mne.report import Report
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, failsafe_run
+from config import gen_log_kwargs, failsafe_run, _update_for_splits
 from config import parallel_func
 
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(script_path=__file__)
-def apply_ica(*, cfg, subject, session):
+def get_input_fnames_apply_ica(**kwargs):
+    cfg = kwargs.pop('cfg')
+    subject = kwargs.pop('subject')
+    session = kwargs.pop('session')
+    assert len(kwargs) == 0, kwargs.keys()
+    del kwargs
     bids_basename = BIDSPath(subject=subject,
                              session=session,
                              task=cfg.task,
                              acquisition=cfg.acq,
-                             run=None,
                              recording=cfg.rec,
                              space=cfg.space,
                              datatype=cfg.datatype,
                              root=cfg.deriv_root,
                              check=False)
-
-    fname_epo_in = bids_basename.copy().update(suffix='epo', extension='.fif')
-    fname_epo_out = bids_basename.copy().update(
-        processing='ica', suffix='epo', extension='.fif')
-    fname_ica = bids_basename.copy().update(suffix='ica', extension='.fif')
-    fname_ica_components = bids_basename.copy().update(
+    in_files = dict()
+    in_files['ica'] = bids_basename.copy().update(
+        suffix='ica', extension='.fif')
+    in_files['components'] = bids_basename.copy().update(
         processing='ica', suffix='components', extension='.tsv')
+    in_files['epochs'] = bids_basename.copy().update(
+        suffix='epo', extension='.fif')
+    return in_files
 
-    report_fname = (bids_basename.copy()
-                    .update(processing='ica', suffix='report',
-                            extension='.html'))
+
+@failsafe_run(script_path=__file__,
+              get_input_fnames=get_input_fnames_apply_ica)
+def apply_ica(*, cfg, subject, session, in_files):
+    bids_basename = in_files['ica'].copy().update(processing=None)
+    out_files = dict()
+    out_files['epochs'] = in_files['epochs'].copy().update(processing='ica')
+    out_files['report'] = bids_basename.copy().update(
+        processing='ica', suffix='report', extension='.html')
 
     title = f'ICA artifact removal – sub-{subject}'
     if session is not None:
@@ -65,23 +75,24 @@ def apply_ica(*, cfg, subject, session):
         title += f', task-{cfg.task}'
 
     # Load ICA.
-    msg = f'Reading ICA: {fname_ica}'
+    msg = f"Reading ICA: {in_files['ica']}"
     logger.debug(**gen_log_kwargs(message=msg, subject=subject,
                                   session=session))
-    ica = read_ica(fname=fname_ica)
+    ica = read_ica(fname=in_files['ica'])
 
     # Select ICs to remove.
-    tsv_data = pd.read_csv(fname_ica_components, sep='\t')
+    tsv_data = pd.read_csv(in_files['components'], sep='\t')
     ica.exclude = (tsv_data
                    .loc[tsv_data['status'] == 'bad', 'component']
                    .to_list())
 
     # Load epochs to reject ICA components.
-    msg = f'Input: {fname_epo_in.basename}, Output: {fname_epo_out.basename}'
+    msg = (f'Input: {in_files["epochs"].basename}, '
+           f'Output: {out_files["epochs"].basename}')
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 
-    epochs = mne.read_epochs(fname_epo_in, preload=True)
+    epochs = mne.read_epochs(in_files['epochs'], preload=True)
     epochs.drop_bad(cfg.ica_reject)
 
     # Now actually reject the components.
@@ -94,9 +105,9 @@ def apply_ica(*, cfg, subject, session):
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
     epochs_cleaned.save(
-        fname_epo_out, overwrite=True, split_naming='bids',
+        out_files['epochs'], overwrite=True, split_naming='bids',
         split_size=cfg._epochs_split_size)
-    # _update_for_splits(out_files, 'epochs_cleaned')
+    _update_for_splits(out_files, 'epochs')
 
     # Compare ERP/ERF before and after ICA artifact rejection. The evoked
     # response is calculated across ALL epochs, just like ICA was run on
@@ -106,7 +117,8 @@ def apply_ica(*, cfg, subject, session):
     # ICA easier to see. Otherwise, individual channels might just have
     # arbitrary DC shifts, and we wouldn't be able to easily decipher what's
     # going on!
-    report = Report(report_fname, title=title, verbose=False)
+    report = Report(
+        out_files['report'], title=title, verbose=False)
     picks = ica.exclude if ica.exclude else None
     report.add_ica(
         ica=ica,
@@ -114,7 +126,10 @@ def apply_ica(*, cfg, subject, session):
         inst=epochs.copy().apply_baseline(cfg.baseline),
         picks=picks
     )
-    report.save(report_fname, overwrite=True, open_browser=cfg.interactive)
+    report.save(
+        out_files['report'], overwrite=True, open_browser=cfg.interactive)
+
+    return out_files
 
 
 def get_config(

--- a/scripts/preprocessing/_05a_apply_ica.py
+++ b/scripts/preprocessing/_05a_apply_ica.py
@@ -87,8 +87,10 @@ def apply_ica(*, cfg, subject, session, in_files):
                    .to_list())
 
     # Load epochs to reject ICA components.
-    msg = (f'Input: {in_files["epochs"].basename}, '
-           f'Output: {out_files["epochs"].basename}')
+    msg = (f'Input: {in_files["epochs"].basename}')
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = (f'Output: {out_files["epochs"].basename}')
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 

--- a/scripts/preprocessing/_05b_apply_ssp.py
+++ b/scripts/preprocessing/_05b_apply_ssp.py
@@ -38,6 +38,7 @@ def get_input_fnames_apply_ssp(**kwargs):
                              space=cfg.space,
                              datatype=cfg.datatype,
                              root=cfg.deriv_root,
+                             extension='.fif',
                              check=False)
     in_files = dict()
     in_files['epochs'] = bids_basename.copy().update(suffix='epo', check=False)
@@ -47,7 +48,7 @@ def get_input_fnames_apply_ssp(**kwargs):
 
 @failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_apply_ssp)
-def apply_ssp(*, cfg, subject, session=None, in_files):
+def apply_ssp(*, cfg, subject, session, in_files):
     # load epochs to reject ICA components
     # compute SSP on first run of raw
     out_files = dict()

--- a/scripts/preprocessing/_05b_apply_ssp.py
+++ b/scripts/preprocessing/_05b_apply_ssp.py
@@ -17,55 +17,63 @@ import mne
 from mne_bids import BIDSPath
 
 import config
-from config import gen_log_kwargs, failsafe_run
+from config import gen_log_kwargs, failsafe_run, _update_for_splits
 from config import parallel_func
 
 
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(script_path=__file__)
-def apply_ssp(*, cfg, subject, session=None):
+def get_input_fnames_apply_ssp(**kwargs):
+    cfg = kwargs.pop('cfg')
+    subject = kwargs.pop('subject')
+    session = kwargs.pop('session')
+    assert len(kwargs) == 0, kwargs.keys()
+    del kwargs
+    bids_basename = BIDSPath(subject=subject,
+                             session=session,
+                             task=cfg.task,
+                             acquisition=cfg.acq,
+                             recording=cfg.rec,
+                             space=cfg.space,
+                             datatype=cfg.datatype,
+                             root=cfg.deriv_root,
+                             check=False)
+    in_files = dict()
+    in_files['epochs'] = bids_basename.copy().update(suffix='epo', check=False)
+    in_files['proj'] = bids_basename.copy().update(suffix='proj', check=False)
+    return in_files
+
+
+@failsafe_run(script_path=__file__,
+              get_input_fnames=get_input_fnames_apply_ssp)
+def apply_ssp(*, cfg, subject, session=None, in_files):
     # load epochs to reject ICA components
     # compute SSP on first run of raw
+    out_files = dict()
+    out_files['epochs'] = in_files['epochs'].copy().update(
+        processing='ssp', check=False)
+    msg = (f"Input: {in_files['epochs'].basename}, "
+           f"Output: {out_files['epochs'].basename}")
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    epochs = mne.read_epochs(in_files['epochs'], preload=True)
 
-    bids_path = BIDSPath(subject=subject,
-                         session=session,
-                         task=cfg.task,
-                         acquisition=cfg.acq,
-                         run=None,
-                         recording=cfg.rec,
-                         space=cfg.space,
-                         extension='.fif',
-                         datatype=cfg.datatype,
-                         root=cfg.deriv_root)
-
-    fname_in = bids_path.copy().update(suffix='epo', check=False)
-    fname_out = bids_path.copy().update(processing='ssp', suffix='epo',
-                                        check=False)
-
-    epochs = mne.read_epochs(fname_in, preload=True)
-
-    msg = f'Input: {fname_in.basename}, Output: {fname_out.basename}'
+    msg = f'Reading SSP projections from : {in_files["proj"]}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 
-    proj_fname_in = bids_path.copy().update(suffix='proj', check=False)
-
-    msg = f'Reading SSP projections from : {proj_fname_in}'
-    logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                 session=session))
-
-    projs = mne.read_proj(proj_fname_in)
+    projs = mne.read_proj(in_files['proj'])
     epochs_cleaned = epochs.copy().add_proj(projs).apply_proj()
 
     msg = 'Saving epochs with projectors.'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
     epochs_cleaned.save(
-        fname_out, overwrite=True, split_naming='bids',
+        out_files['epochs'], overwrite=True, split_naming='bids',
         split_size=cfg._epochs_split_size)
-    # _update_for_splits(out_files, 'epochs_cleaned')
+    _update_for_splits(out_files, 'epochs')
+    return out_files
 
 
 def get_config(

--- a/scripts/preprocessing/_05b_apply_ssp.py
+++ b/scripts/preprocessing/_05b_apply_ssp.py
@@ -54,8 +54,10 @@ def apply_ssp(*, cfg, subject, session, in_files):
     out_files = dict()
     out_files['epochs'] = in_files['epochs'].copy().update(
         processing='ssp', check=False)
-    msg = (f"Input: {in_files['epochs'].basename}, "
-           f"Output: {out_files['epochs'].basename}")
+    msg = f"Input: {in_files['epochs'].basename}"
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = f"Output: {out_files['epochs'].basename}"
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
     epochs = mne.read_epochs(in_files['epochs'], preload=True)

--- a/scripts/preprocessing/_06_ptp_reject.py
+++ b/scripts/preprocessing/_06_ptp_reject.py
@@ -56,8 +56,10 @@ def get_input_fnames_drop_ptp(**kwargs):
 def drop_ptp(*, cfg, subject, session, in_files):
     out_files = dict()
     out_files['epochs'] = in_files['epochs'].copy().update(processing='clean')
-    msg = (f'Input: {in_files["epochs"].basename}, '
-           f'Output: {out_files["epochs"].basename}')
+    msg = f'Input: {in_files["epochs"].basename}'
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = f'Output: {out_files["epochs"].basename}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 

--- a/scripts/preprocessing/_06_ptp_reject.py
+++ b/scripts/preprocessing/_06_ptp_reject.py
@@ -27,8 +27,12 @@ from config import parallel_func
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(script_path=__file__)
-def drop_ptp(*, cfg, subject, session=None):
+def get_input_fnames_drop_ptp(**kwargs):
+    cfg = kwargs.pop('cfg')
+    subject = kwargs.pop('subject')
+    session = kwargs.pop('session')
+    assert len(kwargs) == 0, kwargs.keys()
+    del kwargs
     bids_path = BIDSPath(subject=subject,
                          session=session,
                          task=cfg.task,
@@ -41,17 +45,24 @@ def drop_ptp(*, cfg, subject, session=None):
                          datatype=cfg.datatype,
                          root=cfg.deriv_root,
                          check=False)
+    in_files = dict()
+    in_files['epochs'] = bids_path.copy().update(
+        processing=cfg.spatial_filter)
+    return in_files
 
-    infile_processing = cfg.spatial_filter
-    fname_in = bids_path.copy().update(processing=infile_processing)
-    fname_out = bids_path.copy().update(processing='clean')
 
-    msg = f'Input: {fname_in.basename}, Output: {fname_out.basename}'
+@failsafe_run(script_path=__file__,
+              get_input_fnames=get_input_fnames_drop_ptp)
+def drop_ptp(*, cfg, subject, session, in_files):
+    out_files = dict()
+    out_files['epochs'] = in_files['epochs'].copy().update(processing='clean')
+    msg = (f'Input: {in_files["epochs"].basename}, '
+           f'Output: {out_files["epochs"].basename}')
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 
     # Get rejection parameters and drop bad epochs
-    epochs = mne.read_epochs(fname_in, preload=True)
+    epochs = mne.read_epochs(in_files['epochs'], preload=True)
     reject = config.get_reject(epochs=epochs)
 
     if cfg.ica_reject is not None:
@@ -90,8 +101,9 @@ def drop_ptp(*, cfg, subject, session=None):
 
     epochs.apply_baseline(cfg.baseline)
     epochs.save(
-        fname_out, overwrite=True, split_naming='bids',
+        out_files['epochs'], overwrite=True, split_naming='bids',
         split_size=cfg._epochs_split_size)
+    return out_files
 
 
 def get_config(

--- a/scripts/sensor/_01_make_evoked.py
+++ b/scripts/sensor/_01_make_evoked.py
@@ -41,7 +41,10 @@ def run_evoked(*, cfg, subject, session=None):
                                        check=False)
     fname_out = bids_path.copy().update(suffix='ave', check=False)
 
-    msg = f'Input: {fname_in.basename}, Output: {fname_out.basename}'
+    msg = f'Input: {fname_in.basename}'
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = f'Output: {fname_out.basename}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 

--- a/scripts/sensor/_01_make_evoked.py
+++ b/scripts/sensor/_01_make_evoked.py
@@ -52,7 +52,7 @@ def get_input_fnames_evoked(**kwargs):
 def run_evoked(*, cfg, subject, session, in_files):
     out_files = dict()
     out_files['evoked'] = in_files['epochs'].copy().update(
-        suffix='ave', check=False)
+        suffix='ave', processing=None, check=False)
 
     msg = f'Input: {in_files["epochs"].basename}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,

--- a/scripts/sensor/_01_make_evoked.py
+++ b/scripts/sensor/_01_make_evoked.py
@@ -22,33 +22,46 @@ from config import parallel_func
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(script_path=__file__)
-def run_evoked(*, cfg, subject, session=None):
-    bids_path = BIDSPath(subject=subject,
-                         session=session,
-                         task=cfg.task,
-                         acquisition=cfg.acq,
-                         run=None,
-                         recording=cfg.rec,
-                         space=cfg.space,
-                         extension='.fif',
-                         datatype=cfg.datatype,
-                         root=cfg.deriv_root)
+def get_input_fnames_evoked(**kwargs):
+    cfg = kwargs.pop('cfg')
+    subject = kwargs.pop('subject')
+    session = kwargs.pop('session')
+    assert len(kwargs) == 0, kwargs.keys()
+    del kwargs
+    fname_epochs = BIDSPath(subject=subject,
+                            session=session,
+                            task=cfg.task,
+                            acquisition=cfg.acq,
+                            run=None,
+                            recording=cfg.rec,
+                            space=cfg.space,
+                            suffix='epo',
+                            extension='.fif',
+                            datatype=cfg.datatype,
+                            root=cfg.deriv_root,
+                            processing='clean',  # always use clean epochs
+                            check=False)
+    in_files = dict(
+        epochs=fname_epochs,
+    )
+    return in_files
 
-    processing = 'clean'  # always use the clean epochs
 
-    fname_in = bids_path.copy().update(processing=processing, suffix='epo',
-                                       check=False)
-    fname_out = bids_path.copy().update(suffix='ave', check=False)
+@failsafe_run(script_path=__file__,
+              get_input_fnames=get_input_fnames_evoked)
+def run_evoked(*, cfg, subject, session, in_files):
+    out_files = dict()
+    out_files['evoked'] = in_files['epochs'].copy().update(
+        suffix='ave', check=False)
 
-    msg = f'Input: {fname_in.basename}'
+    msg = f'Input: {in_files["epochs"].basename}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
-    msg = f'Output: {fname_out.basename}'
+    msg = f'Output: {out_files["evoked"].basename}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 
-    epochs = mne.read_epochs(fname_in, preload=True)
+    epochs = mne.read_epochs(in_files.pop("epochs"), preload=True)
 
     msg = 'Creating evoked data based on experimental conditions …'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
@@ -78,7 +91,7 @@ def run_evoked(*, cfg, subject, session=None):
             all_evoked[contrast["name"]] = evoked_diff
 
     evokeds = list(all_evoked.values())
-    mne.write_evokeds(fname_out, evokeds, overwrite=True)
+    mne.write_evokeds(out_files['evoked'], evokeds, overwrite=True)
 
     if cfg.interactive:
         for evoked in evokeds:
@@ -91,6 +104,8 @@ def run_evoked(*, cfg, subject, session=None):
         # for condition, evoked in zip(config.conditions, evokeds):
         #     evoked.plot_joint(title=condition, ts_args=ts_args,
         #                       topomap_args=topomap_args)
+    assert len(in_files) == 0, in_files.keys()
+    return out_files
 
 
 def get_config(

--- a/scripts/sensor/_02_decoding_full_epochs.py
+++ b/scripts/sensor/_02_decoding_full_epochs.py
@@ -158,6 +158,7 @@ def run_epochs_decoding(*, cfg, subject, condition1, condition2, session,
             out_files[f'tsv_{processing}'], sep='\t', index=False)
     return out_files
 
+
 def get_config(
     subject: Optional[str] = None,
     session: Optional[str] = None

--- a/scripts/sensor/_02_decoding_full_epochs.py
+++ b/scripts/sensor/_02_decoding_full_epochs.py
@@ -36,12 +36,15 @@ from config import gen_log_kwargs, failsafe_run, LogReg
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-@failsafe_run(script_path=__file__)
-def run_epochs_decoding(*, cfg, subject, condition1, condition2, session=None):
-    msg = f'Contrasting conditions: {condition1} – {condition2}'
-    logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                 session=session))
-
+def get_input_fnames_epochs_decoding(**kwargs):
+    cfg = kwargs.pop('cfg')
+    subject = kwargs.pop('subject')
+    session = kwargs.pop('session')
+    # TODO: Somehow remove these?
+    del kwargs['condition1']
+    del kwargs['condition2']
+    assert len(kwargs) == 0, kwargs.keys()
+    del kwargs
     fname_epochs = BIDSPath(subject=subject,
                             session=session,
                             task=cfg.task,
@@ -54,8 +57,22 @@ def run_epochs_decoding(*, cfg, subject, condition1, condition2, session=None):
                             datatype=cfg.datatype,
                             root=cfg.deriv_root,
                             check=False)
+    in_files = dict(
+        epochs=fname_epochs,
+    )
+    return in_files
 
-    epochs = mne.read_epochs(fname_epochs)
+
+@failsafe_run(script_path=__file__,
+              get_input_fnames=get_input_fnames_epochs_decoding)
+def run_epochs_decoding(*, cfg, subject, condition1, condition2, session,
+                        in_files):
+    msg = f'Contrasting conditions: {condition1} – {condition2}'
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    out_files = dict()
+
+    epochs = mne.read_epochs(in_files['epochs'])
     if cfg.analyze_channels:
         # We special-case the average reference here to work around a situation
         # where e.g. `analyze_channels` might contain only a single channel:
@@ -121,13 +138,13 @@ def run_epochs_decoding(*, cfg, subject, condition1, condition2, session=None):
         a_vs_b = f'{cond_names[0]}+{cond_names[1]}'.replace(op.sep, '')
         processing = f'{a_vs_b}+FullEpochs+{cfg.decoding_metric}'
         processing = processing.replace('_', '-').replace('-', '')
+        mat_key = f'mat_{processing}'
+        out_files[mat_key] = in_files['epochs'].copy().update(
+            suffix='decoding', processing=processing, extension='.mat')
+        out_files[f'tsv_{processing}'] = out_files[mat_key].copy().update(
+            extension='.tsv')
+        savemat(out_files[f'mat_{processing}'], {'scores': scores})
 
-        fname_mat = fname_epochs.copy().update(suffix='decoding',
-                                               processing=processing,
-                                               extension='.mat')
-        savemat(fname_mat, {'scores': scores})
-
-        fname_tsv = fname_mat.copy().update(extension='.tsv')
         tabular_data = pd.Series(
             {
                 'cond_1': cond_names[0],
@@ -137,8 +154,9 @@ def run_epochs_decoding(*, cfg, subject, condition1, condition2, session=None):
             }
         )
         tabular_data = pd.DataFrame(tabular_data).T
-        tabular_data.to_csv(fname_tsv, sep='\t', index=False)
-
+        tabular_data.to_csv(
+            out_files[f'tsv_{processing}'], sep='\t', index=False)
+    return out_files
 
 def get_config(
     subject: Optional[str] = None,

--- a/scripts/source/_03_make_cov.py
+++ b/scripts/source/_03_make_cov.py
@@ -49,9 +49,13 @@ def compute_cov_from_epochs(cfg, subject, session, tmin, tmax):
         session=session
     )
 
-    msg = (f"Computing regularized covariance based on epochs' baseline "
-           f"periods. Input: {epo_fname.basename}, "
-           f"Output: {cov_fname.basename}")
+    msg = "Computing regularized covariance based on epochs' baseline periods."
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = f"Input: {epo_fname.basename}"
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = f"Output: {cov_fname.basename}"
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 
@@ -93,9 +97,13 @@ def compute_cov_from_raw(cfg, subject, session):
         session=session
     )
 
-    msg = (f'Computing regularized covariance based on {data_type} recording. '
-           f'Input: {bids_path_raw_noise.basename}, '
-           f'Output: {cov_fname.basename}')
+    msg = f'Computing regularized covariance based on {data_type} recording.'
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = f'Input: {bids_path_raw_noise.basename}'
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = f'Output: {cov_fname.basename}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 
@@ -133,8 +141,11 @@ def retrieve_custom_cov(
         session=session
     )
 
-    msg = (f'Retrieving noise covariance matrix from custom user-supplied '
-           f'function, Output: {cov_fname.basename}')
+    msg = ('Retrieving noise covariance matrix from custom user-supplied '
+           'function')
+    logger.info(**gen_log_kwargs(message=msg, subject=subject,
+                                 session=session))
+    msg = 'Output: {cov_fname.basename}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -123,7 +123,7 @@ TEST_SUITE: Dict[str, TestOptionsT] = {
 }
 
 
-def run_tests(test_suite, *, download, debug):
+def run_tests(test_suite, *, download, debug, cache):
     """Run a suite of tests.
 
     Parameters
@@ -136,6 +136,8 @@ def run_tests(test_suite, *, download, debug):
         Whether to (re-)download the test dataset.
     debug : bool
         If True, force debug mode.
+    cache : bool
+        If True (default), use cache. If False, recompute everything.
 
     Notes
     -----
@@ -196,6 +198,7 @@ def run_tests(test_suite, *, download, debug):
             f'--task={task}' if task else '',
             f'--n_jobs={n_jobs}' if n_jobs else '',
             '--debug=1' if debug else '',
+            '--cache=0' if not cache else '',
             f'--interactive=0'
         ]
         # Eliminate "empty" items
@@ -218,6 +221,8 @@ if __name__ == '__main__':
                         nargs='?')
     parser.add_argument('--debug', '-d', choices=['0', '1'], default='0',
                         nargs='?', help='Run in debug mode')
+    parser.add_argument('--no-cache', dest='cache', action='store_false',
+                        help='Do not use cache')
 
     args = parser.parse_args()
     dataset = args.dataset
@@ -229,6 +234,7 @@ if __name__ == '__main__':
     if debug is None:  # --debug
         debug = '1'
     debug = bool(int(debug))
+    cache = args.cache
     # Triage the dataset and raise informative error if it does not exist
     if dataset == 'ALL':
         test_suite = TEST_SUITE
@@ -253,4 +259,4 @@ if __name__ == '__main__':
         extra += ' in debug mode'
     print(f'Running the following tests{extra}: {", ".join(test_suite.keys())}')
 
-    run_tests(test_suite, download=download, debug=debug)
+    run_tests(test_suite, download=download, debug=debug, cache=cache)


### PR DESCRIPTION
### Cleanups

- [x] Clean up startup logging
- [x] Fix bug where only the first run was used for SSP
- [x] Fix bug where `memory_location=None` was not working properly (by always using `ConditionalStepMemory`)
- [x] Add `--no-cache` to `run_tests.py` allow running without any cache
- [x] Unify log formatting (use coloredlogs default, probably good enough)

### Caching implemented

- [x] Epochs
- [x] Run ICA
- [x] Run SSP
- [x] Apply SSP
- [x] Apply ICA
- [x] PTP reject
- [x] Make evoked
- [x] Decoding full epochs
- [x] Decoding time_by_time
- [x] Changelog has been updated (`docs/source/changes.md`)

### Next follow-up PR (not here):

- Add `.pop` to read steps and `assert len(in_files) == 0` at the end of each step (as in the `make_evoked` step)
- Time frequency
- Report (maybe?)
-  Add re-run test checks on CircleCI... somehow?
