### PR TITLE
MAINT: Cleaner logic for empty-room and rest data

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -267,10 +267,10 @@ authors:
   when Maxwell filtering is used.
   ({{ gh(595) }} by {{ authors.larsoner }})
 - Empty-room and resting-state data are processed by default if present,
-  regardless of [`config.noise_cov`][mne_bids_pipeline.config.noise_cov] value
-  based on [`config.process_er = True`][mne_bids_pipeline.config.process_er]
-  and [`config.process_rest = True`][mne_bids_pipeline.config.process_rest]
-  default values
+  regardless of [`config.noise_cov`][mne_bids_pipeline.config.noise_cov] value.
+  This can be controlled by changing the default values from 
+  [`config.process_er = True`][mne_bids_pipeline.config.process_er] and
+  [`config.process_rest = True`][mne_bids_pipeline.config.process_rest]
   ({{ gh(633) }} by {{ authors.larsoner }})
 
 ### Code health

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -266,6 +266,12 @@ authors:
   defaults to `'auto'`, which will use `ssp_meg='combined'` for SSP computation
   when Maxwell filtering is used.
   ({{ gh(595) }} by {{ authors.larsoner }})
+- Empty-room and resting-state data are processed by default if present,
+  regardless of [`config.noise_cov`][mne_bids_pipeline.config.noise_cov] value
+  based on [`config.process_er = True`][mne_bids_pipeline.config.process_er]
+  and [`config.process_rest = True`][mne_bids_pipeline.config.process_rest]
+  default values
+  ({{ gh(633) }} by {{ authors.larsoner }})
 
 ### Code health
 

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -269,7 +269,7 @@ authors:
 - Empty-room and resting-state data are processed by default if present,
   regardless of [`config.noise_cov`][mne_bids_pipeline.config.noise_cov] value.
   This can be controlled by changing the default values from 
-  [`config.process_er = True`][mne_bids_pipeline.config.process_er] and
+  [`config.process_empty_room = True`][mne_bids_pipeline.config.process_empty_room] and
   [`config.process_rest = True`][mne_bids_pipeline.config.process_rest]
   ({{ gh(633) }} by {{ authors.larsoner }})
 
@@ -289,6 +289,10 @@ authors:
 - For storing configuration values, we switched from using `BunchConst` to
   Python's built-in `SimpleNamespace`.
   ({{ gh(472) }} by {{ authors.agramfort }})
+- The `config.process_er` variable was renamed 
+  [`config.process_empty_room`][mne_bids_pipeline.config.process_empty_room]
+  for readability, and the default was changed to `True` for consistency
+  ({{ gh(633) }} by {{ authors.larsoner }})
 
 ### Bug fixes
 

--- a/docs/source/settings/general.md
+++ b/docs/source/settings/general.md
@@ -16,6 +16,7 @@
 ::: mne_bids_pipeline.config.subjects
 ::: mne_bids_pipeline.config.exclude_subjects
 ::: mne_bids_pipeline.config.process_er
+::: mne_bids_pipeline.config.process_rest
 ::: mne_bids_pipeline.config.ch_types
 ::: mne_bids_pipeline.config.data_type
 ::: mne_bids_pipeline.config.eog_channels

--- a/docs/source/settings/general.md
+++ b/docs/source/settings/general.md
@@ -15,7 +15,7 @@
 ::: mne_bids_pipeline.config.space
 ::: mne_bids_pipeline.config.subjects
 ::: mne_bids_pipeline.config.exclude_subjects
-::: mne_bids_pipeline.config.process_er
+::: mne_bids_pipeline.config.process_empty_room
 ::: mne_bids_pipeline.config.process_rest
 ::: mne_bids_pipeline.config.ch_types
 ::: mne_bids_pipeline.config.data_type

--- a/mne_bids_pipeline/config.py
+++ b/mne_bids_pipeline/config.py
@@ -3953,7 +3953,7 @@ if (
     raise ValueError(msg)
 
 
-def _update_for_splits(files_dict, key, *, single=False):
+def _update_for_splits(files_dict, key, *, single=False, allow_missing=False):
     if not isinstance(files_dict, dict):  # fake it
         assert key is None
         files_dict, key = dict(x=files_dict), 'x'
@@ -3961,7 +3961,11 @@ def _update_for_splits(files_dict, key, *, single=False):
     if bids_path.fpath.exists():
         return bids_path  # no modifications needed
     bids_path = bids_path.copy().update(split='01')
-    assert bids_path.fpath.exists(), f'Missing file: {bids_path.fpath}'
+    missing = not bids_path.fpath.exists()
+    if not allow_missing:
+        assert not missing, f'Missing file: {bids_path.fpath}'
+    if missing:
+        return bids_path.update(split=None)
     files_dict[key] = bids_path
     # if we only need the first file (i.e., when reading), quit now
     if single:

--- a/mne_bids_pipeline/config.py
+++ b/mne_bids_pipeline/config.py
@@ -3796,8 +3796,7 @@ def import_er_data(
 def import_rest_data(
     *,
     cfg: SimpleNamespace,
-    subject: str,
-    session: Optional[str] = None
+    bids_path_in: BIDSPath,
 ) -> mne.io.BaseRaw:
     """Import resting-state data for use as a noise source.
 
@@ -3805,10 +3804,8 @@ def import_rest_data(
     ----------
     cfg
         The local configuration.
-    subject
-        The subject for whom to import the empty-room data.
-    session
-        The session for which to import the empty-room data.
+    bids_path_in : BIDSPath
+        The path.
 
     Returns
     -------
@@ -3819,7 +3816,7 @@ def import_rest_data(
     cfg.task = 'rest'
 
     raw_rest = import_experimental_data(
-        cfg=cfg, subject=subject, session=session
+        cfg=cfg, bids_path_in=bids_path_in,
     )
     return raw_rest
 

--- a/mne_bids_pipeline/config.py
+++ b/mne_bids_pipeline/config.py
@@ -3761,9 +3761,9 @@ def import_er_data(
     # rank mismatches will still occur (eventually for some configs).
     # But at least using the union here should reduce them.
     # TODO: We should also uso automatic bad finding on the empty room data
+    raw_ref = mne_bids.read_raw_bids(bids_path_ref_in,
+                                     extra_params=cfg.reader_extra_params)
     if cfg.use_maxwell_filter:
-        raw_ref = mne_bids.read_raw_bids(bids_path_ref_in,
-                                         extra_params=cfg.reader_extra_params)
         # We need to include any automatically found bad channels, if relevant.
         # TODO this is a bit of a hack because we don't use "in_files" access
         # here, but this is *in the same step where this file is generated*

--- a/mne_bids_pipeline/config.py
+++ b/mne_bids_pipeline/config.py
@@ -216,7 +216,7 @@ is automatically excluded from regular analysis.
     The ``emptyroom`` subject will be excluded automatically.
 """
 
-process_er: bool = False
+process_er: bool = True
 """
 Whether to apply the same pre-processing steps to the empty-room data as
 to the experimental data (up until including frequency filtering). This
@@ -224,6 +224,14 @@ is required if you wish to use the empty-room recording to estimate noise
 covariance (via ``noise_cov='emptyroom'``). The empty-room recording
 corresponding to the processed experimental data will be retrieved
 automatically.
+"""
+
+process_rest: bool = True
+"""
+Whether to apply the same pre-processing steps to the resting-state data as
+to the experimental data (up until including frequency filtering). This
+is required if you wish to use the resting-state recording to estimate noise
+covariance (via ``noise_cov='rest'``).
 """
 
 ch_types: Iterable[Literal['meg', 'mag', 'grad', 'eeg']] = []

--- a/mne_bids_pipeline/config.py
+++ b/mne_bids_pipeline/config.py
@@ -215,7 +215,7 @@ is automatically excluded from regular analysis.
     The ``emptyroom`` subject will be excluded automatically.
 """
 
-process_er: bool = True
+process_empty_room: bool = True
 """
 Whether to apply the same pre-processing steps to the empty-room data as
 to the experimental data (up until including frequency filtering). This
@@ -2159,10 +2159,11 @@ if noise_cov == 'emptyroom' and 'eeg' in ch_types:
            'noise_cov to (tmin, tmax)')
     raise ValueError(msg)
 
-if noise_cov == 'emptyroom' and not process_er:
+if noise_cov == 'emptyroom' and not process_empty_room:
     msg = ('You requested noise covariance estimation from empty-room '
            'recordings by setting noise_cov = "emptyroom", but you did not '
-           'enable empty-room data processing. Please set process_er = True')
+           'enable empty-room data processing. '
+           'Please set process_empty_room = True')
     raise ValueError(msg)
 
 if bem_mri_images not in ('FLASH', 'T1', 'auto'):

--- a/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
@@ -66,7 +66,7 @@ def get_input_fnames_maxwell_filter(**kwargs):
     if run == cfg.mf_reference_run:
         if cfg.process_rest and not cfg.task_is_rest:
             raw_rest = bids_path_in.copy().update(task="rest")
-            if raw_rest.fpath.is_file():
+            if raw_rest.fpath.exists():
                 in_files["raw_rest"] = raw_rest
         if cfg.process_er:
             try:
@@ -75,7 +75,7 @@ def get_input_fnames_maxwell_filter(**kwargs):
                     AssertionError,  # MNE-BIDS check assert exists()
                     FileNotFoundError):  # MNE-BIDS PR-1080 exists()
                 raw_noise = None
-            if raw_noise is not None and raw_noise.fpath.is_file():
+            if raw_noise is not None and raw_noise.fpath.exists():
                 in_files["raw_noise"] = raw_noise
 
     in_files["raw_ref_run"] = ref_bids_path

--- a/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
@@ -68,7 +68,7 @@ def get_input_fnames_maxwell_filter(**kwargs):
             raw_rest = bids_path_in.copy().update(task="rest")
             if raw_rest.fpath.exists():
                 in_files["raw_rest"] = raw_rest
-        if cfg.process_er:
+        if cfg.process_empty_room:
             try:
                 raw_noise = ref_bids_path.find_empty_room()
             except (ValueError,  # non-MEG data
@@ -269,7 +269,7 @@ def get_config(
         mf_ctc_fname=config.get_mf_ctc_fname(subject, session),
         mf_st_duration=config.mf_st_duration,
         mf_head_origin=config.mf_head_origin,
-        process_er=config.process_er,
+        process_empty_room=config.process_empty_room,
         process_rest=config.process_rest,
         task_is_rest=config.task_is_rest,
         runs=config.get_runs(subject=subject),  # XXX needs to accept session!

--- a/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
@@ -71,7 +71,7 @@ def get_input_fnames_maxwell_filter(**kwargs):
         if cfg.process_er:
             try:
                 raw_noise = ref_bids_path.find_empty_room()
-            except RuntimeError:  # non-MEG data
+            except ValueError:  # non-MEG data
                 raw_noise = None
             if raw_noise is not None and raw_noise.fpath.is_file():
                 in_files["raw_noise"] = raw_noise

--- a/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
@@ -64,14 +64,16 @@ def get_input_fnames_maxwell_filter(**kwargs):
     )
 
     if run == cfg.mf_reference_run:
-        if cfg.process_rest:
+        if cfg.process_rest and not cfg.task_is_rest:
             raw_rest = bids_path_in.copy().update(task="rest")
             if raw_rest.fpath.is_file():
                 in_files["raw_rest"] = raw_rest
         if cfg.process_er:
             try:
                 raw_noise = ref_bids_path.find_empty_room()
-            except ValueError:  # non-MEG data
+            except (ValueError,  # non-MEG data
+                    AssertionError,  # MNE-BIDS check assert exists()
+                    FileNotFoundError):  # MNE-BIDS PR-1080 exists()
                 raw_noise = None
             if raw_noise is not None and raw_noise.fpath.is_file():
                 in_files["raw_noise"] = raw_noise
@@ -269,6 +271,7 @@ def get_config(
         mf_head_origin=config.mf_head_origin,
         process_er=config.process_er,
         process_rest=config.process_rest,
+        task_is_rest=config.task_is_rest,
         runs=config.get_runs(subject=subject),  # XXX needs to accept session!
         use_maxwell_filter=config.use_maxwell_filter,
         proc=config.proc,

--- a/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
@@ -69,8 +69,11 @@ def get_input_fnames_maxwell_filter(**kwargs):
             if raw_rest.fpath.is_file():
                 in_files["raw_rest"] = raw_rest
         if cfg.process_er:
-            raw_noise = ref_bids_path.find_empty_room()
-            if raw_noise is not None:
+            try:
+                raw_noise = ref_bids_path.find_empty_room()
+            except RuntimeError:  # non-MEG data
+                raw_noise = None
+            if raw_noise is not None and raw_noise.fpath.is_file():
                 in_files["raw_noise"] = raw_noise
 
     in_files["raw_ref_run"] = ref_bids_path

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -72,7 +72,7 @@ def get_input_fnames_frequency_filter(**kwargs):
         path_kwargs['root'] = cfg.bids_root
         path_kwargs['suffix'] = None
         path_kwargs['extension'] = None
-        path_kwmags['processing'] = cfg.proc
+        path_kwargs['processing'] = cfg.proc
     bids_path_in = BIDSPath(**path_kwargs)
 
     in_files = dict()

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -108,7 +108,7 @@ def get_input_fnames_frequency_filter(**kwargs):
             in_files[key] = raw_fname
             _update_for_splits(
                 in_files, key, single=True, allow_missing=True)
-            if not in_files[key].fpath.is_file():
+            if not in_files[key].fpath.exists():
                 in_files.pop(key)
 
     return in_files

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -235,7 +235,7 @@ def filter_data(
             raw_noise = import_er_data(
                 cfg=cfg,
                 bids_path_er_in=bids_path_noise,
-                bids_path_ref_in=None,
+                bids_path_ref_in=bids_path,  # will take bads from this run (0)
             )
         else:
             raw_noise = import_rest_data(
@@ -244,9 +244,9 @@ def filter_data(
             )
         out_key = f'raw_{task}_filt'
         out_files[out_key] = \
-            bids_path_noise.copy().update(
+            bids_path.copy().update(
                 root=cfg.deriv_root, processing='filt', extension='.fif',
-                suffix='raw', split=None)
+                suffix='raw', split=None, task=task, run=None)
 
         raw_noise.load_data()
         filter(

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -203,7 +203,7 @@ def filter_data(
 
     del raw
 
-    nice_names = dict(rest='restiing-state', noise='empty-room')
+    nice_names = dict(rest='resting-state', noise='empty-room')
     for task in ('rest', 'noise'):
         in_key = f'raw_{task}'
         if in_key not in in_files:

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -266,6 +266,7 @@ def get_config(
     cfg = SimpleNamespace(
         reader_extra_params=config.reader_extra_params,
         process_er=config.process_er,
+        process_rest=config.process_rest,
         runs=config.get_runs(subject=subject),
         use_maxwell_filter=config.use_maxwell_filter,
         proc=config.proc,

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -91,8 +91,13 @@ def get_input_fnames_frequency_filter(**kwargs):
                     raw_fname = bids_path_in.copy().update(
                         run=None, task=task)
                 else:
-                    raw_fname = in_files[f'raw_run-{run}'].find_empty_room()
-            if do[task] and raw_fname.fpath.is_file():
+                    try:
+                        raw_fname = \
+                            in_files[f'raw_run-{run}'].find_empty_room()
+                    except RuntimeError:  # non-MEG data
+                        raw_fname = None
+            if do[task] and raw_fname is not None and \
+                    raw_fname.fpath.is_file():
                 in_files[key] = raw_fname
                 _update_for_splits(in_files, key, single=True)
 

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -94,7 +94,7 @@ def get_input_fnames_frequency_filter(**kwargs):
                     try:
                         raw_fname = \
                             in_files[f'raw_run-{run}'].find_empty_room()
-                    except RuntimeError:  # non-MEG data
+                    except ValueError:  # non-MEG data
                         raw_fname = None
             if do[task] and raw_fname is not None and \
                     raw_fname.fpath.is_file():

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -82,7 +82,7 @@ def get_input_fnames_frequency_filter(**kwargs):
     if run == cfg.runs[0]:
         do = dict(
             rest=cfg.process_rest and not cfg.task_is_rest,
-            noise=cfg.process_er,
+            noise=cfg.process_empty_room,
         )
         for task in ('rest', 'noise'):
             if not do[task]:
@@ -280,7 +280,7 @@ def get_config(
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
         reader_extra_params=config.reader_extra_params,
-        process_er=config.process_er,
+        process_empty_room=config.process_empty_room,
         process_rest=config.process_rest,
         task_is_rest=config.task_is_rest,
         runs=config.get_runs(subject=subject),

--- a/mne_bids_pipeline/scripts/preprocessing/_03_make_epochs.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_03_make_epochs.py
@@ -17,7 +17,7 @@ from mne_bids import BIDSPath
 
 import config
 from config import make_epochs, gen_log_kwargs, failsafe_run
-from config import parallel_func, _update_for_splits
+from config import parallel_func, _update_for_splits, _sanitize_callable
 
 logger = logging.getLogger('mne-bids-pipeline')
 
@@ -52,7 +52,7 @@ def get_input_fnames_epochs(**kwargs):
         key = f'raw_run-{run}'
         in_files[key] = bids_path.copy().update(run=run)
         _update_for_splits(in_files, key, single=True)
-    if cfg.use_maxwell_filter and config.noise_cov == 'rest':
+    if cfg.use_maxwell_filter and cfg.noise_cov == 'rest':
         in_files['raw_rest'] = bids_path.copy().update(
             task='rest',
             check=False
@@ -150,7 +150,7 @@ def run_epochs(*, cfg, subject, session, in_files):
     epochs = epochs_all_runs
     del epochs_all_runs
 
-    if cfg.use_maxwell_filter and config.noise_cov == 'rest':
+    if cfg.use_maxwell_filter and cfg.noise_cov == 'rest':
         raw_rest_filt = mne.io.read_raw(in_files.pop('raw_rest'))
         rank_rest = mne.compute_rank(raw_rest_filt, rank='info')['meg']
         if rank_rest < smallest_rank:
@@ -249,6 +249,7 @@ def get_config(
         event_repeated=config.event_repeated,
         decim=config.decim,
         ch_types=config.ch_types,
+        noise_cov=_sanitize_callable(config.noise_cov),
         eeg_reference=config.get_eeg_reference(),
         _epochs_split_size=config._epochs_split_size,
     )

--- a/mne_bids_pipeline/scripts/preprocessing/_03_make_epochs.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_03_make_epochs.py
@@ -224,7 +224,6 @@ def get_config(
     session: Optional[str] = None
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        process_er=config.process_er,
         runs=config.get_runs(subject=subject),
         use_maxwell_filter=config.use_maxwell_filter,
         proc=config.proc,

--- a/mne_bids_pipeline/scripts/report/_01_make_reports.py
+++ b/mne_bids_pipeline/scripts/report/_01_make_reports.py
@@ -1599,7 +1599,6 @@ def get_config(
         space=config.space,
         proc=config.proc,
         analyze_channels=config.analyze_channels,
-        process_er=config.process_er,
         find_noisy_channels_meg=config.find_noisy_channels_meg,
         h_freq=config.h_freq,
         spatial_filter=config.spatial_filter,

--- a/mne_bids_pipeline/scripts/report/_01_make_reports.py
+++ b/mne_bids_pipeline/scripts/report/_01_make_reports.py
@@ -76,7 +76,8 @@ def get_er_path(cfg, subject, session):
                          datatype=cfg.datatype,
                          root=cfg.deriv_root,
                          check=False)
-    raw_fname = _update_for_splits(raw_fname, None, single=True)
+    raw_fname = _update_for_splits(
+        raw_fname, None, single=True, allow_missing=True)
     return raw_fname
 
 
@@ -529,7 +530,8 @@ def run_report_preprocessing(
         )
         del plot_raw_psd
 
-    if cfg.process_er:
+    er_path = get_er_path(cfg=cfg, subject=subject, session=session)
+    if er_path.fpath.exists():
         msg = 'Adding filtered empty-room raw data to report.'
         logger.info(
             **gen_log_kwargs(
@@ -537,7 +539,6 @@ def run_report_preprocessing(
             )
         )
 
-        er_path = get_er_path(cfg=cfg, subject=subject, session=session)
         report.add_raw(
             raw=er_path,
             title='Empty-Room',

--- a/mne_bids_pipeline/tests/configs/config_ds000248.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000248.py
@@ -23,7 +23,6 @@ mf_reference_run = '01'
 find_flat_channels_meg = True
 find_noisy_channels_meg = True
 use_maxwell_filter = True
-process_er = True
 _raw_split_size = '60MB'  # hits both task-noise and task-audiovisual
 _epochs_split_size = '30MB'
 

--- a/mne_bids_pipeline/tests/configs/config_ds000248_no_mri.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000248_no_mri.py
@@ -15,7 +15,7 @@ contrasts = [('Auditory/Right', 'Auditory/Left')]
 
 ch_types = ['meg']
 use_maxwell_filter = False
-process_er = False
+process_empty_room = False
 
 use_template_mri = "fsaverage"
 adjust_coreg = True

--- a/mne_bids_pipeline/tests/configs/config_ds003392.py
+++ b/mne_bids_pipeline/tests/configs/config_ds003392.py
@@ -39,5 +39,4 @@ decoding_time_generalization_decim = 4
 contrasts = [('incoherent', 'coherent')]
 
 # Noise estimation
-process_er = True
 noise_cov = 'emptyroom'

--- a/mne_bids_pipeline/tests/configs/config_ds004229.py
+++ b/mne_bids_pipeline/tests/configs/config_ds004229.py
@@ -32,5 +32,4 @@ conditions = ["auditory"]
 decode = False
 
 # Noise estimation
-process_er = True
 noise_cov = 'emptyroom'


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
- [x] Implement ideas in #632

The logic and flow seems simpler and more transparent to me now. `noise_cov` is no longer used at all in `maxfilter` or `frequency_filter` steps, which is nice!

Closes #632