### PR TITLE
MAINT: Simplify by removing fire

### DIFF
--- a/mne_bids_pipeline/run.py
+++ b/mne_bids_pipeline/run.py
@@ -155,7 +155,8 @@ def _get_script_modules(
 
 
 def main():
-    parser = optparse.OptionParser()
+    from . import __version__
+    parser = optparse.OptionParser(version=f'%prog {__version__}')
     parser.add_option(
         '-c', '--config', dest='config', default=None, metavar='FILE',
         help='The path of the pipeline configuration file to use.')

--- a/mne_bids_pipeline/scripts/report/_01_make_reports.py
+++ b/mne_bids_pipeline/scripts/report/_01_make_reports.py
@@ -1375,13 +1375,17 @@ def run_report(
 
 def add_event_counts(*,
                      cfg,
+                     subject: Optional[str],
                      session: Optional[str],
                      report: mne.Report) -> None:
     try:
         df_events = count_events(BIDSPath(root=cfg.bids_root,
                                           session=session))
     except ValueError:
-        logger.warning('Could not read events.')
+        msg = 'Could not read events.'
+        logger.warning(
+            **gen_log_kwargs(message=msg, subject=subject, session=session)
+        )
         df_events = None
 
     if df_events is not None:
@@ -1475,7 +1479,7 @@ def run_report_average(*, cfg, subject: str, session: str) -> None:
     #
     # Add event stats.
     #
-    add_event_counts(cfg=cfg, report=report, session=session)
+    add_event_counts(cfg=cfg, report=report, subject=subject, session=session)
 
     #######################################################################
     #

--- a/mne_bids_pipeline/tests/run_tests.py
+++ b/mne_bids_pipeline/tests/run_tests.py
@@ -189,9 +189,8 @@ def run_tests(test_suite, *, download, debug, cache):
             f'--steps={",".join(steps)}',
             f'--task={task}' if task else '',
             f'--n_jobs={n_jobs}' if n_jobs else '',
-            '--debug=1' if debug else '',
-            '--cache=0' if not cache else '',
-            '--interactive=0'
+            '--debug' if debug else '',
+            '--no-cache' if not cache else '',
         ]
         command = [x for x in command if x != '']  # Eliminate "empty" items
         subprocess.check_call(command)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "json_tricks",
     "coloredlogs",
     "python-picard",
-    "fire",
     "qtpy",
     "pyvista",
     "pyvistaqt",


### PR DESCRIPTION
This PR proposes to remove `fire` in support of `optparse`. `Fire` has the advantage of automatically turning a function into a command-line util (neat magic!), but I think it comes with several problematic deficiencies:

1. `-h` and `--help` are not autodetected, we needed to work around it.
2. Extra/wrong arguments/switches are not detected properly, we needed to work around it.
3. We have to do a bunch of `str` mangling to deal with the fact that Fire converts stuff like `--subject=123` into an `int`, `optparse` makes this stuff explicit
4. It does not support `store_true`-style switches like just doing `--interactive` to enable interactive mode -- you have to pass `--interactive=1` which is bad/non-standard Unix command-line interfacing
5. `Fire` is nowhere near as standard as `optparse`, so it takes some time/effort to understand what it's doing, and fix it when it's doing something wrong.

This PR fixes all of these issues by just using `optparse`. The result is one fewer dependency, and more deletions (-93) than insertions (+70) to get there. It also adds some advantages that we get immediately from `optparse`, like making it easy to provide the config as an argument instead of as `--config`, so now you can do `mne_bids_pipeline whatever_config.py` directly (just like we do with `mne_browse_raw --fif file.fif` and `mne_browse_raw file.fif`), which I've implemented here already.