### PR TITLE
BUG: Fix bug with naming

### DIFF
--- a/mne_bids_pipeline/scripts/report/_01_make_reports.py
+++ b/mne_bids_pipeline/scripts/report/_01_make_reports.py
@@ -986,9 +986,9 @@ def run_report_sensor(
     for condition in conditions:
         cond = config.sanitize_cond_name(condition)
         fname_tfr_pow_cond = str(fname_tfr_pow.copy()).replace("+condition+",
-                                                               f"+{cond}-")
+                                                               f"+{cond}+")
         fname_tfr_itc_cond = str(fname_tfr_itc.copy()).replace("+condition+",
-                                                               f"+{cond}-")
+                                                               f"+{cond}+")
         with mne.use_log_level('error'):  # filename convention
             power = mne.time_frequency.read_tfrs(
                 fname_tfr_pow_cond, condition=0)

--- a/mne_bids_pipeline/scripts/report/_01_make_reports.py
+++ b/mne_bids_pipeline/scripts/report/_01_make_reports.py
@@ -752,11 +752,11 @@ def run_report_sensor(
         extension='.mat'
     )
     fname_tfr_pow = bids_path.copy().update(
-        suffix='power+condition-tfr',
+        suffix='power+condition+tfr',
         extension='.h5'
     )
     fname_tfr_itc = bids_path.copy().update(
-        suffix='itc+condition-tfr',
+        suffix='itc+condition+tfr',
         extension='.h5'
     )
     fname_noise_cov = get_noise_cov_bids_path(
@@ -985,11 +985,13 @@ def run_report_sensor(
 
     for condition in conditions:
         cond = config.sanitize_cond_name(condition)
-        fname_tfr_pow_cond = str(fname_tfr_pow.copy()).replace("+condition-",
+        fname_tfr_pow_cond = str(fname_tfr_pow.copy()).replace("+condition+",
                                                                f"+{cond}-")
-        fname_tfr_itc_cond = str(fname_tfr_itc.copy()).replace("+condition-",
+        fname_tfr_itc_cond = str(fname_tfr_itc.copy()).replace("+condition+",
                                                                f"+{cond}-")
-        power = mne.time_frequency.read_tfrs(fname_tfr_pow_cond, condition=0)
+        with mne.use_log_level('error'):  # filename convention
+            power = mne.time_frequency.read_tfrs(
+                fname_tfr_pow_cond, condition=0)
         kwargs = dict(
             show=False, fig_facecolor='w', font_color='k', border='k'
         )
@@ -1003,7 +1005,9 @@ def run_report_sensor(
         plt.close(fig_power)
         del power
 
-        itc = mne.time_frequency.read_tfrs(fname_tfr_itc_cond, condition=0)
+        with mne.use_log_level('error'):  # filename convention
+            itc = mne.time_frequency.read_tfrs(
+                fname_tfr_itc_cond, condition=0)
         fig_itc = itc.plot_topo(**kwargs)
         report.add_figure(
             fig=fig_itc,

--- a/mne_bids_pipeline/scripts/report/_01_make_reports.py
+++ b/mne_bids_pipeline/scripts/report/_01_make_reports.py
@@ -752,11 +752,11 @@ def run_report_sensor(
         extension='.mat'
     )
     fname_tfr_pow = bids_path.copy().update(
-        suffix='power+condition+tfr',
+        suffix='power+condition-tfr',
         extension='.h5'
     )
     fname_tfr_itc = bids_path.copy().update(
-        suffix='itc+condition+tfr',
+        suffix='itc+condition-tfr',
         extension='.h5'
     )
     fname_noise_cov = get_noise_cov_bids_path(
@@ -985,10 +985,10 @@ def run_report_sensor(
 
     for condition in conditions:
         cond = config.sanitize_cond_name(condition)
-        fname_tfr_pow_cond = str(fname_tfr_pow.copy()).replace("+condition+",
-                                                               f"+{cond}+")
-        fname_tfr_itc_cond = str(fname_tfr_itc.copy()).replace("+condition+",
-                                                               f"+{cond}+")
+        fname_tfr_pow_cond = str(fname_tfr_pow.copy()).replace("+condition-",
+                                                               f"+{cond}-")
+        fname_tfr_itc_cond = str(fname_tfr_itc.copy()).replace("+condition-",
+                                                               f"+{cond}-")
         power = mne.time_frequency.read_tfrs(fname_tfr_pow_cond, condition=0)
         kwargs = dict(
             show=False, fig_facecolor='w', font_color='k', border='k'

--- a/mne_bids_pipeline/scripts/sensor/_04_time_frequency.py
+++ b/mne_bids_pipeline/scripts/sensor/_04_time_frequency.py
@@ -83,9 +83,9 @@ def run_time_frequency(*, cfg, subject, session, in_files):
         power_key = f'power-{condition_str}'
         itc_key = f'itc-{condition_str}'
         out_files[power_key] = bids_path.copy().update(
-            suffix=f'power+{condition_str}+tfr', extension='.h5')
+            suffix=f'power+{condition_str}-tfr', extension='.h5')
         out_files[itc_key] = bids_path.copy().update(
-            suffix=f'itc+{condition_str}+tfr', extension='.h5')
+            suffix=f'itc+{condition_str}-tfr', extension='.h5')
 
         power.save(out_files[power_key], overwrite=True)
         itc.save(out_files[itc_key], overwrite=True)

--- a/mne_bids_pipeline/scripts/sensor/_04_time_frequency.py
+++ b/mne_bids_pipeline/scripts/sensor/_04_time_frequency.py
@@ -83,9 +83,9 @@ def run_time_frequency(*, cfg, subject, session, in_files):
         power_key = f'power-{condition_str}'
         itc_key = f'itc-{condition_str}'
         out_files[power_key] = bids_path.copy().update(
-            suffix=f'power+{condition_str}-tfr', extension='.h5')
+            suffix=f'power+{condition_str}+tfr', extension='.h5')
         out_files[itc_key] = bids_path.copy().update(
-            suffix=f'itc+{condition_str}-tfr', extension='.h5')
+            suffix=f'itc+{condition_str}+tfr', extension='.h5')
 
         # TODO: verbose='error' here because we write filenames that do not
         # conform to MNE filename checks. This is because BIDS has not

--- a/mne_bids_pipeline/scripts/sensor/_04_time_frequency.py
+++ b/mne_bids_pipeline/scripts/sensor/_04_time_frequency.py
@@ -91,7 +91,7 @@ def run_time_frequency(*, cfg, subject, session, in_files):
         # conform to MNE filename checks. This is because BIDS has not
         # finalized how derivatives should be named. Once this is done, we
         # should update our names and/or MNE's checks.
-        power.save(out_files[power_key], overwrite=True, verbose='error`')
+        power.save(out_files[power_key], overwrite=True, verbose='error')
         itc.save(out_files[itc_key], overwrite=True, verbose='error')
 
     assert len(in_files) == 0, in_files.keys()

--- a/mne_bids_pipeline/scripts/sensor/_04_time_frequency.py
+++ b/mne_bids_pipeline/scripts/sensor/_04_time_frequency.py
@@ -87,8 +87,12 @@ def run_time_frequency(*, cfg, subject, session, in_files):
         out_files[itc_key] = bids_path.copy().update(
             suffix=f'itc+{condition_str}-tfr', extension='.h5')
 
-        power.save(out_files[power_key], overwrite=True)
-        itc.save(out_files[itc_key], overwrite=True)
+        # TODO: verbose='error' here because we write filenames that do not
+        # conform to MNE filename checks. This is because BIDS has not
+        # finalized how derivatives should be named. Once this is done, we
+        # should update our names and/or MNE's checks.
+        power.save(out_files[power_key], overwrite=True, verbose='error`')
+        itc.save(out_files[itc_key], overwrite=True, verbose='error')
 
     assert len(in_files) == 0, in_files.keys()
     return out_files


### PR DESCRIPTION
Fixes:

> RuntimeWarning: This filename (.../derivatives/mne-bids-pipeline/sub-007/meg/sub-007_task-whatever_power+condition+tfr.h5) does not conform to MNE naming conventions. All tfr files should end with -tfr.h5 or _tfr.h5

Is using `-tfr` instead of `+tfr` the correct fix here @hoechenberger ? Or do we need to update MNE-Python to be more tolerant here somehow?
