### PR TITLE
ENH: Show progress for fitting

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -198,6 +198,8 @@ authors:
    (CSP).
    ({{ gh(625) }} by {{ authors.crsegerie }}, {{ authors.agramfort }},
     {{ authors.hoechenberger }}, and {{ authors.larsoner }})
+- Add progress bar for time-by-time decoding
+  ({{ gh(647) by {{ authors.larsoner }})
 
 ### Behavior changes
 


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

Closes #570

Unfortunately we can't really get this to work for `dask` -- workers can't write to the host to give updates, and the `memmap` approach that works for joblib does not appear to work for dask -- so there no progress bar is shown. The alternative would be to show a progress bar that doesn't update at all, which seems worse than not showing one in the first place.

Locally if I comment out the `parallel_backend = 'dask'` and use the bugfix branch https://github.com/mne-tools/mne-python/pull/11311, then I get nice updates:

https://user-images.githubusercontent.com/2365790/200845655-80dfae6d-698a-4b6c-938f-5638db749475.mp4


