### PR TITLE
BUG: Fix bug with oversubscription in ICA on M1

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -388,3 +388,5 @@ authors:
   ({{ gh(606) }} by {{ authors.larsoner }})
 - Fix bug where only the first run was used to compute SSP
   ({{ gh(607) }} by {{ authors.larsoner }})
+- Fix bug with CPU oversubscription when using the Dask backend on macOS M1
+  ({{ gh(638) }} by {{ authors.larsoner }})

--- a/mne_bids_pipeline/run.py
+++ b/mne_bids_pipeline/run.py
@@ -331,6 +331,10 @@ def process(
 
 
 def main():
+    # Fire does not seem to detect a "--help" in all locations, so let's do it
+    # manually.
+    if '--help' in sys.argv or '-h' in sys.argv:
+        sys.argv = sys.argv[:1] + ['--help']
     fire.Fire(process)
 
 

--- a/mne_bids_pipeline/scripts/preprocessing/_04a_run_ica.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_04a_run_ica.py
@@ -15,6 +15,7 @@ import itertools
 from typing import List, Optional, Iterable, Tuple
 from types import SimpleNamespace
 
+from packaging.version import Version
 import pandas as pd
 import numpy as np
 import threadpoolctl
@@ -268,9 +269,11 @@ def run_ica(*, cfg, subject, session, in_files):
         processing='ica+components', suffix='report', extension='.html')
     del bids_basename
 
-    # Prevent oversubscription of CPUs in dask on M1 (probably a dask bug)
+    # Prevent oversubscription of CPUs in dask on M1 on older dask
     if cfg.parallel_backend == 'dask':
-        threadpoolctl.threadpool_limits(limits=1, user_api='openmp')
+        import dask
+        if Version(dask.__version__) < Version('2022.10.0'):
+            threadpoolctl.threadpool_limits(limits=1, user_api='openmp')
 
     # Generate a list of raw data paths (i.e., paths of individual runs)
     # we want to create epochs from.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "importlib_metadata; python_version < '3.8'",
     "psutil",  # for joblib
     "joblib >= 0.14",
+    "threadpoolctl",
     "dask[distributed]",
     "jupyter-server-proxy",  # to have dask and jupyter working together
     "scikit-learn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "typing_extensions; python_version < '3.8'",
     "importlib_metadata; python_version < '3.8'",
     "psutil",  # for joblib
+    "packaging",
     "joblib >= 0.14",
     "threadpoolctl",
     "dask[distributed]",


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

Fixes the oversubscription problem on my machine. I opened https://github.com/dask/dask/issues/9588 for dask. Until they fix it (if they ever do), we can improve things. This code:
```
$ time mne_bids_pipeline --config mne_bids_pipeline/tests/configs/config_ERP_CORE.py --task ERN --steps=preprocessing/_04a_run --cache=0
```
now decreases from 3m17.387s on `main` to 1m7.732s on this PR. I checked, and there seems to be no need to do this for `loky` backend because the `inner_num_threads` must set it properly in `joblib` (or in `sklearn`, not sure).

Also fixes a bug where `--help` could only be detected by `fire.Fire` when it was the only argument. Now if it appears anywhere in the arg list the `--help` is shown.

Closes #626 