### PR TITLE
MAINT: Remove env vars

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -290,6 +290,9 @@ authors:
   [`config.process_empty_room = True`][mne_bids_pipeline._config.process_empty_room] and
   [`config.process_rest = True`][mne_bids_pipeline._config.process_rest]
   ({{ gh(633) }} by {{ authors.larsoner }})
+- Environment variables are no longer used to control execution and variables,
+  use command-line switches instead
+  ({{ gh(663) }} by {{ authors.larsoner}} )
 
 ### Code health
 

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -1,3 +1,4 @@
+import copy
 import importlib
 import os
 import pathlib
@@ -23,9 +24,11 @@ def _import_config(
     # Get the default
     from . import _config
     # Don't use _config itself as it's mutable -- make a new object
+    # with deepcopies of vals (keys are immutable strings so no need to copy)
+    ignore_keys = {'mne', 'np'}  # avoid modules
     config = SimpleNamespace(
-        **{key: val for key, val in _config.__dict__.items()
-           if not key.startswith('__')})
+        **{key: copy.deepcopy(val) for key, val in _config.__dict__.items()
+           if not (key.startswith('__') or key in ignore_keys)})
 
     # Update with user config
     _update_with_user_config(

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -122,7 +122,7 @@ def _update_with_user_config(
                 'root folder of your BIDS dataset')
         config.bids_root = root
     config.bids_root = \
-        pathlib.Path(config.bids_root).expanduser().resolve(strict=True)
+        pathlib.Path(config.bids_root).expanduser().resolve()
     if config.deriv_root is None:
         config.deriv_root = \
             config.bids_root / 'derivatives' / config.PIPELINE_NAME
@@ -156,6 +156,8 @@ def _check_config(config: SimpleNamespace) -> None:
     # https://github.com/mne-tools/mne-bids-pipeline/issues/646
     _check_option(
         'config.parallel_backend', config.parallel_backend, ('dask', 'loky'))
+
+    config.bids_root.resolve(strict=True)
 
     if (config.use_maxwell_filter and
             len(set(

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -1,32 +1,73 @@
-from types import ModuleType
+import importlib
 import os
 import pathlib
-import importlib
+from types import SimpleNamespace
+from typing import Optional
 
 import matplotlib
 import mne
-from mne.utils import _check_option
+from mne.utils import _check_option, _validate_type
 
 from ._logging import logger, gen_log_kwargs
+from ._typing import PathLike
 
 
-def _import_config(*, check: bool = True, log: bool = False) -> ModuleType:
+def _import_config(
+    *,
+    config_path: Optional[PathLike],
+    overrides: Optional[SimpleNamespace] = None,
+    check: bool = True,
+    log: bool = False,
+) -> SimpleNamespace:
     """Import the default config and the user's config."""
     # Get the default
-    from . import _config as config
+    from . import _config
+    # Don't use _config itself as it's mutable -- make a new object
+    config = SimpleNamespace(
+        **{key: val for key, val in _config.__dict__.items()
+           if not key.startswith('__')})
+
     # Update with user config
-    _update_with_user_config(config=config, log=log)
+    _update_with_user_config(
+        config=config,
+        config_path=config_path,
+        overrides=overrides,
+        log=log,
+    )
     # Check it
     if check:
         _check_config(config)
     # Take some standard actions
     mne.set_log_level(verbose=config.mne_log_level.upper())
+
+    # Take variables out of config (which affects the pipeline outputs) and
+    # put into config.exec_params (which affect the pipeline execution methods,
+    # but not the outputs)
+    keys = (
+        # Parallelization
+        'N_JOBS', 'parallel_backend',
+        'dask_temp_dir', 'dask_worker_memory_limit', 'dask_open_dashboard',
+        # Interaction
+        'on_error', 'interactive',
+        # Caching
+        'memory_location', 'memory_verbose', 'memory_file_method',
+        # Misc
+        'deriv_root',
+    )
+    in_both = {'deriv_root', 'interactive'}
+    exec_params = SimpleNamespace(**{k: getattr(config, k) for k in keys})
+    for k in keys:
+        if k not in in_both:
+            delattr(config, k)
+    config.exec_params = exec_params
     return config
 
 
 def _update_with_user_config(
     *,
-    config: ModuleType,  # modified in-place
+    config: SimpleNamespace,  # modified in-place
+    config_path: Optional[PathLike],
+    overrides: Optional[SimpleNamespace],
     log: bool = False,
 ) -> None:
     # 1. Basics and hidden vars
@@ -38,19 +79,13 @@ def _update_with_user_config(
     config._epochs_split_size = '2GB'
 
     # 2. User config
-    if "MNE_BIDS_STUDY_CONFIG" in os.environ:
-        cfg_path = pathlib.Path(os.environ['MNE_BIDS_STUDY_CONFIG'])
-
-        if not cfg_path.exists():
-            raise ValueError(
-                'The custom configuration file specified in the '
-                'MNE_BIDS_STUDY_CONFIG environment variable could not be '
-                f'found: {cfg_path}')
-
+    if config_path is not None:
+        config_path = pathlib.Path(
+            config_path).expanduser().resolve(strict=True)
         # Import configuration from an arbitrary path without having to fiddle
         # with `sys.path`.
         spec = importlib.util.spec_from_file_location(
-            name='custom_config', location=cfg_path)
+            name='custom_config', location=config_path)
         custom_cfg = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(custom_cfg)
         for key in dir(custom_cfg):
@@ -58,10 +93,39 @@ def _update_with_user_config(
                 val = getattr(custom_cfg, key)
                 logger.debug('Overwriting: %s -> %s' % (key, val))
                 setattr(config, key, val)
+    config.config_path = config_path
 
-    # 3. Overrides via command-line switches (via env vars)
-    config.interactive = bool(int(os.getenv(
-        'MNE_BIDS_STUDY_INTERACTIVE', config.interactive)))
+    # 3. Overrides via command-line switches
+    overrides = overrides or SimpleNamespace()
+    for name in dir(overrides):
+        if not name.startswith('__'):
+            val = getattr(overrides, name)
+            if log:
+                msg = f'Overridding config.{name} = {repr(val)}'
+                logger.info(
+                    **gen_log_kwargs(
+                        message=msg, step='', emoji='override', box='╶╴'
+                    )
+                )
+            setattr(config, name, val)
+
+    # 4. Env vars and other triaging
+    if not config.bids_root:
+        root = os.getenv('BIDS_ROOT', None)
+        if root is None:
+            raise ValueError(
+                'You need to specify `bids_root` in your configuration, or '
+                'define an environment variable `BIDS_ROOT` pointing to the '
+                'root folder of your BIDS dataset')
+        config.bids_root = root
+    config.bids_root = \
+        pathlib.Path(config.bids_root).expanduser().resolve(strict=True)
+    if config.deriv_root is None:
+        config.deriv_root = \
+            config.bids_root / 'derivatives' / config.PIPELINE_NAME
+    config.deriv_root = pathlib.Path(config.deriv_root).expanduser().resolve()
+
+    # 5. Consistency
     log_kwargs = dict(emoji='override', box='  ', step='')
     if config.interactive:
         if log and config.on_error != 'debug':
@@ -70,7 +134,6 @@ def _update_with_user_config(
         config.on_error = 'debug'
     else:
         matplotlib.use('Agg')  # do not open any window  # noqa
-        config.on_error = os.getenv('MNE_BIDS_STUDY_ON_ERROR', config.on_error)
     if config.on_error == 'debug':
         if log and config.N_JOBS != 1:
             msg = 'Setting config.N_JOBS=1 because config.on_error="debug"'
@@ -84,11 +147,8 @@ def _update_with_user_config(
             logger.info(**gen_log_kwargs(message=msg, **log_kwargs))
         config.parallel_backend = 'loky'
 
-    if os.getenv('MNE_BIDS_STUDY_USE_CACHE', '') == '0':
-        config.memory_location = False
 
-
-def _check_config(config: ModuleType) -> None:
+def _check_config(config: SimpleNamespace) -> None:
     # TODO: Use pydantic to do these validations
     # https://github.com/mne-tools/mne-bids-pipeline/issues/646
     _check_option(
@@ -212,3 +272,5 @@ def _check_config(config: ModuleType) -> None:
     _check_option(
         'config.on_rename_missing_events', config.on_rename_missing_events,
         ('raise', 'warn', 'ignore'))
+
+    _validate_type(config.N_JOBS, int, 'N_JOBS')

--- a/mne_bids_pipeline/_config_template.py
+++ b/mne_bids_pipeline/_config_template.py
@@ -34,7 +34,7 @@ def create_template_config(
         f'Successfully created template configuration file at: '
         f'{target_path}'
     )
-    logger.info(**gen_log_kwargs(message=message, emoji='✅'))
+    logger.info(**gen_log_kwargs(message=message, emoji='✅', step=''))
 
     message = 'Please edit the file before running the pipeline.'
-    logger.info(**gen_log_kwargs(message=message, emoji='💡'))
+    logger.info(**gen_log_kwargs(message=message, emoji='💡', step=''))

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -233,19 +233,18 @@ def get_mf_reference_run(config: SimpleNamespace) -> str:
 
 
 def get_task(config: SimpleNamespace) -> Optional[str]:
-    task = None
+    task = config.task
+    if task:
+        return task
     _valid_tasks = _get_entity_vals_cached(
         root=config.bids_root,
         entity_key='task',
         ignore_datatypes=_get_ignore_datatypes(config),
     )
-    if not task:
-        if not _valid_tasks:
-            return None
-        else:
-            return _valid_tasks[0]
+    if not _valid_tasks:
+        return None
     else:
-        return task
+        return _valid_tasks[0]
 
 
 def get_channels_to_analyze(

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -120,8 +120,7 @@ def make_epochs(
         except pandas.core.computation.ops.UndefinedVariableError:
             msg = (f'Metadata query failed to select any columns: '
                    f'{metadata_query}')
-            logger.warn(**gen_log_kwargs(message=msg, subject=subject,
-                                         session=session))
+            logger.warn(**gen_log_kwargs(message=msg))
             return epochs
 
         idx_drop = epochs.metadata.index[~idx_keep]
@@ -184,9 +183,7 @@ def _rename_events_func(
                f'they are not present in the BIDS input data:\n'
                f'{", ".join(sorted(list(events_not_in_raw)))}')
         if cfg.on_rename_missing_events == 'warn':
-            logger.warning(
-                **gen_log_kwargs(message=msg, subject=subject, session=session)
-            )
+            logger.warning(**gen_log_kwargs(message=msg))
         elif cfg.on_rename_missing_events == 'raise':
             raise ValueError(msg)
         else:
@@ -195,15 +192,11 @@ def _rename_events_func(
 
     # Do the actual event renaming.
     msg = 'Renaming events …'
-    logger.info(**gen_log_kwargs(
-        message=msg, subject=subject, session=session, run=run)
-    )
+    logger.info(**gen_log_kwargs(message=msg))
     descriptions = list(raw.annotations.description)
     for old_event_name, new_event_name in cfg.rename_events.items():
         msg = f'… {old_event_name} -> {new_event_name}'
-        logger.info(**gen_log_kwargs(
-            message=msg, subject=subject, session=session, run=run)
-        )
+        logger.info(**gen_log_kwargs(message=msg))
         for idx, description in enumerate(descriptions.copy()):
             if description == old_event_name:
                 descriptions[idx] = new_event_name
@@ -237,8 +230,7 @@ def _find_bad_channels(
         msg = ('Finding flat channels, and noisy channels using '
                'Maxwell filtering.')
 
-    logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                 session=session, run=run))
+    logger.info(**gen_log_kwargs(message=msg))
 
     bids_path = BIDSPath(subject=subject,
                          session=session,
@@ -278,9 +270,7 @@ def _find_bad_channels(
                    f'{", ".join(auto_flat_chs)}')
         else:
             msg = 'Found no flat channels.'
-        logger.info(**gen_log_kwargs(
-            message=msg, subject=subject, session=session, run=run)
-        )
+        logger.info(**gen_log_kwargs(message=msg))
         bads.extend(auto_flat_chs)
 
     if cfg.find_noisy_channels_meg:
@@ -290,17 +280,13 @@ def _find_bad_channels(
         else:
             msg = 'Found no noisy channels.'
 
-        logger.info(**gen_log_kwargs(
-            message=msg, subject=subject, session=session, run=run)
-        )
+        logger.info(**gen_log_kwargs(message=msg))
         bads.extend(auto_noisy_chs)
 
     bads = sorted(set(bads))
     raw.info['bads'] = bads
     msg = f'Marked {len(raw.info["bads"])} channels as bad.'
-    logger.info(**gen_log_kwargs(
-        message=msg, subject=subject, session=session, run=run)
-    )
+    logger.info(**gen_log_kwargs(message=msg))
 
     if cfg.find_noisy_channels_meg:
         auto_scores_fname = bids_path.copy().update(
@@ -392,8 +378,7 @@ def _drop_channels_func(
     """
     if cfg.drop_channels:
         msg = f'Dropping channels: {", ".join(cfg.drop_channels)}'
-        logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                     session=session))
+        logger.info(**gen_log_kwargs(message=msg))
         raw.drop_channels(cfg.drop_channels, on_missing='warn')
 
 
@@ -410,14 +395,10 @@ def _create_bipolar_channels(
     """
     if cfg.ch_types == ['eeg'] and cfg.eeg_bipolar_channels:
         msg = 'Creating bipolar channels …'
-        logger.info(**gen_log_kwargs(
-            message=msg, subject=subject, session=session, run=run)
-        )
+        logger.info(**gen_log_kwargs(message=msg))
         for ch_name, (anode, cathode) in cfg.eeg_bipolar_channels.items():
             msg = f'    {anode} – {cathode} -> {ch_name}'
-            logger.info(**gen_log_kwargs(
-                message=msg, subject=subject, session=session, run=run)
-            )
+            logger.info(**gen_log_kwargs(message=msg))
             mne.set_bipolar_reference(raw, anode=anode, cathode=cathode,
                                       ch_name=ch_name, drop_refs=False,
                                       copy=False)
@@ -431,15 +412,11 @@ def _create_bipolar_channels(
                 any([eog_ch_name in cfg.eeg_bipolar_channels
                      for eog_ch_name in cfg.eog_channels])):
             msg = 'Setting channel type of new bipolar EOG channel(s) …'
-            logger.info(**gen_log_kwargs(
-                message=msg, subject=subject, session=session, run=run)
-            )
+            logger.info(**gen_log_kwargs(message=msg))
         for eog_ch_name in cfg.eog_channels:
             if eog_ch_name in cfg.eeg_bipolar_channels:
                 msg = f'    {eog_ch_name} -> eog'
-                logger.info(**gen_log_kwargs(
-                    message=msg, subject=subject, session=session, run=run)
-                )
+                logger.info(**gen_log_kwargs(message=msg))
                 raw.set_channel_types({eog_ch_name: 'eog'})
 
 
@@ -461,9 +438,7 @@ def _set_eeg_montage(
     if cfg.datatype == 'eeg' and montage:
         msg = (f'Setting EEG channel locations to template montage: '
                f'{montage}.')
-        logger.info(**gen_log_kwargs(
-            message=msg, subject=subject, session=session, run=run)
-        )
+        logger.info(**gen_log_kwargs(message=msg))
         if not is_mne_montage:
             montage = mne.channels.make_standard_montage(montage_name)
         raw.set_montage(montage, match_case=False, on_missing='warn')
@@ -633,14 +608,12 @@ def _find_breaks_func(
 ) -> None:
     if not cfg.find_breaks:
         msg = 'Finding breaks has been disabled by the user.'
-        logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                     session=session, run=run))
+        logger.info(**gen_log_kwargs(message=msg))
         return
 
     msg = (f'Finding breaks with a minimum duration of '
            f'{cfg.min_break_duration} seconds.')
-    logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                 session=session, run=run))
+    logger.info(**gen_log_kwargs(message=msg))
 
     break_annots = mne.preprocessing.annotate_break(
         raw=raw,
@@ -651,7 +624,6 @@ def _find_breaks_func(
 
     msg = (f'Found and annotated '
            f'{len(break_annots) if break_annots else "no"} break periods.')
-    logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                 session=session, run=run))
+    logger.info(**gen_log_kwargs(message=msg))
 
     raw.set_annotations(raw.annotations + break_annots)  # add to existing

--- a/mne_bids_pipeline/_parallel.py
+++ b/mne_bids_pipeline/_parallel.py
@@ -6,11 +6,10 @@ from types import SimpleNamespace
 import joblib
 
 from ._logging import logger
-from ._config_utils import get_deriv_root
 
 
-def get_n_jobs(config: SimpleNamespace) -> int:
-    n_jobs = config.N_JOBS
+def get_n_jobs(*, exec_params: SimpleNamespace) -> int:
+    n_jobs = exec_params.N_JOBS
     if n_jobs < 0:
         n_cores = joblib.cpu_count()
         n_jobs = min(n_cores + n_jobs + 1, n_cores)
@@ -21,7 +20,7 @@ def get_n_jobs(config: SimpleNamespace) -> int:
 dask_client = None
 
 
-def setup_dask_client(config: SimpleNamespace) -> None:
+def setup_dask_client(*, exec_params: SimpleNamespace) -> None:
     global dask_client
 
     import dask
@@ -30,13 +29,13 @@ def setup_dask_client(config: SimpleNamespace) -> None:
     if dask_client is not None:
         return
 
-    n_workers = get_n_jobs(config)
+    n_workers = get_n_jobs(exec_params=exec_params)
     logger.info(f'👾 Initializing Dask client with {n_workers} workers …')
 
-    if config.dask_temp_dir is None:
-        this_dask_temp_dir = get_deriv_root(config) / ".dask-worker-space"
+    if exec_params.dask_temp_dir is None:
+        this_dask_temp_dir = exec_params.deriv_root / ".dask-worker-space"
     else:
-        this_dask_temp_dir = config.dask_temp_dir
+        this_dask_temp_dir = exec_params.dask_temp_dir
 
     logger.info(f'📂 Temporary directory is: {this_dask_temp_dir}')
     dask.config.set(
@@ -54,7 +53,7 @@ def setup_dask_client(config: SimpleNamespace) -> None:
         }
     )
     client = Client(  # noqa: F841
-        memory_limit=config.dask_worker_memory_limit,
+        memory_limit=exec_params.dask_worker_memory_limit,
         n_workers=n_workers,
         threads_per_worker=1,
         name='mne-bids-pipeline'
@@ -67,7 +66,7 @@ def setup_dask_client(config: SimpleNamespace) -> None:
         f'to monitor the workers.\n'
     )
 
-    if config.dask_open_dashboard:
+    if exec_params.dask_open_dashboard:
         import webbrowser
         webbrowser.open(url=dashboard_url, autoraise=True)
 
@@ -76,32 +75,37 @@ def setup_dask_client(config: SimpleNamespace) -> None:
 
 
 def get_parallel_backend_name(
-    config: SimpleNamespace
+    *,
+    exec_params: SimpleNamespace
 ) -> Literal['dask', 'loky']:
-    if config.parallel_backend == 'loky' or get_n_jobs(config) == 1:
+    if exec_params.parallel_backend == 'loky' or \
+            get_n_jobs(exec_params=exec_params) == 1:
         return 'loky'
-    elif config.parallel_backend == 'dask':
+    elif exec_params.parallel_backend == 'dask':
         # Disable interactive plotting backend
         import matplotlib
         matplotlib.use('Agg')
         return 'dask'
     else:
+        # TODO: Move to value validation step
         raise ValueError(
-            f'Unknown parallel backend: {config.parallel_backend}')
+            f'Unknown parallel backend: {exec_params.parallel_backend}')
 
 
-def get_parallel_backend(config: SimpleNamespace) -> joblib.parallel_backend:
+def get_parallel_backend(
+    exec_params: SimpleNamespace
+) -> joblib.parallel_backend:
     import joblib
 
-    backend = get_parallel_backend_name(config)
+    backend = get_parallel_backend_name(exec_params=exec_params)
     kwargs = {
-        'n_jobs': get_n_jobs(config)
+        'n_jobs': get_n_jobs(exec_params=exec_params)
     }
 
     if backend == "loky":
         kwargs['inner_max_num_threads'] = 1
     else:
-        setup_dask_client(config)
+        setup_dask_client(exec_params=exec_params)
 
     return joblib.parallel_backend(
         backend,
@@ -112,10 +116,10 @@ def get_parallel_backend(config: SimpleNamespace) -> joblib.parallel_backend:
 def parallel_func(
     func: Callable,
     *,
-    config: SimpleNamespace
+    exec_params: SimpleNamespace
 ):
-    if get_parallel_backend_name(config) == 'loky':
-        if get_n_jobs(config) == 1:
+    if get_parallel_backend_name(exec_params=exec_params) == 'loky':
+        if get_n_jobs(exec_params=exec_params) == 1:
             my_func = func
             parallel = list
         else:

--- a/mne_bids_pipeline/_reject.py
+++ b/mne_bids_pipeline/_reject.py
@@ -35,8 +35,7 @@ def _get_reject(
                 ch_types_autoreject.append('grad')
 
         msg = 'Generating rejection thresholds using autoreject …'
-        logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                     session=session))
+        logger.info(**gen_log_kwargs(message=msg))
         reject = autoreject.get_rejection_threshold(
             epochs=epochs,
             ch_types=ch_types_autoreject,

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -1008,7 +1008,7 @@ def add_csp_grand_average(
             mean_crossval_scores = results['mean_crossval_scores'].ravel()
             # t_vals = results['t_vals']
             clusters = results['clusters']
-            cluster_p_vals = results['cluster_p_vals'].squeeze()
+            cluster_p_vals = np.atleast_1d(results['cluster_p_vals'].squeeze())
             tmin = results['time_bin_edges'].ravel()
             tmin, tmax = tmin[:-1], tmin[1:]
             fmin = results['freq_bin_edges'].ravel()

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -1,5 +1,4 @@
 import contextlib
-import os
 import os.path as op
 from pathlib import Path
 from typing import Optional, List, Literal
@@ -28,14 +27,17 @@ def _open_report(
     *,
     cfg: SimpleNamespace,
     subject: str,
-    session: Optional[str]
+    session: Optional[str],
+    run: Optional[str] = None,
 ):
     fname_report = BIDSPath(
         subject=subject,
         session=session,
+        # Report is across all runs, but for logging purposes it's helpful
+        # to pass the run for gen_log_kwargs
+        run=None,
         task=cfg.task,
         acquisition=cfg.acq,
-        run=None,
         recording=cfg.rec,
         space=cfg.space,
         extension='.h5',
@@ -48,9 +50,7 @@ def _open_report(
     with FileLock(f'{fname_report}.lock'), _agg_backend():
         if not fname_report.is_file():
             msg = 'Initializing report HDF5 file'
-            logger.info(
-                **gen_log_kwargs(message=msg, subject=subject, session=session)
-            )
+            logger.info(**gen_log_kwargs(message=msg))
             report = _gen_empty_report(
                 cfg=cfg,
                 subject=subject,
@@ -59,17 +59,25 @@ def _open_report(
             report.save(fname_report)
         try:
             report = mne.open_report(fname_report)
-        except OSError as exc:
-            raise OSError(
+        except Exception as exc:
+            raise exc.__class__(
                 f'Could not open report HDF5 file:\n{fname_report}\n'
                 f'Got error:\n{exc}\nPerhaps you need to delete it?') from None
-        add_system_info(report)
         try:
             yield report
         finally:
+            try:
+                msg = 'Adding config and sys info to report'
+                logger.info(**gen_log_kwargs(message=msg))
+                _finalize(report=report, cfg=cfg)
+            except Exception:
+                pass
+            fname_report_html = fname_report.with_suffix('.html')
+            msg = f'Saving report: {fname_report_html}'
+            logger.info(**gen_log_kwargs(message=msg))
             report.save(fname_report, overwrite=True)
             report.save(
-                fname_report.with_suffix('.html'), overwrite=True,
+                fname_report_html, overwrite=True,
                 open_browser=False)
 
 
@@ -467,9 +475,7 @@ def add_event_counts(*,
                                           session=session))
     except ValueError:
         msg = 'Could not read events.'
-        logger.warning(
-            **gen_log_kwargs(message=msg, subject=subject, session=session)
-        )
+        logger.warning(**gen_log_kwargs(message=msg))
         df_events = None
 
     if df_events is not None:
@@ -498,22 +504,30 @@ def add_event_counts(*,
             report.add_custom_css(css=css)
 
 
-def add_system_info(report: mne.Report):
+def _finalize(*, report: mne.Report, cfg: SimpleNamespace):
     """Add system information and the pipeline configuration to the report."""
-    config_path = Path(os.environ['MNE_BIDS_STUDY_CONFIG'])
     # ensure they are always appended
     titles = ['Configuration file', 'System information']
     for title in titles:
         report.remove(title=title, remove_all=True)
     # No longer need replace=True in these
     report.add_code(
-        code=config_path,
+        code=cfg.config_path,
         title=titles[0],
         tags=('configuration',),
     )
     report.add_sys_info(
         title=titles[1],
     )
+    # Make our code sections take 50% of screen height
+    css = """
+div.accordion-body pre.my-0 code {
+    overflow-y: auto;
+    max-height: 50vh;
+ }
+"""
+    if css not in report.include:
+        report.add_custom_css(css=css)
 
 
 def _all_conditions(*, cfg):
@@ -528,9 +542,8 @@ def _all_conditions(*, cfg):
 def run_report_average_sensor(*, cfg, session: str) -> None:
     subject = 'average'
     msg = 'Generating grand average report …'
-    logger.info(
-        **gen_log_kwargs(message=msg, subject=subject, session=session)
-    )
+    logger.info(**gen_log_kwargs(message=msg))
+    assert matplotlib.get_backend() == 'agg', matplotlib.get_backend()
 
     evoked_fname = BIDSPath(
         subject=subject,
@@ -553,60 +566,63 @@ def run_report_average_sensor(*, cfg, session: str) -> None:
     if cfg.task is not None:
         title += f', task-{cfg.task}'
 
-    report = mne.Report(
-        title=title,
-        raw_psd=True
-    )
     evokeds = mne.read_evokeds(evoked_fname)
     for evoked in evokeds:
         _restrict_analyze_channels(evoked, cfg)
 
     conditions = _all_conditions(cfg=cfg)
+    with _open_report(cfg=cfg, subject=subject, session=session) as report:
 
-    #######################################################################
-    #
-    # Add event stats.
-    #
-    add_event_counts(cfg=cfg, report=report, subject=subject, session=session)
+        #######################################################################
+        #
+        # Add event stats.
+        #
+        add_event_counts(
+            cfg=cfg,
+            report=report,
+            subject=subject,
+            session=session,
+        )
 
-    #######################################################################
-    #
-    # Visualize evoked responses.
-    #
-    for condition, evoked in zip(conditions, evokeds):
-        if condition in cfg.conditions:
-            title = f'Average: {condition}'
-            tags = (
-                'evoked',
-                _sanitize_cond_tag(condition)
+        #######################################################################
+        #
+        # Visualize evoked responses.
+        #
+        for condition, evoked in zip(conditions, evokeds):
+            if condition in cfg.conditions:
+                title = f'Average: {condition}'
+                tags = (
+                    'evoked',
+                    _sanitize_cond_tag(condition)
+                )
+            else:  # It's a contrast of two conditions.
+                # XXX Will change once we process contrasts here too
+                continue
+
+            report.add_evokeds(
+                evokeds=evoked,
+                titles=title,
+                projs=False,
+                tags=tags,
+                n_time_points=cfg.report_evoked_n_time_points,
+                # captions=evoked.comment,  # TODO upstream
+                replace=True,
+                n_jobs=1,  # don't auto parallelize
             )
-        else:  # It's a contrast of two conditions.
-            # XXX Will change once we process contrasts here too
-            continue
 
-        report.add_evokeds(
-            evokeds=evoked,
-            titles=title,
-            projs=False,
-            tags=tags,
-            n_time_points=cfg.report_evoked_n_time_points,
-            # captions=evoked.comment,  # TODO upstream
-            replace=True,
-        )
+        #######################################################################
+        #
+        # Visualize decoding results.
+        #
+        if cfg.decode and cfg.decoding_contrasts:
+            add_decoding_grand_average(
+                session=session, cfg=cfg, report=report
+            )
 
-    #######################################################################
-    #
-    # Visualize decoding results.
-    #
-    if cfg.decode and cfg.decoding_contrasts:
-        add_decoding_grand_average(
-            session=session, cfg=cfg, report=report
-        )
-
-    if cfg.decode and cfg.decoding_csp:
-        add_csp_grand_average(
-            session=session, cfg=cfg, report=report
-        )
+        if cfg.decode and cfg.decoding_csp:
+            add_csp_grand_average(
+                session=session, cfg=cfg, report=report
+            )
 
 
 def run_report_average_source(*, cfg, session: str) -> None:

--- a/mne_bids_pipeline/scripts/freesurfer/_01_recon_all.py
+++ b/mne_bids_pipeline/scripts/freesurfer/_01_recon_all.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from mne.utils import run_subprocess
 
-from ..._config_utils import get_fs_subjects_dir, get_bids_root, get_subjects
+from ..._config_utils import get_fs_subjects_dir, get_subjects
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import parallel_func, get_parallel_backend
 
@@ -23,13 +23,13 @@ def run_recon(root_dir, subject, fs_bids_app, subjects_dir) -> None:
     if subj_dir.exists():
         msg = (f"Subject {subject} is already present. Please delete the "
                f"directory if you want to recompute.")
-        logger.info(**gen_log_kwargs(message=msg, subject=subject))
+        logger.info(**gen_log_kwargs(message=msg))
         return
     msg = (
         "Running recon-all on subject {subject}. This will take "
         "a LONG time – it's a good idea to let it run over night."
     )
-    logger.info(**gen_log_kwargs(message=msg, subject=subject))
+    logger.info(**gen_log_kwargs(message=msg))
 
     env = os.environ
     if 'FREESURFER_HOME' not in env:
@@ -77,12 +77,13 @@ def main(*, config) -> None:
 
     """  # noqa
     subjects = get_subjects(config)
-    root_dir = get_bids_root(config)
+    root_dir = config.bids_root
     subjects_dir = Path(get_fs_subjects_dir(config))
     subjects_dir.mkdir(parents=True, exist_ok=True)
 
-    with get_parallel_backend(config):
-        parallel, run_func = parallel_func(run_recon, config=config)
+    with get_parallel_backend(config.exec_params):
+        parallel, run_func = parallel_func(
+            run_recon, exec_params=config.exec_params)
         parallel(run_func(root_dir, subject, fs_bids_app, subjects_dir)
                  for subject in subjects)
 

--- a/mne_bids_pipeline/scripts/freesurfer/_02_coreg_surfaces.py
+++ b/mne_bids_pipeline/scripts/freesurfer/_02_coreg_surfaces.py
@@ -49,7 +49,7 @@ def make_coreg_surfaces(
 ) -> dict:
     """Create head surfaces for use with MNE-Python coregistration tools."""
     msg = 'Creating scalp surfaces for coregistration'
-    logger.info(**gen_log_kwargs(message=msg, subject=subject))
+    logger.info(**gen_log_kwargs(message=msg))
     in_files.pop('t1' if 't1' in in_files else 'seghead')
     mne.bem.make_scalp_surfaces(
         subject=cfg.fs_subject,
@@ -63,6 +63,7 @@ def make_coreg_surfaces(
 
 def get_config(*, config, subject) -> SimpleNamespace:
     cfg = SimpleNamespace(
+        exec_params=config.exec_params,
         subject=subject,
         fs_subject=get_fs_subject(config, subject),
         subjects_dir=get_fs_subjects_dir(config),
@@ -76,8 +77,9 @@ def main(*, config) -> None:
     if (Path(get_fs_subjects_dir(config)) / 'fsaverage').exists():
         subjects.append('fsaverage')
 
-    with get_parallel_backend(config):
-        parallel, run_func = parallel_func(make_coreg_surfaces, config=config)
+    with get_parallel_backend(config.exec_params):
+        parallel, run_func = parallel_func(
+            make_coreg_surfaces, exec_params=config.exec_params)
 
         parallel(
             run_func(

--- a/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
+++ b/mne_bids_pipeline/scripts/init/_01_find_empty_room.py
@@ -7,8 +7,7 @@ from mne.utils import _pl
 from mne_bids import BIDSPath
 
 from ..._config_utils import (
-    get_bids_root, get_datatype, get_task, get_sessions, get_subjects,
-    get_runs)
+    get_datatype, get_task, get_sessions, get_subjects, get_runs)
 from ..._io import _empty_room_match_path, _write_json
 from ..._logging import gen_log_kwargs, logger
 from ..._run import _update_for_splits, failsafe_run, save_logs
@@ -76,8 +75,7 @@ def find_empty_room(
         if len(in_files):  # MNE-BIDS < 0.12 missing get_empty_room_candidates
             ending = f'{len(in_files)} empty-room file{_pl(in_files)}'
         msg = f"Nearest-date matching {ending}"
-        logger.info(**gen_log_kwargs(
-            message=msg, subject=subject, session=session, run=run))
+        logger.info(**gen_log_kwargs(message=msg))
         try:
             fname = raw_path.find_empty_room()
         except (ValueError,  # non-MEG data
@@ -100,13 +98,14 @@ def get_config(
     config,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
+        exec_params=config.exec_params,
         proc=config.proc,
         task=get_task(config),
         datatype=get_datatype(config),
         acq=config.acq,
         rec=config.rec,
         space=config.space,
-        bids_root=get_bids_root(config),
+        bids_root=config.bids_root,
         deriv_root=config.deriv_root,
     )
     return cfg

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -360,6 +360,8 @@ def get_config(
         _raw_split_size=config._raw_split_size,
         config_path=config.config_path,
     )
+    if config.sessions == ['N170'] and config.task == 'ERN':
+        raise RuntimeError
     return cfg
 
 

--- a/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
+++ b/mne_bids_pipeline/scripts/preprocessing/_02_frequency_filter.py
@@ -14,8 +14,6 @@ To save space, the raw data can be resampled.
 If config.interactive = True plots raw data and power spectral density.
 """  # noqa: E501
 
-import itertools
-
 import numpy as np
 from typing import Optional, Union
 from types import SimpleNamespace
@@ -24,8 +22,8 @@ import mne
 from mne_bids import BIDSPath, get_bids_path_from_fname
 
 from ..._config_utils import (
-    get_sessions, get_runs, get_subjects, get_task, get_bids_root,
-    get_deriv_root, get_datatype, get_mf_reference_run,
+    get_sessions, get_runs, get_subjects, get_task, get_datatype,
+    get_mf_reference_run,
 )
 from ..._import_data import (
     import_experimental_data, import_er_data, import_rest_data)
@@ -133,8 +131,7 @@ def filter(
     else:
         msg = (f'Not applying frequency filtering to {data_type} data.')
 
-    logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                 session=session, run=run))
+    logger.info(**gen_log_kwargs(message=msg))
 
     if l_freq is None and h_freq is None:
         return
@@ -158,8 +155,7 @@ def resample(
         return
 
     msg = f'Resampling {data_type} data to {sfreq:.1f} Hz'
-    logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                 session=session, run=run,))
+    logger.info(**gen_log_kwargs(message=msg))
     raw.resample(sfreq, npad='auto')
 
 
@@ -182,8 +178,7 @@ def filter_data(
     # Create paths for reading and writing the filtered data.
     if cfg.use_maxwell_filter:
         msg = f'Reading: {bids_path.basename}'
-        logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                     session=session, run=run))
+        logger.info(**gen_log_kwargs(message=msg))
         raw = mne.io.read_raw_fif(bids_path)
     else:
         raw = import_experimental_data(bids_path_in=bids_path,
@@ -224,8 +219,7 @@ def filter_data(
         if cfg.use_maxwell_filter:
             msg = (f'Reading {data_type} recording: '
                    f'{bids_path_noise.basename}')
-            logger.info(**gen_log_kwargs(message=msg, subject=subject,
-                                         session=session, run=task))
+            logger.info(**gen_log_kwargs(message=msg, run=task))
             raw_noise = mne.io.read_raw_fif(bids_path_noise)
         elif data_type == 'empty-room':
             raw_noise = import_er_data(
@@ -276,9 +270,7 @@ def filter_data(
         # worse.
         if run == cfg.runs[0] and cfg.find_noisy_channels_meg:
             msg = 'Adding visualization of noisy channel detection to report.'
-            logger.info(
-                **gen_log_kwargs(message=msg, subject=subject, session=session)
-            )
+            logger.info(**gen_log_kwargs(message=msg))
             figs, captions = plot_auto_scores_(
                 cfg=cfg,
                 subject=subject,
@@ -296,11 +288,7 @@ def filter_data(
                 plt.close(fig)
 
         msg = 'Adding filtered raw data to report.'
-        logger.info(
-            **gen_log_kwargs(
-                message=msg, subject=subject, session=session, run=run
-            )
-        )
+        logger.info(**gen_log_kwargs(message=msg))
         for fname in out_files.values():
             title = 'Raw'
             if fname.run is not None:
@@ -328,6 +316,7 @@ def get_config(
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
+        exec_params=config.exec_params,
         reader_extra_params=config.reader_extra_params,
         process_empty_room=config.process_empty_room,
         process_rest=config.process_rest,
@@ -340,8 +329,8 @@ def get_config(
         acq=config.acq,
         rec=config.rec,
         space=config.space,
-        bids_root=get_bids_root(config),
-        deriv_root=get_deriv_root(config),
+        bids_root=config.bids_root,
+        deriv_root=config.deriv_root,
         l_freq=config.l_freq,
         h_freq=config.h_freq,
         l_trans_bandwidth=config.l_trans_bandwidth,
@@ -369,33 +358,27 @@ def get_config(
         on_rename_missing_events=config.on_rename_missing_events,
         plot_psd_for_runs=config.plot_psd_for_runs,
         _raw_split_size=config._raw_split_size,
+        config_path=config.config_path,
     )
     return cfg
 
 
 def main(*, config) -> None:
     """Run filter."""
-    with get_parallel_backend(config):
-        parallel, run_func = parallel_func(filter_data, config=config)
-
-        # Enabling different runs for different subjects
-        sub_run_ses = []
-        for subject in get_subjects(config):
-            sub_run_ses += list(
-                itertools.product(
-                    [subject],
-                    get_runs(config=config, subject=subject),
-                    get_sessions(config),
-                )
-            )
+    with get_parallel_backend(config.exec_params):
+        parallel, run_func = parallel_func(
+            filter_data, exec_params=config.exec_params)
 
         logs = parallel(
             run_func(
                 cfg=get_config(config=config, subject=subject),
                 subject=subject,
+                session=session,
                 run=run,
-                session=session
-            ) for subject, run, session in sub_run_ses
+            )
+            for subject in get_subjects(config)
+            for session in get_sessions(config)
+            for run in get_runs(config=config, subject=subject)
         )
 
     save_logs(config=config, logs=logs)

--- a/mne_bids_pipeline/scripts/sensor/_06_make_cov.py
+++ b/mne_bids_pipeline/scripts/sensor/_06_make_cov.py
@@ -261,9 +261,7 @@ def get_config(
 
 def main(*, config) -> None:
     """Run cov."""
-    cfg = get_config(config=config)
-
-    if not cfg.run_source_estimation:
+    if not config.run_source_estimation:
         msg = 'Skipping, run_source_estimation is set to False …'
         logger.info(**gen_log_kwargs(message=msg, emoji='skip'))
         return
@@ -280,7 +278,11 @@ def main(*, config) -> None:
         parallel, run_func = parallel_func(
             run_covariance, exec_params=config.exec_params)
         logs = parallel(
-            run_func(cfg=cfg, subject=subject, session=session)
+            run_func(
+                cfg=get_config(config=config),
+                subject=subject,
+                session=session,
+            )
             for subject in get_subjects(config)
             for session in get_sessions(config)
         )

--- a/mne_bids_pipeline/scripts/sensor/_06_make_cov.py
+++ b/mne_bids_pipeline/scripts/sensor/_06_make_cov.py
@@ -96,8 +96,14 @@ def compute_cov_from_epochs(
     logger.info(**gen_log_kwargs(message=msg))
 
     epochs = mne.read_epochs(epo_fname, preload=True)
-    cov = mne.compute_covariance(epochs, tmin=tmin, tmax=tmax, method='shrunk',
-                                 rank='info')
+    cov = mne.compute_covariance(
+        epochs,
+        tmin=tmin,
+        tmax=tmax,
+        method='shrunk',
+        rank='info',
+        verbose='error',  # TODO: not baseline corrected, maybe problematic?
+    )
     return cov
 
 
@@ -220,7 +226,7 @@ def run_covariance(*, cfg, subject, session, in_files):
                 else:  # It's a contrast of two conditions.
                     title = f'Whitening: {condition}'
                     tags = tags + ('contrast',)
-                fig = evoked.plot_white(cov)
+                fig = evoked.plot_white(cov, verbose='error')
                 report.add_figure(
                     fig=fig,
                     title=title,

--- a/mne_bids_pipeline/scripts/source/_01_make_bem_surfaces.py
+++ b/mne_bids_pipeline/scripts/source/_01_make_bem_surfaces.py
@@ -86,6 +86,7 @@ def get_config(
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
+        exec_params=config.exec_params,
         fs_subject=get_fs_subject(config=config, subject=subject),
         fs_subjects_dir=get_fs_subjects_dir(config=config),
         bem_mri_images=config.bem_mri_images,
@@ -112,8 +113,9 @@ def main(*, config) -> None:
             mne.datasets.fetch_fsaverage(get_fs_subjects_dir(config))
         return
 
-    with get_parallel_backend(config):
-        parallel, run_func = parallel_func(make_bem_surfaces, config=config)
+    with get_parallel_backend(config.exec_params):
+        parallel, run_func = parallel_func(
+            make_bem_surfaces, exec_params=config.exec_params)
         logs = parallel(
             run_func(
                 cfg=get_config(

--- a/mne_bids_pipeline/scripts/source/_02_make_bem_solution.py
+++ b/mne_bids_pipeline/scripts/source/_02_make_bem_solution.py
@@ -58,6 +58,7 @@ def get_config(
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
+        exec_params=config.exec_params,
         fs_subject=get_fs_subject(config=config, subject=subject),
         fs_subjects_dir=get_fs_subjects_dir(config),
         ch_types=config.ch_types,
@@ -82,8 +83,9 @@ def main(*, config) -> None:
             mne.datasets.fetch_fsaverage(get_fs_subjects_dir(config))
         return
 
-    with get_parallel_backend(config):
-        parallel, run_func = parallel_func(make_bem_solution, config=config)
+    with get_parallel_backend(config.exec_params):
+        parallel, run_func = parallel_func(
+            make_bem_solution, exec_params=config.exec_params)
         logs = parallel(
             run_func(
                 cfg=get_config(config=config, subject=subject),

--- a/mne_bids_pipeline/scripts/source/_03_setup_source_space.py
+++ b/mne_bids_pipeline/scripts/source/_03_setup_source_space.py
@@ -52,6 +52,7 @@ def get_config(
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
+        exec_params=config.exec_params,
         spacing=config.spacing,
         use_template_mri=config.use_template_mri,
         fs_subject=get_fs_subject(config=config, subject=subject),
@@ -74,11 +75,9 @@ def main(*, config) -> None:
     else:
         subjects = get_subjects(config=config)
 
-    with get_parallel_backend(config):
+    with get_parallel_backend(config.exec_params):
         parallel, run_func = parallel_func(
-            run_setup_source_space,
-            config=config,
-        )
+            run_setup_source_space, exec_params=config.exec_params)
         logs = parallel(
             run_func(
                 cfg=get_config(

--- a/mne_bids_pipeline/scripts/source/_99_group_average.py
+++ b/mne_bids_pipeline/scripts/source/_99_group_average.py
@@ -148,7 +148,7 @@ def run_group_average_source(*, cfg, subject='average'):
                 fs_subject=get_fs_subject(config=cfg, subject=subject),
                 session=session
             )
-            for subject, session in get_subjects(cfg)
+            for subject in get_subjects(cfg)
             for session in get_sessions(cfg)
         )
         mean_morphed_stcs = np.array(all_morphed_stcs).mean(axis=0)

--- a/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
+++ b/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
@@ -23,14 +23,23 @@ components from a total of 6 experimental tasks:
                 event-related potential research. *NeuroImage* 225: 117465.
                 [https://doi.org/10.1016/j.neuroimage.2020.117465](https://doi.org/10.1016/j.neuroimage.2020.117465)
 """
-import os
+import argparse
 import mne
+import sys
 
 study_name = 'ERP-CORE'
 bids_root = '~/mne_data/ERP_CORE'
 deriv_root = '~/mne_data/derivatives/mne-bids-pipeline/ERP_CORE'
 
-task = os.environ.get('MNE_BIDS_STUDY_TASK')
+# Find the --task option
+args = [arg for arg in sys.argv
+        if arg.startswith('--task') or not arg.startswith('-')]
+parser = argparse.ArgumentParser()
+parser.add_argument('ignored', nargs='*')
+parser.add_argument(
+    '--task', choices=('N400', 'ERN', 'LRP', 'MMN', 'N2pc', 'N170', 'P3'),
+    required=True)
+task = parser.parse_args(args).task
 sessions = [task]
 
 subjects = ['015', '016', '017', '018', '019']

--- a/mne_bids_pipeline/tests/conftest.py
+++ b/mne_bids_pipeline/tests/conftest.py
@@ -21,6 +21,8 @@ def pytest_configure(config):
     ignore:The register_cmap function.*:PendingDeprecationWarning
     ignore:Jupyter is migrating its paths[.\n]*:DeprecationWarning
     ignore:numpy\.ndarray size changed, may indicate binary.*:RuntimeWarning
+    always::ResourceWarning
+    ignore:subprocess .* is still running:ResourceWarning
     """
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/mne_bids_pipeline/tests/conftest.py
+++ b/mne_bids_pipeline/tests/conftest.py
@@ -14,3 +14,14 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "dataset_test: mark that a test runs a dataset"
     )
+    warning_lines = r"""
+    error::
+    ignore:There is no current event loop:DeprecationWarning
+    ignore:distutils Version classes are deprecated.*:DeprecationWarning
+    ignore:The register_cmap function.*:PendingDeprecationWarning
+    ignore:numpy\.ndarray size changed, may indicate binary.*:RuntimeWarning
+    """
+    for warning_line in warning_lines.split('\n'):
+        warning_line = warning_line.strip()
+        if warning_line and not warning_line.startswith('#'):
+            config.addinivalue_line('filterwarnings', warning_line)

--- a/mne_bids_pipeline/tests/conftest.py
+++ b/mne_bids_pipeline/tests/conftest.py
@@ -19,6 +19,7 @@ def pytest_configure(config):
     ignore:There is no current event loop:DeprecationWarning
     ignore:distutils Version classes are deprecated.*:DeprecationWarning
     ignore:The register_cmap function.*:PendingDeprecationWarning
+    ignore:Jupyter is migrating its paths[.\n]*:DeprecationWarning
     ignore:numpy\.ndarray size changed, may indicate binary.*:RuntimeWarning
     """
     for warning_line in warning_lines.split('\n'):

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -168,10 +168,11 @@ def test_run(dataset, monkeypatch, dataset_test, capsys):
         str(config_path),
         f'--steps={",".join(steps)}']
     if task:
-        command.append(f'--task={task}' if task else '')
+        command.append(f'--task={task}')
     if '--pdb' in sys.argv:
-        monkeypatch.setenv('MNE_BIDS_STUDY_PARALLEL_BACKEND', 'loky')
         command.append('--n_jobs=1')
+    monkeypatch.setenv('_MNE_BIDS_STUDY_TESTING', 'true')
     monkeypatch.setattr(sys, 'argv', command)
     with capsys.disabled():
+        print()
         main()


### PR DESCRIPTION
1. Remove env vars by splitting `config` into two conceptual things during config import:
    1. Variables that affect execution but not outputs (parallel backend, n_jobs, etc.) get put in `config.exec_params`, which is `.pop`ed by `failsafe_run` before any execution/caching
    2. Variables that affect outputs are left in other `config.*` vars
3. Simplify a lot of `gen_log_kwargs` calls by automatically getting `subject, session, run` from the stack (a bit magical but *a lot* less boilerplate -- I think of it as similar to getting the time and/or script name automatically, whereas `message=msg` is still there / more explicitly kept as the message)
4. Fix some log coloring bugs that crept in via #658
5. Get rid of `get_bids_root` / `get_deriv_root` by triaging in `_config_import.py` -- I think most if not all `get_*` functions can be similarly removed in follow-up PRs. These can all be resolved in `_main.py`'s call to `_import_config()`, thereby simplifying the logic in `get_config` calls for individual runs
6. Replaced a bunch of `itertools` calls that seemed unnecessary (more chars/lines and less standard than just nesting `for` loops)
7. Fix bug with sys info appending
8. Move whitening of evoked to `Covariance` section since it's really mostly useful for debugging cov (and also it's a much cleaner / more linear flow)
9. Make report `code` and `sys_info` sections take at 50% of screen vertical space, using interior scrollbars (makes browsing easier)
10. Treat warnings-as-errors in tests (to catch DeprecationWarnings etc. well ahead of time)

Closes #659
Closes #662

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)