### PR TITLE
ENH: Cache coreg, bem, cov

### DIFF
--- a/config.py
+++ b/config.py
@@ -2007,6 +2007,7 @@ def gen_log_kwargs(
     session: Optional[Union[str, int]] = None,
     run: Optional[Union[str, int]] = None,
     emoji: str = '⏳️',
+    script_path: Optional[PathLike] = None,
 ) -> LogKwargsT:
     if subject is not None:
         subject = f' sub-{subject}'
@@ -2960,6 +2961,7 @@ class ConditionalStepMemory():
         self.force_run = force_run
 
     def cache(self, func):
+
         def wrapper(*args, **kwargs):
             in_files = out_files = None
             if self.get_output_fnames is not None:

--- a/config.py
+++ b/config.py
@@ -1537,9 +1537,10 @@ already. ``True`` forces their recreation, overwriting existing BEM surfaces.
 
 recreate_scalp_surface: bool = False
 """
-Whether to re-create the high-resolution scalp surface used for visualization
-of the coregistration in the report. If ``False``, the scalp surface is only
-created if it does not exist already. If ``True``, forces a re-computation.
+Whether to re-create the scalp surfaces used for visualization of the
+coregistration in the report and the lower-density coregistration surfaces.
+If ``False``, the scalp surface is only created if it does not exist already.
+If ``True``, forces a re-computation.
 """
 
 freesurfer_verbose: bool = False
@@ -2847,9 +2848,15 @@ def get_decoding_contrasts() -> Iterable[Tuple[str, str]]:
 def failsafe_run(
     script_path: PathLike,
     get_input_fnames: Optional[Callable] = None,
+    get_output_fnames: Optional[Callable] = None,
+    force_run: bool = False,
 ):
     on_error = get_on_error()
-    memory = ConditionalStepMemory(get_input_fnames=get_input_fnames)
+    memory = ConditionalStepMemory(
+        get_input_fnames=get_input_fnames,
+        get_output_fnames=get_output_fnames,
+        force_run=force_run,
+    )
 
     def failsafe_run_decorator(func):
         @functools.wraps(func)  # Preserve "identity" of original function
@@ -2935,7 +2942,8 @@ def hash_file_path(path):
 
 
 class ConditionalStepMemory():
-    def __init__(self, get_input_fnames=None):
+    def __init__(self, get_input_fnames=None, get_output_fnames=None,
+                 force_run=False):
         if memory_location is True:
             use_location = get_deriv_root() / 'joblib'
         elif not memory_location:
@@ -2948,10 +2956,14 @@ class ConditionalStepMemory():
         else:
             self.memory = None
         self.get_input_fnames = get_input_fnames
+        self.get_output_fnames = get_output_fnames
+        self.force_run = force_run
 
     def cache(self, func):
         def wrapper(*args, **kwargs):
-            in_files = None
+            in_files = out_files = None
+            if self.get_output_fnames is not None:
+                out_files = self.get_output_fnames(**kwargs)
             if self.get_input_fnames is not None:
                 in_files = kwargs['in_files'] = self.get_input_fnames(**kwargs)
             if self.memory is None:
@@ -2963,9 +2975,8 @@ class ConditionalStepMemory():
 
             # Deal with cases (e.g., custom cov) where input files are unknown
             unknown_inputs = in_files.pop('__unknown_inputs__', False)
-
-            # Deal with cases (e.g., BEM) where a user can force recreation
-            force_run = in_files.pop('__force_run__', False)
+            # If this is ever true, we'll need to improve the logic below
+            assert not (unknown_inputs and self.force_run)
 
             hashes = []
             for k, v in in_files.items():
@@ -2990,27 +3001,46 @@ class ConditionalStepMemory():
             # call (https://github.com/joblib/joblib/issues/1342), but our hash
             # should be plenty fast so let's not bother for now.
             memorized_func = self.memory.cache(func)
+            msg = emoji = None
+            short_circuit = False
+            subject = kwargs.get('subject', None)
+            session = kwargs.get('session', None)
+            run = kwargs.get('run', None)
             if memorized_func.check_call_in_cache(*args, **kwargs):
-                subject = kwargs.get('subject', None)
-                session = kwargs.get('session', None)
-                run = kwargs.get('run', None)
                 if unknown_inputs:
                     msg = ('Computation forced because input files cannot '
                            f'be determined ({unknown_inputs}) …')
                     emoji = '🤷'
-                elif force_run:
+                elif self.force_run:
                     msg = 'Computation forced despite existing cached result …'
                     emoji = '🔂'
                 else:
                     msg = 'Computation unnecessary (cached) …'
                     emoji = 'cache'
+            # When out_files is not None, we should check if the output files
+            # exist and stop if they do (e.g., in bem surface or coreg surface
+            # creation)
+            elif out_files is not None:
+                have_all = all(path.exists() for path in out_files.values())
+                if not have_all:
+                    msg = 'Output files missing, will recompute …'
+                    emoji = '🧩'
+                elif self.force_run:
+                    msg = 'Computation forced despite existing output files …'
+                    emoji = '🔂'
+                else:
+                    msg = 'Computation unnecessary (output files exist) …'
+                    emoji = '🔍'
+                    short_circuit = True
+            if msg is not None:
                 logger.info(**gen_log_kwargs(
                     message=msg, subject=subject, session=session, run=run,
                     emoji=emoji))
-            else:
-                force_run = False  # wasn't actually forced
+            if short_circuit:
+                return
+
             # https://joblib.readthedocs.io/en/latest/memory.html#joblib.memory.MemorizedFunc.call  # noqa: E501
-            if force_run or unknown_inputs:
+            if self.force_run or unknown_inputs:
                 out_files, _ = memorized_func.call(*args, **kwargs)
             else:
                 out_files = memorized_func(*args, **kwargs)

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -171,9 +171,9 @@ authors:
 - Generalization across time additional decimation can be configured using
   [`decoding_time_generalization_decim`][config.decoding_time_generalization_decim].
   ({{ gh(603) }} by {{ authors.larsoner }})
-- Caching of pipeline enabled (up to/including decoding and time-frequency)
+- Caching of pipeline enabled for many pipeline steps
   by default using [`memory_location=True'`][config.memory_location]
-  ({{ gh(563) }}, {{ gh (600)  }}, and {{ gh(608) }}
+  ({{ gh(563) }}, {{ gh (600) }}, {{ gh(608) }}, {{ gh(615) }}
   by {{ authors.agramfort }} and {{ authors.larsoner }})
 - Basic testing of infant MEG data with movement was added to CI testing
   ({{ gh(582) }} by {{ authors.larsoner }})

--- a/run.py
+++ b/run.py
@@ -24,14 +24,46 @@ logger = logging.getLogger(__name__)
 log_level_styles = {
     'info': {
         'bright': True,
-        'bold': True
+        'bold': True,
     }
 }
-log_fmt = '[%(asctime)s] %(message)s'
+log_field_styles = {
+    'asctime': {
+        'color': 'green'
+    },
+    'step': {
+        'color': 'cyan',
+        'bold': True,
+        'bright': True,
+    },
+    'msg': {
+        'color': 'cyan',
+        'bold': True,
+        'bright': True,
+    }
+}
+log_fmt = '[%(asctime)s] %(step)s%(message)s'
+
+
+class LogFilter(logging.Filter):
+    def filter(self, record):
+        if not hasattr(record, 'step'):
+            record.step = ''
+        if not hasattr(record, 'subject'):
+            record.subject = ''
+        if not hasattr(record, 'session'):
+            record.session = ''
+        if not hasattr(record, 'run'):
+            record.run = ''
+
+        return True
+
+
+logger.addFilter(LogFilter())
+
 coloredlogs.install(
-    fmt=log_fmt,
-    level_styles=log_level_styles,
-    logger=logger
+    fmt=log_fmt, level='info', logger=logger,
+    level_styles=log_level_styles, field_styles=log_field_styles,
 )
 
 PathLike = Union[str, pathlib.Path]
@@ -268,9 +300,11 @@ def process(
     )
 
     for script_module in script_modules:
-        logger.info(f'🚀 Now running script: {script_module.__name__} 👇')
+        this_name = script_module.__name__.split('.', maxsplit=1)[-1]
+        this_name = this_name.replace('.', '/')
+        logger.info('Now running  👇', extra=dict(step=f'🚀 {this_name} '))
         script_module.main()
-        logger.info(f'🎉 Done running script: {script_module.__name__} 👆')
+        logger.info('Done running 👆', extra=dict(step=f'🎉 {this_name} '))
 
 
 if __name__ == '__main__':

--- a/scripts/freesurfer/_02_coreg_surfaces.py
+++ b/scripts/freesurfer/_02_coreg_surfaces.py
@@ -8,7 +8,8 @@ from types import SimpleNamespace
 import mne.bem
 
 import config
-from config import parallel_func, failsafe_run, _get_scalp_in_files
+from config import (parallel_func, failsafe_run, _get_scalp_in_files,
+                    gen_log_kwargs)
 
 PathLike = Union[str, Path]
 logger = logging.getLogger('mne-bids-pipeline')
@@ -44,11 +45,8 @@ def make_coreg_surfaces(
     in_files: dict,
 ) -> dict:
     """Create head surfaces for use with MNE-Python coregistration tools."""
-    subject_str = f'sub-{subject}' if subject != 'fsaverage' else 'fsaverage'
-    logger.info(
-        f'Creating scalp surfaces for coregistration, '
-        f'subject: {subject_str} (FreeSurfer subject: {cfg.fs_subject})'
-    )
+    msg = 'Creating scalp surfaces for coregistration'
+    logger.info(**gen_log_kwargs(message=msg, subject=subject))
     in_files.pop('t1' if 't1' in in_files else 'seghead')
     mne.bem.make_scalp_surfaces(
         subject=cfg.fs_subject,

--- a/scripts/source/_01_make_bem_surfaces.py
+++ b/scripts/source/_01_make_bem_surfaces.py
@@ -10,6 +10,7 @@ This script will also create a high-resolution surface of the scalp, which can
 be used for visualization of the sensor alignment (coregistration).
 """
 
+import glob
 import logging
 from pathlib import Path
 from typing import Optional
@@ -24,35 +25,42 @@ from config import parallel_func
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-def make_bem(*, cfg, subject):
-    fs_subject = cfg.fs_subject
-    mri_dir = Path(cfg.fs_subjects_dir) / fs_subject / 'mri'
-    bem_dir = Path(cfg.fs_subjects_dir) / fs_subject / 'bem'
-    watershed_bem_dir = bem_dir / 'watershed'
-    flash_bem_dir = bem_dir / 'flash'
+def _get_bem_params(cfg):
+    mri_dir = Path(cfg.fs_subjects_dir) / cfg.fs_subject / 'mri'
     flash_dir = mri_dir / 'flash' / 'parameter_maps'
-    show = True if cfg.interactive else False
-
     if cfg.bem_mri_images == 'FLASH' and not flash_dir.exists():
         raise RuntimeError('Cannot locate FLASH MRI images.')
-    elif cfg.bem_mri_images == 'FLASH':
+    if cfg.bem_mri_images == 'FLASH':
         mri_images = 'FLASH'
     elif cfg.bem_mri_images == 'auto' and flash_dir.exists():
         mri_images = 'FLASH'
     else:
         mri_images = 'T1'
+    return mri_images, mri_dir, flash_dir
 
-    if ((mri_images == 'FLASH' and flash_bem_dir.exists()) or
-            (mri_images == 'T1' and watershed_bem_dir.exists())):
-        msg = 'Found existing BEM surfaces. '
-        if cfg.recreate_bem:
-            msg += 'Overwriting as requested in configuration.'
-            logger.info(**gen_log_kwargs(message=msg, subject=subject))
-        else:
-            msg = 'Skipping surface extraction as requested in configuration.'
-            logger.info(**gen_log_kwargs(message=msg, subject=subject))
-            return
 
+def get_input_fnames_make_bem(**kwargs):
+    cfg = kwargs.pop('cfg')
+    kwargs.pop('subject')
+    assert len(kwargs) == 0, kwargs.keys()
+    in_files = dict()
+    mri_images, mri_dir, flash_dir = _get_bem_params(cfg)
+    in_files['t1'] = mri_dir / 'T1.mgz'
+    if mri_images == 'FLASH':
+        flash_fnames = sorted(glob.glob(str(flash_dir / "mef*_*.mgz")))
+        # We could check for existence here, but make_flash_bem does it later
+        for fname in flash_fnames:
+            in_files[fname.stem] = fname
+    if cfg.recreate_bem:
+        in_files['__force_run__'] = True
+    return in_files
+
+
+@failsafe_run(script_path=__file__,
+              get_input_fnames=get_input_fnames_make_bem)
+def make_bem(*, cfg, subject, in_files):
+    mri_images, _, _ = _get_bem_params(cfg)
+    in_files.clear()  # assume we use everything we add
     if mri_images == 'FLASH':
         msg = 'Creating BEM surfaces from FLASH MRI images'
         bem_func = mne.bem.make_flash_bem
@@ -60,47 +68,21 @@ def make_bem(*, cfg, subject):
         msg = ('Creating BEM surfaces from T1-weighted MRI images using '
                'watershed algorithm')
         bem_func = mne.bem.make_watershed_bem
-
+    out_files = dict()
+    bem_dir = Path(cfg.fs_subjects_dir) / cfg.fs_subject / 'bem'
+    for surf in ('inner_skull', 'outer_skull', 'outer_skin'):
+        out_files[surf] = bem_dir / f'{surf}.surf'
     logger.info(**gen_log_kwargs(message=msg, subject=subject))
+    show = True if cfg.interactive else False
     bem_func(
-        subject=fs_subject,
+        subject=cfg.fs_subject,
         subjects_dir=cfg.fs_subjects_dir,
         copy=True,
         overwrite=True,
         show=show,
         verbose=cfg.freesurfer_verbose
     )
-
-
-def make_scalp_surface(*, cfg, subject):
-    fs_subject = cfg.fs_subject
-    bem_dir = Path(cfg.fs_subjects_dir) / fs_subject / 'bem'
-
-    regenerate_surface = cfg.recreate_scalp_surface
-
-    # Even if the user didn't ask for re-creation of the surface, we check if
-    # the required file exist; if it doesn't, we create it
-    surface_fname = bem_dir / f'sub-{subject}-head-dense.fif'
-    if not regenerate_surface and not surface_fname.exists():
-        regenerate_surface = True
-
-    if not regenerate_surface:
-        # Seems everything is in place, so we can safely skip surface creation
-        msg = 'Not generating high-resolution scalp surface.'
-        logger.info(**gen_log_kwargs(message=msg, subject=subject))
-        return
-
-    msg = 'Generating high-resolution scalp surface for coregistration.'
-    logger.info(**gen_log_kwargs(message=msg, subject=subject))
-
-    mne.bem.make_scalp_surfaces(
-        subject=fs_subject,
-        subjects_dir=cfg.fs_subjects_dir,
-        no_decimate=True,
-        force=True,
-        overwrite=True,
-        verbose=cfg.freesurfer_verbose
-    )
+    return out_files
 
 
 def get_config(
@@ -119,12 +101,6 @@ def get_config(
     return cfg
 
 
-@failsafe_run(script_path=__file__)
-def make_bem_and_scalp_surface(*, cfg, subject):
-    make_bem(cfg=cfg, subject=subject)
-    make_scalp_surface(cfg=cfg, subject=subject)
-
-
 def main():
     """Run BEM surface extraction."""
     if not config.run_source_estimation:
@@ -138,7 +114,7 @@ def main():
         return
 
     with config.get_parallel_backend():
-        parallel, run_func = parallel_func(make_bem_and_scalp_surface)
+        parallel, run_func = parallel_func(make_bem)
         logs = parallel(
             run_func(cfg=get_config(subject=subject), subject=subject)
             for subject in config.get_subjects()

--- a/scripts/source/_01_make_bem_surfaces.py
+++ b/scripts/source/_01_make_bem_surfaces.py
@@ -103,6 +103,7 @@ def get_config(
 
 def main():
     """Run BEM surface extraction."""
+    return
     if not config.run_source_estimation:
         msg = 'Skipping, run_source_estimation is set to False …'
         logger.info(**gen_log_kwargs(message=msg, emoji='skip'))

--- a/scripts/source/_01_make_bem_surfaces.py
+++ b/scripts/source/_01_make_bem_surfaces.py
@@ -103,7 +103,6 @@ def get_config(
 
 def main():
     """Run BEM surface extraction."""
-    return
     if not config.run_source_estimation:
         msg = 'Skipping, run_source_estimation is set to False …'
         logger.info(**gen_log_kwargs(message=msg, emoji='skip'))

--- a/scripts/source/_02_make_forward.py
+++ b/scripts/source/_02_make_forward.py
@@ -199,7 +199,6 @@ def get_config(
 
 def main():
     """Run forward."""
-    return
     if not config.run_source_estimation:
         msg = 'Skipping, run_source_estimation is set to False …'
         logger.info(**gen_log_kwargs(message=msg, emoji='skip'))

--- a/scripts/source/_02_make_forward.py
+++ b/scripts/source/_02_make_forward.py
@@ -199,6 +199,7 @@ def get_config(
 
 def main():
     """Run forward."""
+    return
     if not config.run_source_estimation:
         msg = 'Skipping, run_source_estimation is set to False …'
         logger.info(**gen_log_kwargs(message=msg, emoji='skip'))

--- a/scripts/source/_03_make_cov.py
+++ b/scripts/source/_03_make_cov.py
@@ -164,8 +164,9 @@ def retrieve_custom_cov(
 def _get_cov_type(cfg):
     if cfg.noise_cov == 'custom':
         return 'custom'
-    elif (cfg.noise_cov == 'rest' or (cfg.noise_cov == 'emptyroom' and
-                                      'eeg' not in cfg.ch_types)):
+    elif cfg.noise_cov == 'rest':
+        return 'raw'
+    elif cfg.noise_cov == 'emptyroom' and 'eeg' not in cfg.ch_types:
         return 'raw'
     else:
         return 'epochs'

--- a/scripts/source/_03_make_cov.py
+++ b/scripts/source/_03_make_cov.py
@@ -76,7 +76,6 @@ def get_input_fnames_cov(**kwargs):
                                 root=cfg.deriv_root,
                                 check=False)
         in_files['epochs'] = fname_epochs
-    assert len(in_files) == 1, in_files
     return in_files
 
 

--- a/scripts/source/_03_make_cov.py
+++ b/scripts/source/_03_make_cov.py
@@ -23,31 +23,67 @@ from config import (
 logger = logging.getLogger('mne-bids-pipeline')
 
 
-def compute_cov_from_epochs(cfg, subject, session, tmin, tmax):
-    bids_path = BIDSPath(subject=subject,
-                         session=session,
-                         task=cfg.task,
-                         acquisition=cfg.acq,
-                         run=None,
-                         processing=cfg.proc,
-                         recording=cfg.rec,
-                         space=cfg.space,
-                         extension='.fif',
-                         datatype=cfg.datatype,
-                         root=cfg.deriv_root,
-                         check=False)
+def get_input_fnames_cov(**kwargs):
+    cfg = kwargs.pop('cfg')
+    subject = kwargs.pop('subject')
+    session = kwargs.pop('session')
+    assert len(kwargs) == 0, kwargs.keys()
+    del kwargs
+    # short circuit to say: always re-run
+    cov_type = _get_cov_type(cfg)
+    in_files = dict()
+    if cov_type == 'custom':
+        in_files['__unknown_inputs__'] = True
+        return in_files
+    if cov_type == 'raw':
+        bids_path_raw_noise = BIDSPath(
+            subject=subject,
+            session=session,
+            task=cfg.task,
+            acquisition=cfg.acq,
+            run=None,
+            recording=cfg.rec,
+            space=cfg.space,
+            processing='filt',
+            suffix='raw',
+            extension='.fif',
+            datatype=cfg.datatype,
+            root=cfg.deriv_root,
+            check=False
+        )
+        data_type = ('resting-state' if cfg.noise_cov == 'rest' else
+                     'empty-room')
+        if data_type == 'resting-state':
+            bids_path_raw_noise.task = 'rest'
+        else:
+            bids_path_raw_noise.task = 'noise'
+        in_files['raw'] = bids_path_raw_noise
+    else:
+        assert cov_type == 'epochs', cov_type
+        processing = None
+        if cfg.spatial_filter is not None:
+            processing = 'clean'
+        fname_epochs = BIDSPath(subject=subject,
+                                session=session,
+                                task=cfg.task,
+                                acquisition=cfg.acq,
+                                run=None,
+                                recording=cfg.rec,
+                                space=cfg.space,
+                                extension='.fif',
+                                suffix='epo',
+                                processing=processing,
+                                datatype=cfg.datatype,
+                                root=cfg.deriv_root,
+                                check=False)
+        in_files['epochs'] = fname_epochs
+    return in_files
 
-    processing = None
-    if cfg.spatial_filter is not None:
-        processing = 'clean'
 
-    epo_fname = bids_path.copy().update(processing=processing, suffix='epo')
-    cov_fname = get_noise_cov_bids_path(
-        noise_cov=config.noise_cov,
-        cfg=cfg,
-        subject=subject,
-        session=session
-    )
+def compute_cov_from_epochs(cfg, tmin, tmax, in_files, out_files):
+    epo_fname = in_files.pop('epochs')
+    subject = epo_fname.subject
+    session = epo_fname.session
 
     msg = "Computing regularized covariance based on epochs' baseline periods."
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
@@ -55,70 +91,48 @@ def compute_cov_from_epochs(cfg, subject, session, tmin, tmax):
     msg = f"Input: {epo_fname.basename}"
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
-    msg = f"Output: {cov_fname.basename}"
+    msg = f"Output: {out_files['cov'].basename}"
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 
-    epochs = mne.read_epochs(epo_fname, preload=True)
+    epochs = mne.read_epochs(in_files.pop('epochs'), preload=True)
     cov = mne.compute_covariance(epochs, tmin=tmin, tmax=tmax, method='shrunk',
                                  rank='info')
-    cov.save(cov_fname, overwrite=True)
+    cov.save(out_files['cov'], overwrite=True)
 
 
-def compute_cov_from_raw(cfg, subject, session):
-    bids_path_raw_noise = BIDSPath(
-        subject=subject,
-        session=session,
-        task=cfg.task,
-        acquisition=cfg.acq,
-        run=None,
-        recording=cfg.rec,
-        space=cfg.space,
-        processing='filt',
-        suffix='raw',
-        extension='.fif',
-        datatype=cfg.datatype,
-        root=cfg.deriv_root,
-        check=False
-    )
-
-    data_type = ('resting-state' if config.noise_cov == 'rest' else
-                 'empty-room')
-
-    if data_type == 'resting-state':
-        bids_path_raw_noise.task = 'rest'
-    else:
-        bids_path_raw_noise.task = 'noise'
-
-    cov_fname = get_noise_cov_bids_path(
-        noise_cov=config.noise_cov,
-        cfg=cfg,
-        subject=subject,
-        session=session
-    )
-
+def compute_cov_from_raw(*, cfg, subject, session, in_files, out_files):
+    fname_raw = in_files.pop('raw')
+    data_type = 'resting-state' if fname_raw.task == 'rest' else 'empty-room'
     msg = f'Computing regularized covariance based on {data_type} recording.'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
-    msg = f'Input: {bids_path_raw_noise.basename}'
+    msg = f'Input:  {fname_raw.basename}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
-    msg = f'Output: {cov_fname.basename}'
+    msg = f'Output: {out_files["cov"].basename}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 
-    raw_noise = mne.io.read_raw_fif(bids_path_raw_noise, preload=True)
+    raw_noise = mne.io.read_raw_fif(fname_raw, preload=True)
     cov = mne.compute_raw_covariance(raw_noise, method='shrunk', rank='info')
-    cov.save(cov_fname, overwrite=True)
+    cov.save(out_files['cov'], overwrite=True)
 
 
 def retrieve_custom_cov(
     cfg: SimpleNamespace,
     subject: str,
-    session: str
+    session: str,
+    in_files: None,
+    out_files: dict,
 ):
+    # This should be the only place we use config.noise_cov (rather than cfg.*
+    # entries)
+    assert cfg.noise_cov == 'custom'
     assert callable(config.noise_cov)
+    assert in_files is None  # signals that this cannot be cached...
 
+    # ... so we construct the input file we need here
     evoked_bids_path = BIDSPath(
         subject=subject,
         session=session,
@@ -134,12 +148,6 @@ def retrieve_custom_cov(
         root=cfg.deriv_root,
         check=False
     )
-    cov_fname = get_noise_cov_bids_path(
-        noise_cov=config.noise_cov,
-        cfg=cfg,
-        subject=subject,
-        session=session
-    )
 
     msg = ('Retrieving noise covariance matrix from custom user-supplied '
            'function')
@@ -151,30 +159,50 @@ def retrieve_custom_cov(
 
     cov = config.noise_cov(evoked_bids_path)
     assert isinstance(cov, mne.Covariance)
-    cov.save(cov_fname, overwrite=True)
+    cov.save(out_files['cov'], overwrite=True)
 
 
-@failsafe_run(script_path=__file__)
-def run_covariance(*, cfg, subject, session=None, custom_func=None):
-    if callable(config.noise_cov):
-        retrieve_custom_cov(
-            cfg=cfg, subject=subject, session=session
-        )
+def _get_cov_type(cfg):
+    if cfg.noise_cov == 'custom':
+        return 'custom'
     elif (
-        (config.noise_cov == 'emptyroom' and 'eeg' not in cfg.ch_types) or
-        config.noise_cov == 'rest'
+        (cfg.noise_cov == 'emptyroom' and 'eeg' not in cfg.ch_types) or
+         cfg.noise_cov == 'rest'
     ):
-        compute_cov_from_raw(cfg=cfg, subject=subject, session=session)
+        return 'raw'
+    else:
+        return 'epochs'
+
+
+@failsafe_run(script_path=__file__,
+              get_input_fnames=get_input_fnames_cov)
+def run_covariance(*, cfg, subject, session, in_files):
+    out_files = dict()
+    out_files['cov'] = get_noise_cov_bids_path(
+        noise_cov=config.noise_cov,
+        cfg=cfg,
+        subject=subject,
+        session=session
+    )
+    cov_type = _get_cov_type(cfg)
+    kwargs = dict(cfg=cfg, in_files=in_files, out_files=out_files)
+    if cov_type == 'custom':
+        retrieve_custom_cov(**kwargs)
+    elif cov_type == 'raw':
+        compute_cov_from_raw(**kwargs)
     else:
         tmin, tmax = config.noise_cov
-        compute_cov_from_epochs(cfg=cfg, subject=subject, session=session,
-                                tmin=tmin, tmax=tmax)
+        compute_cov_from_epochs(tmin=tmin, tmax=tmax, **kwargs)
+    assert out_files['cov'].is_file(), out_files['cov']
+    return out_files
 
 
 def get_config(
     subject: Optional[str] = None,
     session: Optional[str] = None
 ) -> SimpleNamespace:
+    # Callables are not nicely pickleable, so let's pass a string instead
+    noise_cov = 'custom' if callable(config.noise_cov) else config.noise_cov
     cfg = SimpleNamespace(
         task=config.get_task(),
         datatype=config.get_datatype(),
@@ -186,6 +214,7 @@ def get_config(
         ch_types=config.ch_types,
         deriv_root=config.get_deriv_root(),
         run_source_estimation=config.run_source_estimation,
+        noise_cov=noise_cov,
     )
     return cfg
 

--- a/scripts/source/_03_make_cov.py
+++ b/scripts/source/_03_make_cov.py
@@ -174,7 +174,6 @@ def _get_cov_type(cfg):
 @failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_cov)
 def run_covariance(*, cfg, subject, session, in_files):
-    assert len(in_files) == 1, in_files
     out_files = dict()
     out_files['cov'] = get_noise_cov_bids_path(
         noise_cov=config.noise_cov,

--- a/scripts/source/_03_make_cov.py
+++ b/scripts/source/_03_make_cov.py
@@ -164,9 +164,8 @@ def retrieve_custom_cov(
 def _get_cov_type(cfg):
     if cfg.noise_cov == 'custom':
         return 'custom'
-    elif (
-        (cfg.noise_cov == 'emptyroom' and 'eeg' not in cfg.ch_types) or
-         cfg.noise_cov == 'rest'):
+    elif (cfg.noise_cov == 'rest' or (cfg.noise_cov == 'emptyroom' and
+                                      'eeg' not in cfg.ch_types)):
         return 'raw'
     else:
         return 'epochs'

--- a/scripts/source/_03_make_cov.py
+++ b/scripts/source/_03_make_cov.py
@@ -8,7 +8,6 @@ Covariance matrices are computed and saved.
 
 import itertools
 import logging
-from typing import Optional
 from types import SimpleNamespace
 
 import mne
@@ -88,14 +87,14 @@ def compute_cov_from_epochs(
     msg = "Computing regularized covariance based on epochs' baseline periods."
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
-    msg = f"Input: {epo_fname.basename}"
+    msg = f"Input:  {epo_fname.basename}"
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
     msg = f"Output: {out_files['cov'].basename}"
     logger.info(**gen_log_kwargs(message=msg, subject=subject,
                                  session=session))
 
-    epochs = mne.read_epochs(in_files.pop('epochs'), preload=True)
+    epochs = mne.read_epochs(epo_fname, preload=True)
     cov = mne.compute_covariance(epochs, tmin=tmin, tmax=tmax, method='shrunk',
                                  rank='info')
     return cov
@@ -167,8 +166,7 @@ def _get_cov_type(cfg):
         return 'custom'
     elif (
         (cfg.noise_cov == 'emptyroom' and 'eeg' not in cfg.ch_types) or
-         cfg.noise_cov == 'rest'
-    ):
+         cfg.noise_cov == 'rest'):
         return 'raw'
     else:
         return 'epochs'
@@ -177,6 +175,7 @@ def _get_cov_type(cfg):
 @failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_cov)
 def run_covariance(*, cfg, subject, session, in_files):
+    assert len(in_files) == 1, in_files
     out_files = dict()
     out_files['cov'] = get_noise_cov_bids_path(
         noise_cov=config.noise_cov,

--- a/tests/configs/config_ds000248.py
+++ b/tests/configs/config_ds000248.py
@@ -46,7 +46,6 @@ decim = 4
 
 bem_mri_images = 'FLASH'
 recreate_bem = True
-recreate_scalp_surface = True
 
 N_JOBS = 2
 

--- a/tests/configs/config_ds000248_coreg_surfaces.py
+++ b/tests/configs/config_ds000248_coreg_surfaces.py
@@ -10,3 +10,5 @@ subjects_dir = f'{bids_root}/derivatives/freesurfer/subjects'
 subjects = ['01']
 conditions = ['Auditory']
 ch_types = ['meg']
+
+recreate_scalp_surface = True

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,4 +1,5 @@
 """Download test data and run a test suite."""
+import difflib
 import sys
 import shutil
 import os
@@ -244,12 +245,17 @@ if __name__ == '__main__':
     if 'n/a' in test_suite.values():
         if os.environ.get('DATASET') is None:
             parser.print_help()
-        print('\n\n')
-        raise KeyError(
-            f'"{args.dataset}" is not a valid dataset key in the TEST_SUITE '
-            f'dictionary in the run_tests.py module. Use one of: '
-            f'{", ".join(TEST_SUITE.keys())}.'
+        print('\n')
+        extra = ''
+        matches = difflib.get_close_matches(args.dataset, TEST_SUITE.keys())
+        if matches:
+            extra = f'\n\nDid you mean one of {matches}?'
+        print(
+            f'\n\n{repr(args.dataset)}" is not a valid dataset key in the '
+            f'TEST_SUITE dictionary in the run_tests.py module.{extra}\n\n'
+            f'Valid options: {", ".join(sorted(TEST_SUITE.keys()))}.\n'
         )
+        raise KeyError(f'{repr(args.dataset)} is not a valid dataset key.')
 
     # Run the tests
     extra = ''
@@ -257,6 +263,7 @@ if __name__ == '__main__':
         extra += ' after downloading data'
     if debug:
         extra += ' in debug mode'
-    print(f'Running the following tests{extra}: {", ".join(test_suite.keys())}')
+    print(f'📝 Running the following tests{extra}: '
+          f'{", ".join(test_suite.keys())}')
 
     run_tests(test_suite, download=download, debug=debug, cache=cache)


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
- [x] Add a magic `in_files['__force_run__'] = True` to force rerunning even if the call is in the cache
- [x] Cache `_02_coreg_surfaces.py`
- [x] Remove redundant `-head.fif` creation from `_01_bem_surfaces.py` in favor of `_02_coreg_surfaces.py`
- [x] Cache `_01_bem_surfaces.py`
- [x] Add a magic `in_files['__unknown_inputs__'] = True` that gets detected to force running without cache (e.g., for cov-as-callable)
- [x] Cache `_03_make_cov.py`
- [x] For all steps above -- but `_02_coreg_surfaces.py` and `_01_bem_surfaces.py` in particular -- skipping can only occur if the function has been called before. If people ship FS subjects with BEM and/or head surfaces, they will be recomputed (because they won't exist in the cache until *mne-bids-pipeline* computes them). We should change this to (re)enable skipping if the files already exist.

Not super thoroughly tested, but the ideas are there at least.

Questions

