### PR TITLE
ENH: Add find_empty_room step

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
     - name: Install flake8 and codespell
-      run: pip install flake8 https://github.com/codespell-project/codespell/zipball/master tomli
+      run: pip install flake8 git+https://github.com/codespell-project/codespell#egg=codespel tomli
     - run: make flake
     - run: make codespell-error
   check-doc:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ trailing-spaces:
 	find . -name "*.py" | xargs perl -pi -e 's/[ \t]*$$//'
 
 flake:
-	flake8 . --exclude "**/freesurfer/contrib,docs/,dist/"
+	flake8 . --exclude "**/freesurfer/contrib,docs/,dist/,build/"
 	@echo "flake8 passed"
 
 codespell:  # running manually; auto-fix spelling mistakes

--- a/mne_bids_pipeline/_io.py
+++ b/mne_bids_pipeline/_io.py
@@ -1,18 +1,25 @@
 """I/O helpers."""
 
 import json_tricks
+from types import SimpleNamespace
+from mne_bids import BIDSPath
+
+from ._typing import PathLike
 
 
-def _write_json(fname, data):
+def _write_json(fname: PathLike, data: dict) -> None:
     with open(fname, 'w') as f:
         json_tricks.dump(data, fp=f, allow_nan=True, sort_keys=False)
 
 
-def _read_json(fname):
+def _read_json(fname: PathLike) -> dict:
     with open(fname, 'r') as f:
         return json_tricks.load(f)
 
 
-def _empty_room_match_path(run_path, cfg):
+def _empty_room_match_path(
+    run_path: BIDSPath,
+    cfg: SimpleNamespace
+) -> BIDSPath:
     return run_path.copy().update(
         extension='.json', suffix='emptyroommatch', root=cfg.deriv_root)

--- a/mne_bids_pipeline/_io.py
+++ b/mne_bids_pipeline/_io.py
@@ -6,3 +6,13 @@ import json_tricks
 def _write_json(fname, data):
     with open(fname, 'w') as f:
         json_tricks.dump(data, fp=f, allow_nan=True, sort_keys=False)
+
+
+def _read_json(fname):
+    with open(fname, 'r') as f:
+        return json_tricks.load(f)
+
+
+def _empty_room_match_path(run_path, cfg):
+    return run_path.copy().update(
+        extension='.json', suffix='emptyroommatch', root=cfg.deriv_root)

--- a/mne_bids_pipeline/_io.py
+++ b/mne_bids_pipeline/_io.py
@@ -1,19 +1,20 @@
 """I/O helpers."""
 
-import json_tricks
 from types import SimpleNamespace
+
+import json_tricks
 from mne_bids import BIDSPath
 
 from ._typing import PathLike
 
 
 def _write_json(fname: PathLike, data: dict) -> None:
-    with open(fname, 'w') as f:
+    with open(fname, 'w', encoding='utf-8') as f:
         json_tricks.dump(data, fp=f, allow_nan=True, sort_keys=False)
 
 
 def _read_json(fname: PathLike) -> dict:
-    with open(fname, 'r') as f:
+    with open(fname, 'r', encoding='utf-8') as f:
         return json_tricks.load(f)
 
 
@@ -22,4 +23,5 @@ def _empty_room_match_path(
     cfg: SimpleNamespace
 ) -> BIDSPath:
     return run_path.copy().update(
-        extension='.json', suffix='emptyroommatch', root=cfg.deriv_root)
+        extension='.json', suffix='emptyroommatch', root=cfg.deriv_root
+    )

--- a/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
+++ b/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
@@ -13,7 +13,7 @@ from ..._logging import logger
 
 def get_input_fnames_find_empty_room(
     *,
-    subject: Optional[str],
+    subject: str,
     session: Optional[str],
     run:  Optional[str],
     cfg: SimpleNamespace
@@ -55,7 +55,7 @@ def get_input_fnames_find_empty_room(
               get_input_fnames=get_input_fnames_find_empty_room)
 def find_empty_room(
     *,
-    subject: Optional[str],
+    subject: str,
     session: Optional[str],
     run:  Optional[str],
     in_files: Dict[str, BIDSPath],

--- a/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
+++ b/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
@@ -1,17 +1,23 @@
 """Find empty-room data matches."""
 
 from types import SimpleNamespace
-
-from mne_bids import BIDSPath
+from typing import Dict, Optional
 
 import config
-from config import gen_log_kwargs, failsafe_run, _update_for_splits
+from config import _update_for_splits, failsafe_run, gen_log_kwargs
+from mne_bids import BIDSPath
 
-from ..._io import _write_json, _empty_room_match_path
+from ..._io import _empty_room_match_path, _write_json
 from ..._logging import logger
 
 
-def get_input_fnames_find_empty_room(*, subject, session, run, cfg):
+def get_input_fnames_find_empty_room(
+    *,
+    subject: Optional[str],
+    session: Optional[str],
+    run:  Optional[str],
+    cfg: SimpleNamespace
+) -> Dict[str, BIDSPath]:
     """Get paths of files required by filter_data function."""
     bids_path_in = BIDSPath(
         subject=subject,
@@ -26,7 +32,7 @@ def get_input_fnames_find_empty_room(*, subject, session, run, cfg):
         root=cfg.bids_root,
         check=False
     )
-    in_files = dict()
+    in_files: Dict[str, BIDSPath] = dict()
     in_files[f'raw_run-{run}'] = bids_path_in
     _update_for_splits(in_files, f'raw_run-{run}', single=True)
     try:
@@ -47,7 +53,14 @@ def get_input_fnames_find_empty_room(*, subject, session, run, cfg):
 
 @failsafe_run(script_path=__file__,
               get_input_fnames=get_input_fnames_find_empty_room)
-def find_empty_room(*, subject, session, run, in_files, cfg):
+def find_empty_room(
+    *,
+    subject: Optional[str],
+    session: Optional[str],
+    run:  Optional[str],
+    in_files: Dict[str, BIDSPath],
+    cfg: SimpleNamespace
+) -> Dict[str, BIDSPath]:
     raw_path = in_files.pop(f'raw_run-{run}')
     try:
         fname = raw_path.find_empty_room(use_sidecar_only=True)
@@ -77,8 +90,7 @@ def find_empty_room(*, subject, session, run, in_files, cfg):
     return out_files
 
 
-def get_config(
-) -> SimpleNamespace:
+def get_config() -> SimpleNamespace:
     cfg = SimpleNamespace(
         proc=config.proc,
         task=config.get_task(),
@@ -92,7 +104,7 @@ def get_config(
     return cfg
 
 
-def main():
+def main() -> None:
     """Run find_empty_room."""
     if not config.process_empty_room:
         msg = 'Skipping, process_empty_room is set to False …'

--- a/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
+++ b/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
@@ -1,0 +1,117 @@
+"""Find empty-room data matches."""
+
+from types import SimpleNamespace
+
+from mne_bids import BIDSPath
+
+import config
+from config import gen_log_kwargs, failsafe_run, _update_for_splits
+
+from ..._io import _write_json, _empty_room_match_path
+from ..._logging import logger
+
+
+def get_input_fnames_find_empty_room(*, subject, session, run, cfg):
+    """Get paths of files required by filter_data function."""
+    bids_path_in = BIDSPath(
+        subject=subject,
+        run=run,
+        session=session,
+        task=cfg.task,
+        acquisition=cfg.acq,
+        recording=cfg.rec,
+        space=cfg.space,
+        datatype=cfg.datatype,
+        processing=cfg.proc,
+        root=cfg.bids_root,
+        check=False
+    )
+    in_files = dict()
+    in_files[f'raw_run-{run}'] = bids_path_in
+    _update_for_splits(in_files, f'raw_run-{run}', single=True)
+    try:
+        fname = in_files[f'raw_run-{run}'].find_empty_room(
+            use_sidecar_only=True)
+    except (FileNotFoundError, AssertionError):  # not downloaded as part of ds
+        return in_files
+    if fname is not None:
+        # TODO: We should include the sidecar here...
+        pass
+    else:
+        # TODO: Add all empty-room files that will be traversed by MNE-BIDS.
+        # For this, we need to refactor MNE-BIDS to get a list of possible
+        # empty-room matches.
+        pass
+    return in_files
+
+
+@failsafe_run(script_path=__file__,
+              get_input_fnames=get_input_fnames_find_empty_room)
+def find_empty_room(*, subject, session, run, in_files, cfg):
+    raw_path = in_files.pop(f'raw_run-{run}')
+    try:
+        fname = raw_path.find_empty_room(use_sidecar_only=True)
+    except (FileNotFoundError, AssertionError):
+        fname = ''
+    if fname is None:
+        # sidecar is very fast and checking all can be slow (seconds), so only
+        # log when actually looking through files
+        msg = (
+            f"Nearest-date matching {len(in_files)} empty-room files")
+        logger.info(**gen_log_kwargs(
+            message=msg, subject=subject, session=session, run=run))
+        try:
+            fname = raw_path.find_empty_room()
+        except (ValueError,  # non-MEG data
+                AssertionError,  # MNE-BIDS check assert exists()
+                FileNotFoundError):  # MNE-BIDS PR-1080 exists()
+            fname = None
+        in_files.clear()  # MNE-BIDS find_empty_room should have looked at all
+    elif fname == '':
+        fname = None  # not downloaded
+    out_files = dict()
+    out_files['empty_room_match'] = _empty_room_match_path(raw_path, cfg)
+    _write_json(out_files['empty_room_match'], dict(fname=fname))
+    return out_files
+
+
+def get_config(
+) -> SimpleNamespace:
+    cfg = SimpleNamespace(
+        proc=config.proc,
+        task=config.get_task(),
+        datatype=config.get_datatype(),
+        acq=config.acq,
+        rec=config.rec,
+        space=config.space,
+        bids_root=config.get_bids_root(),
+        deriv_root=config.deriv_root,
+    )
+    return cfg
+
+
+def main():
+    """Run find_empty_room."""
+    if not config.process_empty_room:
+        msg = 'Skipping, process_empty_room is set to False …'
+        logger.info(**gen_log_kwargs(message=msg, emoji='skip'))
+        return
+    # This will be I/O bound if the sidecar is not complete, so let's not run
+    # in parallel.
+    logs = list()
+    for subject in config.get_subjects():
+        if config.use_maxwell_filter:
+            run = config.mf_reference_run
+        else:
+            run = config.get_runs(subject=subject)[0]
+        logs.append(find_empty_room(
+            cfg=get_config(),
+            subject=subject,
+            session=config.get_sessions()[0],
+            run=run,
+        ))
+    config.save_logs(logs)
+
+
+if __name__ == '__main__':
+    main()

--- a/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
+++ b/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
@@ -69,6 +69,8 @@ def find_empty_room(*, subject, session, run, in_files, cfg):
         in_files.clear()  # MNE-BIDS find_empty_room should have looked at all
     elif fname == '':
         fname = None  # not downloaded, or EEG data
+    elif not fname.fpath.exists():
+        fname = None  # path found by sidecar but does not exist
     out_files = dict()
     out_files['empty_room_match'] = _empty_room_match_path(raw_path, cfg)
     _write_json(out_files['empty_room_match'], dict(fname=fname))
@@ -94,6 +96,10 @@ def main():
     """Run find_empty_room."""
     if not config.process_empty_room:
         msg = 'Skipping, process_empty_room is set to False …'
+        logger.info(**gen_log_kwargs(message=msg, emoji='skip'))
+        return
+    if config.get_datatype() != 'meg':
+        msg = 'Skipping, empty-room data only relevant for MEG …'
         logger.info(**gen_log_kwargs(message=msg, emoji='skip'))
         return
     # This will be I/O bound if the sidecar is not complete, so let's not run

--- a/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
+++ b/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
@@ -32,7 +32,7 @@ def get_input_fnames_find_empty_room(*, subject, session, run, cfg):
     try:
         fname = in_files[f'raw_run-{run}'].find_empty_room(
             use_sidecar_only=True)
-    except (FileNotFoundError, AssertionError):  # not downloaded as part of ds
+    except (FileNotFoundError, AssertionError, ValueError):
         return in_files
     if fname is not None:
         # TODO: We should include the sidecar here...
@@ -51,7 +51,7 @@ def find_empty_room(*, subject, session, run, in_files, cfg):
     raw_path = in_files.pop(f'raw_run-{run}')
     try:
         fname = raw_path.find_empty_room(use_sidecar_only=True)
-    except (FileNotFoundError, AssertionError):
+    except (FileNotFoundError, AssertionError, ValueError):
         fname = ''
     if fname is None:
         # sidecar is very fast and checking all can be slow (seconds), so only
@@ -68,7 +68,7 @@ def find_empty_room(*, subject, session, run, in_files, cfg):
             fname = None
         in_files.clear()  # MNE-BIDS find_empty_room should have looked at all
     elif fname == '':
-        fname = None  # not downloaded
+        fname = None  # not downloaded, or EEG data
     out_files = dict()
     out_files['empty_room_match'] = _empty_room_match_path(raw_path, cfg)
     _write_json(out_files['empty_room_match'], dict(fname=fname))

--- a/mne_bids_pipeline/scripts/init/__init__.py
+++ b/mne_bids_pipeline/scripts/init/__init__.py
@@ -1,5 +1,9 @@
-"""Filesystem initialization."""
+"""Filesystem initialization and dataset inspection."""
 
 from . import _00_init_derivatives_dir
+from . import _01_find_empty_room
 
-SCRIPTS = (_00_init_derivatives_dir,)
+SCRIPTS = (
+    _00_init_derivatives_dir,
+    _01_find_empty_room,
+)

--- a/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
@@ -15,13 +15,12 @@ The function loads machine-specific calibration files.
 """
 
 import itertools
-from pathlib import Path
 from typing import Optional
 from types import SimpleNamespace
 
 import numpy as np
 import mne
-from mne_bids import BIDSPath, read_raw_bids
+from mne_bids import BIDSPath, read_raw_bids, get_bids_path_from_fname
 
 import config
 from config import (gen_log_kwargs, failsafe_run, _script_path,
@@ -73,8 +72,7 @@ def get_input_fnames_maxwell_filter(**kwargs):
             raw_noise = _read_json(
                 _empty_room_match_path(bids_path_in, cfg))['fname']
             if raw_noise is not None:
-                raw_noise = Path(raw_noise)
-                assert raw_noise.exists()  # guaranteed by match step
+                raw_noise = get_bids_path_from_fname(raw_noise)
                 in_files["raw_noise"] = raw_noise
 
     in_files["raw_ref_run"] = ref_bids_path

--- a/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
@@ -68,7 +68,7 @@ def get_input_fnames_maxwell_filter(**kwargs):
             raw_rest = bids_path_in.copy().update(task="rest")
             if raw_rest.fpath.exists():
                 in_files["raw_rest"] = raw_rest
-        if cfg.process_empty_room:
+        if cfg.process_empty_room and cfg.datatype == 'meg':
             raw_noise = _read_json(
                 _empty_room_match_path(bids_path_in, cfg))['fname']
             if raw_noise is not None:

--- a/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_01_maxfilter.py
@@ -15,7 +15,6 @@ The function loads machine-specific calibration files.
 """
 
 import itertools
-import logging
 from pathlib import Path
 from typing import Optional
 from types import SimpleNamespace
@@ -30,9 +29,8 @@ from config import (gen_log_kwargs, failsafe_run, _script_path,
                     _update_for_splits)
 from config import parallel_func
 
+from ..._logging import logger
 from ..._io import _empty_room_match_path, _read_json
-
-logger = logging.getLogger('mne-bids-pipeline')
 
 
 def get_input_fnames_maxwell_filter(**kwargs):

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -16,7 +16,6 @@ If config.interactive = True plots raw data and power spectral density.
 
 import sys
 import itertools
-import logging
 
 import numpy as np
 from typing import Optional, Union

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -35,8 +35,8 @@ from config import (gen_log_kwargs, failsafe_run,
                     _update_for_splits)
 from config import parallel_func
 
-
-logger = logging.getLogger('mne-bids-pipeline')
+from ..._io import _read_json, _empty_room_match_path
+from ..._logging import logger
 
 
 def get_input_fnames_frequency_filter(**kwargs):
@@ -96,13 +96,8 @@ def get_input_fnames_frequency_filter(**kwargs):
                     raw_fname = bids_path_in.copy().update(
                         run=None, task=task)
                 else:
-                    try:
-                        raw_fname = \
-                            in_files[f'raw_run-{run}'].find_empty_room()
-                    except (ValueError,  # non-MEG data
-                            AssertionError,  # MNE-BIDS check assert exists()
-                            FileNotFoundError):  # MNE-BIDS PR-1080 exists()
-                        raw_fname = None
+                    raw_fname = _read_json(
+                        _empty_room_match_path(bids_path_in, cfg))['fname']
             if raw_fname is None:
                 continue
             in_files[key] = raw_fname

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -26,7 +26,7 @@ else:
 from types import SimpleNamespace
 
 import mne
-from mne_bids import BIDSPath
+from mne_bids import BIDSPath, get_bids_path_from_fname
 
 import config
 from config import (gen_log_kwargs, failsafe_run,
@@ -97,6 +97,8 @@ def get_input_fnames_frequency_filter(**kwargs):
                 else:
                     raw_fname = _read_json(
                         _empty_room_match_path(bids_path_in, cfg))['fname']
+                    if raw_fname is not None:
+                        raw_fname = get_bids_path_from_fname(raw_fname)
             if raw_fname is None:
                 continue
             in_files[key] = raw_fname

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -81,7 +81,7 @@ def get_input_fnames_frequency_filter(**kwargs):
     if run == cfg.runs[0]:
         do = dict(
             rest=cfg.process_rest and not cfg.task_is_rest,
-            noise=cfg.process_empty_room,
+            noise=cfg.process_empty_room and cfg.datatype == 'meg',
         )
         for task in ('rest', 'noise'):
             if not do[task]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tests = [
     "jinja2",
     "black",  # function signature formatting
     "livereload",
-    "openneuro-py @ git+https://github.com/larsoner/openneuro-py@iterate#egg=openneuro-py",
+    "openneuro-py",
     "httpx >= 0.20",
     "tqdm",
     "Pygments",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tests = [
     "jinja2",
     "black",  # function signature formatting
     "livereload",
-    "openneuro-py @ https://api.github.com/repos/larsoner/openneuro-py/zipball/iterate",
+    "openneuro-py @ git+https://github.com/larsoner/openneuro-py/tree/iterate",
     "httpx >= 0.20",
     "tqdm",
     "Pygments",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tests = [
     "jinja2",
     "black",  # function signature formatting
     "livereload",
-    "openneuro-py @ git+https://github.com/larsoner/openneuro-py/tree/iterate",
+    "openneuro-py @ git+https://github.com/larsoner/openneuro-py@iterate",
     "httpx >= 0.20",
     "tqdm",
     "Pygments",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tests = [
     "jinja2",
     "black",  # function signature formatting
     "livereload",
-    "openneuro-py @ git+https://github.com/larsoner/openneuro-py@iterate",
+    "openneuro-py @ git+https://github.com/larsoner/openneuro-py@iterate#egg=openneuro-py",
     "httpx >= 0.20",
     "tqdm",
     "Pygments",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tests = [
     "jinja2",
     "black",  # function signature formatting
     "livereload",
-    "openneuro-py",
+    "openneuro-py >= 2022.2.0",
     "httpx >= 0.20",
     "tqdm",
     "Pygments",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tests = [
     "jinja2",
     "black",  # function signature formatting
     "livereload",
-    "openneuro-py",
+    "openneuro-py @ https://api.github.com/repos/larsoner/openneuro-py/zipball/iterate",
     "httpx >= 0.20",
     "tqdm",
     "Pygments",


### PR DESCRIPTION
Not sure if a `changelog.md` is really necessary here since this is mostly for internal account purposes.

Also tests https://github.com/hoechenberger/openneuro-py/pull/75 implicitly. Locally I actually get some failures with `ds000248` when downloading the dataset, I wonder if something is broken. We'll see if CircleCI has the same problem...

Eventually we'll want to add the set of empty-room files MNE-BIDS will look at for empty-room files, but that will require refactoring MNE-BIDS a bit. So for now let's assume that users have a complete dataset (if they want one) from the beginning.

Closes #629