### PR TITLE
MAINT: Split bad-finding step

### DIFF
--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -205,6 +205,9 @@ authors:
 - Make report generation happen within relevant steps instead of at the end
   of all steps
   ({{ gh(652) }} by {{ authors.larsoner }})
+- Initial raw data plots are now added to reports and bad channel detection
+  is executed in a dedicated step
+  ({{ gh(666) }} by {{ authors.larsoner }})
 
 ### Behavior changes
 

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -34,6 +34,7 @@ def _import_config(
         overrides=overrides,
         log=log,
     )
+
     # Check it
     if check:
         _check_config(config)
@@ -59,9 +60,9 @@ def _import_config(
         # Caching
         'memory_location', 'memory_verbose', 'memory_file_method',
         # Misc
-        'deriv_root',
+        'deriv_root', 'config_path',
     )
-    in_both = {'deriv_root', 'interactive'}
+    in_both = {'deriv_root'}
     exec_params = SimpleNamespace(**{k: getattr(config, k) for k in keys})
     for k in keys:
         if k not in in_both:

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -260,8 +260,9 @@ def get_channels_to_analyze(
     # Return names of the channels of the channel types we wish to analyze.
     # We also include channels marked as "bad" here.
     # `exclude=[]`: keep "bad" channels, too.
+    kwargs = dict(eog=True, ecg=True, exclude=())
     if get_datatype(config) == 'meg' and _meg_in_ch_types(config.ch_types):
-        pick_idx = mne.pick_types(info, eog=True, ecg=True, exclude=[])
+        pick_idx = mne.pick_types(info, **kwargs)
 
         if 'mag' in config.ch_types:
             pick_idx = np.concatenate(
@@ -270,8 +271,8 @@ def get_channels_to_analyze(
             pick_idx = np.concatenate(
                 [pick_idx, mne.pick_types(info, meg='grad', exclude=[])])
         if 'meg' in config.ch_types:
-            pick_idx = mne.pick_types(info, meg=True, eog=True, ecg=True,
-                                      exclude=[])
+            pick_idx = mne.pick_types(info, meg=True, exclude=[])
+        pick_idx.sort()
     elif config.ch_types == ['eeg']:
         pick_idx = mne.pick_types(info, meg=False, eeg=True, eog=True,
                                   ecg=True, exclude=[])

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -6,6 +6,7 @@ from mne_bids import BIDSPath, read_raw_bids, get_bids_path_from_fname
 import numpy as np
 import pandas as pd
 
+from ._config_utils import get_channels_to_analyze
 from ._io import _read_json, _empty_room_match_path
 from ._logging import gen_log_kwargs, logger
 from ._run import _update_for_splits
@@ -212,6 +213,9 @@ def _load_data(cfg: SimpleNamespace, bids_path: BIDSPath) -> mne.io.BaseRaw:
     subject = bids_path.subject
     raw = read_raw_bids(bids_path=bids_path,
                         extra_params=cfg.reader_extra_params)
+
+    picks = get_channels_to_analyze(raw.info, cfg)
+    raw.pick(picks)
 
     _crop_data(cfg, raw=raw, subject=subject)
 

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -469,8 +469,6 @@ def _find_breaks_func(
     run: Optional[str],
 ) -> None:
     if not cfg.find_breaks:
-        msg = 'Finding breaks has been disabled by the user.'
-        logger.info(**gen_log_kwargs(message=msg))
         return
 
     msg = (f'Finding breaks with a minimum duration of '

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -1,16 +1,14 @@
-import copy
 from types import SimpleNamespace
 from typing import Dict, Optional, Iterable, Union, List, Literal
 
 import mne
-from mne_bids import BIDSPath, read_raw_bids
+from mne_bids import BIDSPath, read_raw_bids, get_bids_path_from_fname
 import numpy as np
 import pandas as pd
 
-from ._config_utils import get_channels_to_analyze, get_task
-from ._io import _write_json
+from ._io import _read_json, _empty_room_match_path
 from ._logging import gen_log_kwargs, logger
-from ._viz import plot_auto_scores
+from ._run import _update_for_splits
 from .typing import PathLike
 
 
@@ -205,129 +203,6 @@ def _rename_events_func(
     raw.annotations.description = descriptions
 
 
-def _find_bad_channels(
-    cfg: SimpleNamespace,
-    raw: mne.io.BaseRaw,
-    subject: str,
-    session: Optional[str],
-    task: Optional[str],
-    run: Optional[str],
-) -> None:
-    """Find and mark bad MEG channels.
-
-    Modifies ``raw`` in-place.
-    """
-    if not (cfg.find_flat_channels_meg or cfg.find_noisy_channels_meg):
-        return
-
-    if (cfg.find_flat_channels_meg and
-            not cfg.find_noisy_channels_meg):
-        msg = 'Finding flat channels.'
-    elif (cfg.find_noisy_channels_meg and
-            not cfg.find_flat_channels_meg):
-        msg = 'Finding noisy channels using Maxwell filtering.'
-    else:
-        msg = ('Finding flat channels, and noisy channels using '
-               'Maxwell filtering.')
-
-    logger.info(**gen_log_kwargs(message=msg))
-
-    bids_path = BIDSPath(subject=subject,
-                         session=session,
-                         task=task,
-                         run=run,
-                         acquisition=cfg.acq,
-                         processing=cfg.proc,
-                         recording=cfg.rec,
-                         space=cfg.space,
-                         suffix=cfg.datatype,
-                         datatype=cfg.datatype,
-                         root=cfg.deriv_root)
-
-    # Filter the data manually before passing it to find_bad_channels_maxwell()
-    # This reduces memory usage, as we can control the number of jobs used
-    # during filtering.
-    raw_filt = raw.copy().filter(l_freq=None, h_freq=40, n_jobs=1)
-
-    auto_noisy_chs, auto_flat_chs, auto_scores = \
-        mne.preprocessing.find_bad_channels_maxwell(
-            raw=raw_filt,
-            calibration=cfg.mf_cal_fname,
-            cross_talk=cfg.mf_ctc_fname,
-            origin=cfg.mf_head_origin,
-            coord_frame='head',
-            return_scores=True,
-            h_freq=None  # we filtered manually above
-        )
-    del raw_filt
-
-    preexisting_bads = raw.info['bads'].copy()
-    bads = preexisting_bads.copy()
-
-    if cfg.find_flat_channels_meg:
-        if auto_flat_chs:
-            msg = (f'Found {len(auto_flat_chs)} flat channels: '
-                   f'{", ".join(auto_flat_chs)}')
-        else:
-            msg = 'Found no flat channels.'
-        logger.info(**gen_log_kwargs(message=msg))
-        bads.extend(auto_flat_chs)
-
-    if cfg.find_noisy_channels_meg:
-        if auto_noisy_chs:
-            msg = (f'Found {len(auto_noisy_chs)} noisy channels: '
-                   f'{", ".join(auto_noisy_chs)}')
-        else:
-            msg = 'Found no noisy channels.'
-
-        logger.info(**gen_log_kwargs(message=msg))
-        bads.extend(auto_noisy_chs)
-
-    bads = sorted(set(bads))
-    raw.info['bads'] = bads
-    msg = f'Marked {len(raw.info["bads"])} channels as bad.'
-    logger.info(**gen_log_kwargs(message=msg))
-
-    if cfg.find_noisy_channels_meg:
-        auto_scores_fname = bids_path.copy().update(
-            suffix='scores', extension='.json', check=False)
-        # TODO: This should be in our list of output files!
-        _write_json(auto_scores_fname, auto_scores)
-
-        if cfg.interactive:
-            import matplotlib.pyplot as plt
-            plot_auto_scores(auto_scores, ch_types=cfg.ch_types)
-            plt.show()
-
-    # Write the bad channels to disk.
-    # TODO: This should also be in our list of output files
-    bads_tsv_fname = bids_path.copy().update(suffix='bads',
-                                             extension='.tsv',
-                                             check=False)
-    bads_for_tsv = []
-    reasons = []
-
-    if cfg.find_flat_channels_meg:
-        bads_for_tsv.extend(auto_flat_chs)
-        reasons.extend(['auto-flat'] * len(auto_flat_chs))
-        preexisting_bads = set(preexisting_bads) - set(auto_flat_chs)
-
-    if cfg.find_noisy_channels_meg:
-        bads_for_tsv.extend(auto_noisy_chs)
-        reasons.extend(['auto-noisy'] * len(auto_noisy_chs))
-        preexisting_bads = set(preexisting_bads) - set(auto_noisy_chs)
-
-    preexisting_bads = list(preexisting_bads)
-    if preexisting_bads:
-        bads_for_tsv.extend(preexisting_bads)
-        reasons.extend(['pre-existing (before MNE-BIDS-pipeline was run)'] *
-                       len(preexisting_bads))
-
-    tsv_data = pd.DataFrame(dict(name=bads_for_tsv, reason=reasons))
-    tsv_data = tsv_data.sort_values(by='name')
-    tsv_data.to_csv(bads_tsv_fname, sep='\t', index=False)
-
-
 def _load_data(cfg: SimpleNamespace, bids_path: BIDSPath) -> mne.io.BaseRaw:
     # read_raw_bids automatically
     # - populates bad channels using the BIDS channels.tsv
@@ -337,12 +212,6 @@ def _load_data(cfg: SimpleNamespace, bids_path: BIDSPath) -> mne.io.BaseRaw:
     subject = bids_path.subject
     raw = read_raw_bids(bids_path=bids_path,
                         extra_params=cfg.reader_extra_params)
-
-    # Save only the channel types we wish to analyze (including the
-    # channels marked as "bad").
-    if not cfg.use_maxwell_filter:
-        picks = get_channels_to_analyze(raw.info, cfg)
-        raw.pick(picks)
 
     _crop_data(cfg, raw=raw, subject=subject)
 
@@ -465,6 +334,8 @@ def import_experimental_data(
     *,
     cfg: SimpleNamespace,
     bids_path_in: BIDSPath,
+    bids_path_bads_in: Optional[BIDSPath],
+    data_is_rest: Optional[bool],
 ) -> mne.io.BaseRaw:
     """Run the data import.
 
@@ -474,6 +345,11 @@ def import_experimental_data(
         The local configuration.
     bids_path_in
         The BIDS path to the data to import.
+    bids_path_bads_in
+        The BIDS path to the bad channels file.
+    data_is_rest : bool | None
+        Whether the data is resting state data. If ``None``, ``cfg.task``
+        is checked.
 
     Returns
     -------
@@ -493,13 +369,20 @@ def import_experimental_data(
     _drop_channels_func(cfg=cfg, raw=raw, subject=subject, session=session)
     _find_breaks_func(cfg=cfg, raw=raw, subject=subject, session=session,
                       run=run)
-    if cfg.task != "rest":
+    if data_is_rest is None:
+        data_is_rest = (cfg.task == 'rest') or cfg.task_is_rest
+    if not data_is_rest:
         _rename_events_func(
             cfg=cfg, raw=raw, subject=subject, session=session, run=run
         )
         _fix_stim_artifact_func(cfg=cfg, raw=raw)
-    _find_bad_channels(cfg=cfg, raw=raw, subject=subject, session=session,
-                       task=get_task(cfg), run=run)
+
+    if bids_path_bads_in is not None:
+        bads = _read_bads_tsv(cfg=cfg, bids_path_bads=bids_path_bads_in)
+        msg = f'Marking {len(bads)} channels as bad.'
+        logger.info(**gen_log_kwargs(message=msg))
+        raw.info['bads'] = bads
+        raw.info._check_consistency()
 
     return raw
 
@@ -508,7 +391,9 @@ def import_er_data(
     *,
     cfg: SimpleNamespace,
     bids_path_er_in: BIDSPath,
-    bids_path_ref_in: BIDSPath,
+    bids_path_ref_in: Optional[BIDSPath],
+    bids_path_er_bads_in: Optional[BIDSPath],
+    bids_path_ref_bads_in: Optional[BIDSPath],
 ) -> mne.io.BaseRaw:
     """Import empty-room data.
 
@@ -520,6 +405,10 @@ def import_er_data(
         The BIDS path to the empty room data.
     bids_path_ref_in
         The BIDS path to the reference data.
+    bids_path_er_bads_in
+        The BIDS path to the empty room bad channels file.
+    bids_path_ref_bads_in
+        The BIDS path to the reference data bad channels file.
 
     Returns
     -------
@@ -530,72 +419,44 @@ def import_er_data(
     session = bids_path_er_in.session
 
     _drop_channels_func(cfg, raw=raw_er, subject='emptyroom', session=session)
-
-    # Only keep MEG channels.
+    if bids_path_er_bads_in is not None:
+        raw_er.info['bads'] = _read_bads_tsv(
+            cfg=cfg,
+            bids_path_bads=bids_path_er_bads_in,
+        )
     raw_er.pick_types(meg=True, exclude=[])
 
-    # TODO: This 'union' operation should affect the raw runs, too, otherwise
-    # rank mismatches will still occur (eventually for some configs).
-    # But at least using the union here should reduce them.
-    # TODO: We should also uso automatic bad finding on the empty room data
+    # Don't deal with ref for now (initial data quality / auto bad step)
+    if bids_path_ref_in is None:
+        return raw_er
+
+    # Load reference run plus its auto-bads
     raw_ref = read_raw_bids(bids_path_ref_in,
                             extra_params=cfg.reader_extra_params)
+    if bids_path_ref_bads_in is not None:
+        bads = _read_bads_tsv(
+            cfg=cfg,
+            bids_path_in=bids_path_ref_bads_in,
+        )
+        raw_ref.info['bads'] = bads
+        raw_ref.info._check_consistency()
+    raw_ref.pick_types(meg=True, exclude=[])
+
     if cfg.use_maxwell_filter:
         # We need to include any automatically found bad channels, if relevant.
-        # TODO this is a bit of a hack because we don't use "in_files" access
-        # here, but this is *in the same step where this file is generated*
-        # so we cannot / should not put it in `in_files`.
-        if cfg.find_flat_channels_meg or cfg.find_noisy_channels_meg:
-            # match filename from _find_bad_channels
-            bads_tsv_fname = bids_path_ref_in.copy().update(
-                suffix='bads', extension='.tsv', root=cfg.deriv_root,
-                check=False)
-            bads_tsv = pd.read_csv(bads_tsv_fname.fpath, sep='\t', header=0)
-            bads_tsv = bads_tsv[bads_tsv.columns[0]].tolist()
-            raw_ref.info['bads'] = sorted(
-                set(raw_ref.info['bads']) | set(bads_tsv))
-            raw_ref.info._check_consistency()
+        # TODO: This 'union' operation should affect the raw runs, too,
+        # otherwise rank mismatches will still occur (eventually for some
+        # configs). But at least using the union here should reduce them.
         raw_er = mne.preprocessing.maxwell_filter_prepare_emptyroom(
             raw_er=raw_er,
             raw=raw_ref,
             bads='union',
         )
     else:
-        # Set same set of bads as in the reference run, but only for MEG
-        # channels (we might not have non-MEG channels in empty-room
-        # recordings).
-        raw_er.info['bads'] = [ch for ch in raw_ref.info['bads']
-                               if ch.startswith('MEG')]
+        # Take bads from the reference run
+        raw_er.info['bads'] = raw_ref.info['bads']
 
     return raw_er
-
-
-def import_rest_data(
-    *,
-    cfg: SimpleNamespace,
-    bids_path_in: BIDSPath,
-) -> mne.io.BaseRaw:
-    """Import resting-state data for use as a noise source.
-
-    Parameters
-    ----------
-    cfg
-        The local configuration.
-    bids_path_in : BIDSPath
-        The path.
-
-    Returns
-    -------
-    raw_rest
-        The imported data.
-    """
-    cfg = copy.deepcopy(cfg)
-    cfg.task = 'rest'
-
-    raw_rest = import_experimental_data(
-        cfg=cfg, bids_path_in=bids_path_in,
-    )
-    return raw_rest
 
 
 def _find_breaks_func(
@@ -627,3 +488,138 @@ def _find_breaks_func(
     logger.info(**gen_log_kwargs(message=msg))
 
     raw.set_annotations(raw.annotations + break_annots)  # add to existing
+
+
+def _get_raw_paths(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+    run: Optional[str],
+    kind: Literal['raw', 'sss'],
+    add_bads: bool = True,
+) -> dict:
+    # Construct the basenames of the files we wish to load, and of the empty-
+    # room recording we wish to save.
+    # The basenames of the empty-room recording output file does not contain
+    # the "run" entity.
+    path_kwargs = dict(
+        subject=subject,
+        run=run,
+        session=session,
+        task=cfg.task,
+        acquisition=cfg.acq,
+        recording=cfg.rec,
+        space=cfg.space,
+        datatype=cfg.datatype,
+        check=False
+    )
+    if kind == 'sss':
+        path_kwargs['root'] = cfg.deriv_root
+        path_kwargs['suffix'] = 'raw'
+        path_kwargs['extension'] = '.fif'
+        path_kwargs['processing'] = 'sss'
+    else:
+        assert kind == 'orig', kind
+        path_kwargs['root'] = cfg.bids_root
+        path_kwargs['suffix'] = None
+        path_kwargs['extension'] = None
+        path_kwargs['processing'] = cfg.proc
+    bids_path_in = BIDSPath(**path_kwargs)
+
+    in_files = dict()
+    key = f'raw_run-{run}'
+    in_files[key] = bids_path_in
+    _update_for_splits(in_files, key, single=True)
+    if add_bads:
+        _add_bads_file(
+            cfg=cfg,
+            in_files=in_files,
+            key=key,
+        )
+
+    if run == cfg.runs[0]:
+        do = dict(
+            rest=cfg.process_rest and not cfg.task_is_rest,
+            noise=cfg.process_empty_room and cfg.datatype == 'meg',
+        )
+        for task in ('rest', 'noise'):
+            if not do[task]:
+                continue
+            key = f'raw_{task}'
+            if kind == 'sss':
+                raw_fname = bids_path_in.copy().update(
+                    run=None, task=task)
+            else:
+                if task == 'rest':
+                    raw_fname = bids_path_in.copy().update(
+                        run=None, task=task)
+                else:
+                    raw_fname = _read_json(
+                        _empty_room_match_path(bids_path_in, cfg))['fname']
+                    if raw_fname is not None:
+                        raw_fname = get_bids_path_from_fname(raw_fname)
+            if raw_fname is None:
+                continue
+            in_files[key] = raw_fname
+            _update_for_splits(
+                in_files, key, single=True, allow_missing=True)
+            if not in_files[key].fpath.exists():
+                in_files.pop(key)
+            elif add_bads:
+                _add_bads_file(
+                    cfg=cfg,
+                    in_files=in_files,
+                    key=key,
+                )
+
+    return in_files
+
+
+def _add_bads_file(
+    *,
+    cfg: SimpleNamespace,
+    in_files: dict,
+    key: str,
+) -> None:
+    bids_path_in = in_files[key]
+    bads_tsv_fname = _bads_path(cfg=cfg, bids_path_in=bids_path_in)
+    if bads_tsv_fname.fpath.is_file():
+        in_files[f'{key}-bads'] = bads_tsv_fname
+
+
+def _auto_scores_path(
+    *,
+    cfg: SimpleNamespace,
+    bids_path_in: BIDSPath,
+) -> BIDSPath:
+    return bids_path_in.copy().update(
+        suffix='scores',
+        extension='.json',
+        root=cfg.deriv_root,
+        split=None,
+        check=False,
+    )
+
+
+def _bads_path(
+    *,
+    cfg: SimpleNamespace,
+    bids_path_in: BIDSPath,
+) -> BIDSPath:
+    return bids_path_in.copy().update(
+        suffix='bads',
+        extension='.tsv',
+        root=cfg.deriv_root,
+        split=None,
+        check=False,
+    )
+
+
+def _read_bads_tsv(
+    *,
+    cfg: SimpleNamespace,
+    bids_path_bads: BIDSPath,
+) -> List[str]:
+    bads_tsv = pd.read_csv(bids_path_bads.fpath, sep='\t', header=0)
+    return bads_tsv[bads_tsv.columns[0]].tolist()

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -19,13 +19,13 @@ from ._config_utils import (
     sanitize_cond_name, get_subjects, _restrict_analyze_channels)
 from ._decoding import _handle_csp_args
 from ._logging import logger, gen_log_kwargs
-from ._viz import plot_auto_scores
 
 
 @contextlib.contextmanager
 def _open_report(
     *,
     cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
     subject: str,
     session: Optional[str],
     run: Optional[str] = None,
@@ -69,7 +69,7 @@ def _open_report(
             try:
                 msg = 'Adding config and sys info to report'
                 logger.info(**gen_log_kwargs(message=msg))
-                _finalize(report=report, cfg=cfg)
+                _finalize(report=report, exec_params=exec_params)
             except Exception:
                 pass
             fname_report_html = fname_report.with_suffix('.html')
@@ -79,43 +79,6 @@ def _open_report(
             report.save(
                 fname_report_html, overwrite=True,
                 open_browser=False)
-
-
-def plot_auto_scores_(cfg, subject, session):
-    """Plot automated bad channel detection scores.
-    """
-    import json_tricks
-    fname_scores = BIDSPath(subject=subject,
-                            session=session,
-                            task=cfg.task,
-                            acquisition=cfg.acq,
-                            run=None,
-                            processing=cfg.proc,
-                            recording=cfg.rec,
-                            space=cfg.space,
-                            suffix='scores',
-                            extension='.json',
-                            datatype=cfg.datatype,
-                            root=cfg.deriv_root,
-                            check=False)
-
-    all_figs = []
-    all_captions = []
-    for run in cfg.runs:
-        fname_scores.update(run=run)
-        auto_scores = json_tricks.loads(
-            fname_scores.fpath.read_text(encoding='utf-8-sig')
-        )
-
-        figs = plot_auto_scores(auto_scores, ch_types=cfg.ch_types)
-        all_figs.extend(figs)
-
-        # Could be more than 1 fig, e.g. "grad" and "mag"
-        captions = [f'Run {run}'] * len(figs)
-        all_captions.extend(captions)
-
-    assert all_figs
-    return all_figs, all_captions
 
 
 # def plot_full_epochs_decoding_scores(
@@ -504,7 +467,7 @@ def add_event_counts(*,
             report.add_custom_css(css=css)
 
 
-def _finalize(*, report: mne.Report, cfg: SimpleNamespace):
+def _finalize(*, report: mne.Report, exec_params: SimpleNamespace):
     """Add system information and the pipeline configuration to the report."""
     # ensure they are always appended
     titles = ['Configuration file', 'System information']
@@ -512,7 +475,7 @@ def _finalize(*, report: mne.Report, cfg: SimpleNamespace):
         report.remove(title=title, remove_all=True)
     # No longer need replace=True in these
     report.add_code(
-        code=cfg.config_path,
+        code=exec_params.config_path,
         title=titles[0],
         tags=('configuration',),
     )
@@ -539,8 +502,13 @@ def _all_conditions(*, cfg):
     return conditions
 
 
-def run_report_average_sensor(*, cfg, session: str) -> None:
-    subject = 'average'
+def run_report_average_sensor(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+) -> None:
     msg = 'Generating grand average report …'
     logger.info(**gen_log_kwargs(message=msg))
     assert matplotlib.get_backend() == 'agg', matplotlib.get_backend()
@@ -571,7 +539,11 @@ def run_report_average_sensor(*, cfg, session: str) -> None:
         _restrict_analyze_channels(evoked, cfg)
 
     conditions = _all_conditions(cfg=cfg)
-    with _open_report(cfg=cfg, subject=subject, session=session) as report:
+    with _open_report(
+            cfg=cfg,
+            exec_params=exec_params,
+            subject=subject,
+            session=session) as report:
 
         #######################################################################
         #
@@ -625,12 +597,17 @@ def run_report_average_sensor(*, cfg, session: str) -> None:
             )
 
 
-def run_report_average_source(*, cfg, session: str) -> None:
+def run_report_average_source(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+) -> None:
     #######################################################################
     #
     # Visualize forward solution, inverse operator, and inverse solutions.
     #
-    subject = 'average'
     evoked_fname = BIDSPath(
         subject=subject,
         session=session,
@@ -651,7 +628,11 @@ def run_report_average_source(*, cfg, session: str) -> None:
     hemi_str = 'hemi'  # MNE will auto-append '-lh' and '-rh'.
     morph_str = 'morph2fsaverage'
     conditions = _all_conditions(cfg=cfg)
-    with _open_report(cfg=cfg, subject=subject, session=session) as report:
+    with _open_report(
+            cfg=cfg,
+            exec_params=exec_params,
+            subject=subject,
+            session=session) as report:
         for condition, evoked in zip(conditions, evokeds):
             tags = (
                 'source-estimate',
@@ -1128,3 +1109,30 @@ def _agg_backend():
         yield
     finally:
         matplotlib.use(backend, force=True)
+
+
+def _add_raw(
+    *,
+    cfg: SimpleNamespace,
+    report: mne.report.Report,
+    bids_path_in: BIDSPath,
+    title: str,
+):
+    if bids_path_in.run is not None:
+        title += f', run {bids_path_in.run}'
+    elif bids_path_in.task in ('noise', 'rest'):
+        title += f', run {bids_path_in.task}'
+    plot_raw_psd = (
+        cfg.plot_psd_for_runs == 'all' or
+        bids_path_in.run in cfg.plot_psd_for_runs or
+        bids_path_in.task in cfg.plot_psd_for_runs
+    )
+    report.add_raw(
+        raw=bids_path_in,
+        title=title,
+        butterfly=5,
+        psd=plot_raw_psd,
+        tags=('raw', 'filtered', f'run-{bids_path_in.run}'),
+        # caption=bids_path_in.basename,  # TODO upstream
+        replace=True,
+    )

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -69,7 +69,13 @@ def _open_report(
             try:
                 msg = 'Adding config and sys info to report'
                 logger.info(**gen_log_kwargs(message=msg))
-                _finalize(report=report, exec_params=exec_params)
+                _finalize(
+                    report=report,
+                    exec_params=exec_params,
+                    subject=subject,
+                    session=session,
+                    run=run,
+                )
             except Exception:
                 pass
             fname_report_html = fname_report.with_suffix('.html')
@@ -467,7 +473,14 @@ def add_event_counts(*,
             report.add_custom_css(css=css)
 
 
-def _finalize(*, report: mne.Report, exec_params: SimpleNamespace):
+def _finalize(
+    *,
+    report: mne.Report,
+    exec_params: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+    run: Optional[str],
+) -> None:
     """Add system information and the pipeline configuration to the report."""
     # ensure they are always appended
     titles = ['Configuration file', 'System information']

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -1127,12 +1127,13 @@ def _add_raw(
         bids_path_in.run in cfg.plot_psd_for_runs or
         bids_path_in.task in cfg.plot_psd_for_runs
     )
-    report.add_raw(
-        raw=bids_path_in,
-        title=title,
-        butterfly=5,
-        psd=plot_raw_psd,
-        tags=('raw', 'filtered', f'run-{bids_path_in.run}'),
-        # caption=bids_path_in.basename,  # TODO upstream
-        replace=True,
-    )
+    with mne.use_log_level('error'):
+        report.add_raw(
+            raw=bids_path_in,
+            title=title,
+            butterfly=5,
+            psd=plot_raw_psd,
+            tags=('raw', 'filtered', f'run-{bids_path_in.run}'),
+            # caption=bids_path_in.basename,  # TODO upstream
+            replace=True,
+        )

--- a/mne_bids_pipeline/steps/freesurfer/_02_coreg_surfaces.py
+++ b/mne_bids_pipeline/steps/freesurfer/_02_coreg_surfaces.py
@@ -19,16 +19,19 @@ from ..._run import failsafe_run
 fs_bids_app = Path(__file__).parent / 'contrib' / 'run.py'
 
 
-def get_input_fnames_coreg_surfaces(**kwargs):
-    cfg = kwargs.pop('cfg')
-    kwargs.pop('subject')  # unused
-    assert len(kwargs) == 0, kwargs.keys()
-    del kwargs
-    in_files = _get_scalp_in_files(cfg)
-    return in_files
+def get_input_fnames_coreg_surfaces(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+) -> dict:
+    return _get_scalp_in_files(cfg)
 
 
-def get_output_fnames_coreg_surfaces(*, cfg, subject):
+def get_output_fnames_coreg_surfaces(
+    *,
+    cfg: SimpleNamespace,
+    subject: str
+) -> dict:
     out_files = dict()
     subject_path = Path(cfg.subjects_dir) / cfg.fs_subject
     out_files['seghead'] = subject_path / 'surf' / 'lh.seghead'
@@ -44,6 +47,7 @@ def get_output_fnames_coreg_surfaces(*, cfg, subject):
 )
 def make_coreg_surfaces(
     cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
     subject: str,
     in_files: dict,
 ) -> dict:
@@ -63,7 +67,6 @@ def make_coreg_surfaces(
 
 def get_config(*, config, subject) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        exec_params=config.exec_params,
         subject=subject,
         fs_subject=get_fs_subject(config, subject),
         subjects_dir=get_fs_subjects_dir(config),
@@ -83,8 +86,12 @@ def main(*, config) -> None:
 
         parallel(
             run_func(
-                cfg=get_config(config=config, subject=subject),
-                subject=subject,
+                cfg=get_config(
+                    config=config,
+                    subject=subject,
+                ),
+                exec_params=config.exec_params,
                 force_run=config.recreate_scalp_surface,
+                subject=subject,
             ) for subject in subjects
         )

--- a/mne_bids_pipeline/steps/init/_01_init_derivatives_dir.py
+++ b/mne_bids_pipeline/steps/init/_01_init_derivatives_dir.py
@@ -44,7 +44,8 @@ def init_dataset(cfg) -> None:
 @failsafe_run()
 def init_subject_dirs(
     *,
-    cfg,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
     subject: str,
     session: Optional[str],
 ) -> None:
@@ -63,7 +64,6 @@ def get_config(
     config,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        exec_params=config.exec_params,
         datatype=get_datatype(config),
         deriv_root=config.deriv_root,
         PIPELINE_NAME=config.PIPELINE_NAME,
@@ -81,7 +81,10 @@ def main(*, config):
     for subject in get_subjects(config):
         for session in get_sessions(config):
             init_subject_dirs(
-                cfg=get_config(config=config),
+                cfg=get_config(
+                    config=config,
+                ),
+                exec_params=config.exec_params,
                 subject=subject,
                 session=session,
             )

--- a/mne_bids_pipeline/steps/init/_02_find_empty_room.py
+++ b/mne_bids_pipeline/steps/init/_02_find_empty_room.py
@@ -56,11 +56,12 @@ def get_input_fnames_find_empty_room(
 )
 def find_empty_room(
     *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
     subject: str,
     session: Optional[str],
     run: Optional[str],
     in_files: Dict[str, BIDSPath],
-    cfg: SimpleNamespace
 ) -> Dict[str, BIDSPath]:
     raw_path = in_files.pop(f'raw_run-{run}')
     in_files.pop('sidecar', None)
@@ -98,7 +99,6 @@ def get_config(
     config,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        exec_params=config.exec_params,
         proc=config.proc,
         task=get_task(config),
         datatype=get_datatype(config),
@@ -130,7 +130,10 @@ def main(*, config) -> None:
         else:
             run = get_runs(config=config, subject=subject)[0]
         logs.append(find_empty_room(
-            cfg=get_config(config=config),
+            cfg=get_config(
+                config=config,
+            ),
+            exec_params=config.exec_params,
             subject=subject,
             session=get_sessions(config)[0],
             run=run,

--- a/mne_bids_pipeline/steps/init/__init__.py
+++ b/mne_bids_pipeline/steps/init/__init__.py
@@ -1,9 +1,9 @@
 """Filesystem initialization and dataset inspection."""
 
-from . import _00_init_derivatives_dir
-from . import _01_find_empty_room
+from . import _01_init_derivatives_dir
+from . import _02_find_empty_room
 
 _STEPS = (
-    _00_init_derivatives_dir,
-    _01_find_empty_room,
+    _01_init_derivatives_dir,
+    _02_find_empty_room,
 )

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -1,0 +1,319 @@
+"""Assess data quality and find bad (and flat) channels."""
+
+from types import SimpleNamespace
+from typing import Optional
+
+import pandas as pd
+
+import mne
+from mne_bids import BIDSPath
+
+from ..._config_utils import (
+    get_mf_cal_fname, get_mf_ctc_fname, get_subjects, get_sessions,
+    get_runs, get_task, get_datatype,
+)
+from ..._import_data import (
+    _get_raw_paths, import_experimental_data, import_er_data,
+    _bads_path, _auto_scores_path)
+from ..._io import _write_json
+from ..._logging import gen_log_kwargs, logger
+from ..._parallel import parallel_func, get_parallel_backend
+from ..._report import _open_report, _add_raw
+from ..._run import failsafe_run, save_logs
+from ..._viz import plot_auto_scores
+
+
+def get_input_fnames_data_quality(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+    run: str,
+) -> dict:
+    """Get paths of files required by maxwell_filter function."""
+    in_files = _get_raw_paths(
+        cfg=cfg,
+        subject=subject,
+        session=session,
+        run=run,
+        kind='orig',
+        add_bads=False,
+    )
+    return in_files
+
+
+@failsafe_run(
+    get_input_fnames=get_input_fnames_data_quality,
+)
+def assess_data_quality(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+    run: str,
+    in_files: dict,
+) -> None:
+    """Assess data quality and find and mark bad channels."""
+    import matplotlib.pyplot as plt
+    out_files = dict()
+    for key in list(in_files.keys()):
+        bids_path_in = in_files.pop(key)
+        auto_scores = _find_bads(
+            cfg=cfg,
+            exec_params=exec_params,
+            bids_path_in=bids_path_in,
+            key=key,
+            subject=subject,
+            session=session,
+            run=run,
+            out_files=out_files,
+        )
+
+        # Report
+        with _open_report(
+                cfg=cfg,
+                exec_params=exec_params,
+                subject=subject,
+                session=session,
+                run=run) as report:
+            # Original data
+            kind = 'original' if not cfg.proc else cfg.proc
+            msg = f'Adding {kind} raw data to report.'
+            logger.info(**gen_log_kwargs(message=msg))
+            _add_raw(
+                cfg=cfg,
+                report=report,
+                bids_path_in=bids_path_in,
+                title=f'Raw ({kind})',
+            )
+            if cfg.find_noisy_channels_meg:
+                assert auto_scores is not None
+                msg = 'Adding noisy channel detection to report.'
+                logger.info(**gen_log_kwargs(message=msg))
+                figs = plot_auto_scores(auto_scores, ch_types=cfg.ch_types)
+                captions = [f'Run {run}'] * len(figs)
+                tags = ('raw', 'data-quality', f'run-{run}')
+                report.add_figure(
+                    fig=figs,
+                    caption=captions,
+                    section='Data quality',
+                    title=f'Bad channel detection: {run}',
+                    tags=tags,
+                    replace=True,
+                )
+                for fig in figs:
+                    plt.close(fig)
+
+    assert len(in_files) == 0, in_files.keys()
+    return out_files
+
+
+def _find_bads(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    bids_path_in: BIDSPath,
+    subject: str,
+    session: Optional[str],
+    run: str,
+    key: str,
+    out_files: dict,
+):
+    if not (cfg.find_noisy_channels_meg or cfg.find_flat_channels_meg):
+        return None
+
+    if (cfg.find_flat_channels_meg and
+            not cfg.find_noisy_channels_meg):
+        msg = 'Finding flat channels.'
+    elif (cfg.find_noisy_channels_meg and
+            not cfg.find_flat_channels_meg):
+        msg = 'Finding noisy channels using Maxwell filtering.'
+    else:
+        msg = ('Finding flat channels, and noisy channels using '
+               'Maxwell filtering.')
+    logger.info(**gen_log_kwargs(message=msg))
+
+    if key == 'raw_noise':
+        raw = import_er_data(
+            bids_path_er_in=bids_path_in,
+            bids_path_er_bads_in=None,
+            bids_path_ref_in=None,
+            bids_path_ref_bads_in=None,
+            cfg=cfg,
+            datatype='meg',
+        )
+    else:
+        data_is_rest = (key == 'raw_rest')
+        raw = import_experimental_data(
+            bids_path_in=bids_path_in,
+            bids_path_bads_in=None,
+            cfg=cfg,
+            data_is_rest=data_is_rest,
+        )
+
+    # Filter the data manually before passing it to find_bad_channels_maxwell()
+    # This reduces memory usage, as we can control the number of jobs used
+    # during filtering.
+    preexisting_bads = raw.info['bads'].copy()
+    bads = preexisting_bads.copy()
+    raw_filt = raw.copy().filter(l_freq=None, h_freq=40, n_jobs=1)
+    auto_noisy_chs, auto_flat_chs, auto_scores = \
+        mne.preprocessing.find_bad_channels_maxwell(
+            raw=raw_filt,
+            calibration=cfg.mf_cal_fname,
+            cross_talk=cfg.mf_ctc_fname,
+            origin=cfg.mf_head_origin,
+            coord_frame='head',
+            return_scores=True,
+            h_freq=None  # we filtered manually above
+        )
+    del raw_filt
+
+    if cfg.find_flat_channels_meg:
+        if auto_flat_chs:
+            msg = (f'Found {len(auto_flat_chs)} flat channels: '
+                   f'{", ".join(auto_flat_chs)}')
+        else:
+            msg = 'Found no flat channels.'
+        logger.info(**gen_log_kwargs(message=msg))
+        bads.extend(auto_flat_chs)
+
+    if cfg.find_noisy_channels_meg:
+        if auto_noisy_chs:
+            msg = (f'Found {len(auto_noisy_chs)} noisy channels: '
+                   f'{", ".join(auto_noisy_chs)}')
+        else:
+            msg = 'Found no noisy channels.'
+
+        logger.info(**gen_log_kwargs(message=msg))
+        bads.extend(auto_noisy_chs)
+
+    bads = sorted(set(bads))
+    msg = f'Found {len(bads)} channels as bad.'
+    raw.info['bads'] = bads
+    del bads
+    logger.info(**gen_log_kwargs(message=msg))
+
+    if cfg.find_noisy_channels_meg:
+        out_files['auto_scores'] = _auto_scores_path(
+            cfg=cfg,
+            bids_path_in=bids_path_in,
+        )
+        _write_json(out_files['auto_scores'], auto_scores)
+
+    # Write the bad channels to disk.
+    out_files['bads_tsv'] = _bads_path(cfg=cfg, bids_path_in=bids_path_in)
+    bads_for_tsv = []
+    reasons = []
+
+    if cfg.find_flat_channels_meg:
+        bads_for_tsv.extend(auto_flat_chs)
+        reasons.extend(['auto-flat'] * len(auto_flat_chs))
+        preexisting_bads = set(preexisting_bads) - set(auto_flat_chs)
+
+    if cfg.find_noisy_channels_meg:
+        bads_for_tsv.extend(auto_noisy_chs)
+        reasons.extend(['auto-noisy'] * len(auto_noisy_chs))
+        preexisting_bads = set(preexisting_bads) - set(auto_noisy_chs)
+
+    preexisting_bads = list(preexisting_bads)
+    if preexisting_bads:
+        bads_for_tsv.extend(preexisting_bads)
+        reasons.extend(['pre-existing (before MNE-BIDS-pipeline was run)'] *
+                       len(preexisting_bads))
+
+    tsv_data = pd.DataFrame(dict(name=bads_for_tsv, reason=reasons))
+    tsv_data = tsv_data.sort_values(by='name')
+    tsv_data.to_csv(out_files['bads_tsv'], sep='\t', index=False)
+
+    # Interaction
+    if exec_params.interactive and cfg.find_noisy_channels_meg:
+        import matplotlib.pyplot as plt
+        plot_auto_scores(auto_scores, ch_types=cfg.ch_types)
+        plt.show()
+
+    return auto_scores
+
+
+def get_config(
+    *,
+    config: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+) -> SimpleNamespace:
+    if config.find_noisy_channels_meg or config.find_flat_channels_meg:
+        mf_cal_fname = get_mf_cal_fname(
+                config=config,
+                subject=subject,
+                session=session,
+            )
+        mf_ctc_fname = get_mf_ctc_fname(
+            config=config,
+            subject=subject,
+            session=session,
+        )
+    else:
+        mf_cal_fname = mf_ctc_fname = None
+    cfg = SimpleNamespace(
+        process_empty_room=config.process_empty_room,
+        process_rest=config.process_rest,
+        task_is_rest=config.task_is_rest,
+        runs=get_runs(config=config, subject=subject),
+        proc=config.proc,
+        task=get_task(config),
+        datatype=get_datatype(config),
+        acq=config.acq,
+        rec=config.rec,
+        space=config.space,
+        bids_root=config.bids_root,
+        deriv_root=config.deriv_root,
+        mf_cal_fname=mf_cal_fname,
+        mf_ctc_fname=mf_ctc_fname,
+        mf_head_origin=config.mf_head_origin,
+        reader_extra_params=config.reader_extra_params,
+        crop_runs=config.crop_runs,
+        rename_events=config.rename_events,
+        eeg_bipolar_channels=config.eeg_bipolar_channels,
+        eeg_template_montage=config.eeg_template_montage,
+        fix_stim_artifact=config.fix_stim_artifact,
+        stim_artifact_tmin=config.stim_artifact_tmin,
+        stim_artifact_tmax=config.stim_artifact_tmax,
+        find_flat_channels_meg=config.find_flat_channels_meg,
+        find_noisy_channels_meg=config.find_noisy_channels_meg,
+        drop_channels=config.drop_channels,
+        find_breaks=config.find_breaks,
+        min_break_duration=config.min_break_duration,
+        t_break_annot_start_after_previous_event=config.t_break_annot_start_after_previous_event,  # noqa:E501
+        t_break_annot_stop_before_next_event=config.t_break_annot_stop_before_next_event,  # noqa:E501
+        data_type=config.data_type,
+        ch_types=config.ch_types,
+        eog_channels=config.eog_channels,
+        on_rename_missing_events=config.on_rename_missing_events,
+        plot_psd_for_runs=config.plot_psd_for_runs,
+    )
+    return cfg
+
+
+def main(*, config: SimpleNamespace) -> None:
+    """Run maxwell_filter."""
+    with get_parallel_backend(config.exec_params):
+        parallel, run_func = parallel_func(
+            assess_data_quality, exec_params=config.exec_params)
+        logs = parallel(
+            run_func(
+                cfg=get_config(
+                    config=config,
+                    subject=subject,
+                    session=session),
+                exec_params=config.exec_params,
+                subject=subject,
+                session=session,
+                run=run
+            )
+            for subject in get_subjects(config)
+            for session in get_sessions(config)
+            for run in get_runs(config=config, subject=subject)
+        )
+
+    save_logs(config=config, logs=logs)

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -141,7 +141,6 @@ def _find_bads(
             bids_path_ref_in=None,
             bids_path_ref_bads_in=None,
             cfg=cfg,
-            datatype='meg',
         )
     else:
         data_is_rest = (key == 'raw_rest')

--- a/mne_bids_pipeline/steps/preprocessing/_02_maxfilter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_02_maxfilter.py
@@ -51,8 +51,7 @@ def get_input_fnames_maxwell_filter(
     )
     ref_bids_path = list(in_files.values())[0].copy().update(
         run=cfg.mf_reference_run,
-        extension='.fif',
-        check=True
+        check=True,
     )
     key = "raw_ref_run"
     in_files[key] = ref_bids_path
@@ -200,6 +199,7 @@ def run_maxwell_filter(
                 bids_path_ref_in=bids_path_ref_in,
                 bids_path_er_bads_in=bids_path_noise_bads,
                 bids_path_ref_bads_in=bids_path_ref_bads_in,
+                prepare_maxwell_filter=True,
             )
 
         # Maxwell-filter noise data.

--- a/mne_bids_pipeline/steps/preprocessing/_02_maxfilter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_02_maxfilter.py
@@ -164,7 +164,8 @@ def run_maxwell_filter(
             cfg=cfg,
             exec_params=exec_params,
             subject=subject,
-            session=session) as report:
+            session=session,
+            run=run) as report:
         msg = 'Adding Maxwell filtered raw data to report.'
         _add_raw(
             cfg=cfg,
@@ -197,7 +198,11 @@ def run_maxwell_filter(
                 cfg=cfg,
                 bids_path_er_in=bids_path_noise,
                 bids_path_ref_in=bids_path_ref_in,
-                bids_path_er_bads_in=bids_path_noise_bads,
+                # TODO: This can break processing, need to use union for all,
+                # otherwise can get for ds003392:
+                # "Reference run data rank does not match empty-room data rank"
+                # bids_path_er_bads_in=bids_path_noise_bads,
+                bids_path_er_bads_in=None,
                 bids_path_ref_bads_in=bids_path_ref_bads_in,
                 prepare_maxwell_filter=True,
             )
@@ -257,18 +262,18 @@ def run_maxwell_filter(
         _update_for_splits(out_files, in_key)
         del raw_noise_sss
 
-    with _open_report(
-            cfg=cfg,
-            exec_params=exec_params,
-            subject=subject,
-            session=session) as report:
-        msg = 'Adding Maxwell filtered raw data to report.'
-        logger.info(**gen_log_kwargs(message=msg))
-        for fname in out_files.values():
+        with _open_report(
+                cfg=cfg,
+                exec_params=exec_params,
+                subject=subject,
+                session=session,
+                run=task) as report:
+            msg = 'Adding Maxwell filtered raw data to report'
+            logger.info(**gen_log_kwargs(message=msg, run=task))
             _add_raw(
                 cfg=cfg,
                 report=report,
-                bids_path_in=fname,
+                bids_path_in=out_files[in_key],
                 title='Raw (maxwell filtered)',
             )
 

--- a/mne_bids_pipeline/steps/preprocessing/_03_frequency_filter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_03_frequency_filter.py
@@ -48,6 +48,7 @@ def get_input_fnames_frequency_filter(
         session=session,
         run=run,
         kind=kind,
+        include_mf_ref=False,
     )
 
 
@@ -222,8 +223,9 @@ def filter_data(
             cfg=cfg,
             exec_params=exec_params,
             subject=subject,
-            session=session) as report:
-        msg = 'Adding filtered raw data to report.'
+            session=session,
+            run=run) as report:
+        msg = 'Adding filtered raw data to report'
         logger.info(**gen_log_kwargs(message=msg))
         for fname in out_files.values():
             _add_raw(

--- a/mne_bids_pipeline/steps/preprocessing/_03_frequency_filter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_03_frequency_filter.py
@@ -180,6 +180,7 @@ def filter_data(
                 bids_path_er_bads_in=bids_path_noise_bads,
                 # take bads from this run (0)
                 bids_path_ref_bads_in=bids_path_bads_in,
+                prepare_maxwell_filter=False,
             )
         else:
             raw_noise = import_experimental_data(

--- a/mne_bids_pipeline/steps/preprocessing/_03_frequency_filter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_03_frequency_filter.py
@@ -144,7 +144,7 @@ def filter_data(
         h_freq=cfg.h_freq, l_freq=cfg.l_freq,
         h_trans_bandwidth=cfg.h_trans_bandwidth,
         l_trans_bandwidth=cfg.l_trans_bandwidth,
-        data_type='experimental'
+        data_type='experimental',
     )
     resample(raw=raw, subject=subject, session=session, run=run,
              sfreq=cfg.resample_sfreq, data_type='experimental')
@@ -197,13 +197,13 @@ def filter_data(
 
         raw_noise.load_data()
         filter(
-            raw=raw_noise, subject=subject, session=session, run=None,
+            raw=raw_noise, subject=subject, session=session, run=task,
             h_freq=cfg.h_freq, l_freq=cfg.l_freq,
             h_trans_bandwidth=cfg.h_trans_bandwidth,
             l_trans_bandwidth=cfg.l_trans_bandwidth,
-            data_type=data_type
+            data_type=data_type,
         )
-        resample(raw=raw_noise, subject=subject, session=session, run=None,
+        resample(raw=raw_noise, subject=subject, session=session, run=task,
                  sfreq=cfg.resample_sfreq, data_type=data_type)
 
         raw_noise.save(

--- a/mne_bids_pipeline/steps/preprocessing/__init__.py
+++ b/mne_bids_pipeline/steps/preprocessing/__init__.py
@@ -1,21 +1,23 @@
 """Preprocessing."""
 
-from . import _01_maxfilter
-from . import _02_frequency_filter
-from . import _03_make_epochs
-from . import _04a_run_ica
-from . import _04b_run_ssp
-from . import _05a_apply_ica
-from . import _05b_apply_ssp
-from . import _06_ptp_reject
+from . import _01_data_quality
+from . import _02_maxfilter
+from . import _03_frequency_filter
+from . import _04_make_epochs
+from . import _05a_run_ica
+from . import _05b_run_ssp
+from . import _06a_apply_ica
+from . import _06b_apply_ssp
+from . import _07_ptp_reject
 
 _STEPS = (
-    _01_maxfilter,
-    _02_frequency_filter,
-    _03_make_epochs,
-    _04a_run_ica,
-    _04b_run_ssp,
-    _05a_apply_ica,
-    _05b_apply_ssp,
-    _06_ptp_reject,
+    _01_data_quality,
+    _02_maxfilter,
+    _03_frequency_filter,
+    _04_make_epochs,
+    _05a_run_ica,
+    _05b_run_ssp,
+    _06a_apply_ica,
+    _06b_apply_ssp,
+    _07_ptp_reject,
 )

--- a/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
+++ b/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
@@ -323,7 +323,10 @@ def main(*, config: SimpleNamespace) -> None:
     # so we don't dispatch manually to multiple jobs.
     logs = [
         run_time_decoding(
-            cfg=get_config(config=config),
+            cfg=get_config(
+                config=config,
+            ),
+            exec_params=config.exec_params,
             subject=subject,
             condition1=cond_1,
             condition2=cond_2,

--- a/mne_bids_pipeline/steps/sensor/_06_make_cov.py
+++ b/mne_bids_pipeline/steps/sensor/_06_make_cov.py
@@ -84,7 +84,13 @@ def get_input_fnames_cov(
 
 
 def compute_cov_from_epochs(
-        *, cfg, subject, session, tmin, tmax, in_files, out_files):
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+    in_files: dict,
+    out_files: dict,
+) -> mne.Covariance:
     epo_fname = in_files.pop('epochs')
 
     msg = "Computing regularized covariance based on epochs' baseline periods."
@@ -106,7 +112,14 @@ def compute_cov_from_epochs(
     return cov
 
 
-def compute_cov_from_raw(*, cfg, subject, session, in_files, out_files):
+def compute_cov_from_raw(
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+    in_files: dict,
+    out_files: dict,
+) -> mne.Covariance:
     fname_raw = in_files.pop('raw')
     data_type = 'resting-state' if fname_raw.task == 'rest' else 'empty-room'
     msg = f'Computing regularized covariance based on {data_type} recording.'
@@ -126,9 +139,9 @@ def retrieve_custom_cov(
     exec_params: SimpleNamespace,
     subject: str,
     session: Optional[str],
-    in_files: None,
+    in_files: dict,
     out_files: dict,
-):
+) -> mne.Covariance:
     # This should be the only place we use config.noise_cov (rather than cfg.*
     # entries)
     config = _import_config(

--- a/mne_bids_pipeline/steps/sensor/_06_make_cov.py
+++ b/mne_bids_pipeline/steps/sensor/_06_make_cov.py
@@ -84,6 +84,9 @@ def get_input_fnames_cov(
 
 
 def compute_cov_from_epochs(
+    *,
+    tmin: Optional[float],
+    tmax: Optional[float],
     cfg: SimpleNamespace,
     exec_params: SimpleNamespace,
     subject: str,
@@ -113,6 +116,7 @@ def compute_cov_from_epochs(
 
 
 def compute_cov_from_raw(
+    *,
     cfg: SimpleNamespace,
     exec_params: SimpleNamespace,
     subject: str,
@@ -135,6 +139,7 @@ def compute_cov_from_raw(
 
 
 def retrieve_custom_cov(
+    *,
     cfg: SimpleNamespace,
     exec_params: SimpleNamespace,
     subject: str,

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -36,8 +36,8 @@ def average_evokeds(
     # Container for all conditions:
     all_evokeds = defaultdict(list)
 
-    for subject in cfg.subjects:
-        fname_in = BIDSPath(subject=subject,
+    for this_subject in cfg.subjects:
+        fname_in = BIDSPath(subject=this_subject,
                             session=session,
                             task=cfg.task,
                             acquisition=cfg.acq,
@@ -373,7 +373,8 @@ def average_full_epochs_decoding(
         del bootstrapped_means, se, ci_lower, ci_upper
 
         fname_out = fname_mat.copy().update(subject='average')
-        fname_out.parent.mkdir(exist_ok=True, parents=True)
+        if not fname_out.fpath.parent.exists():
+            os.makedirs(fname_out.fpath.parent)
         savemat(fname_out, contrast_score_stats)
         del contrast_score_stats, fname_out
 

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -373,6 +373,7 @@ def average_full_epochs_decoding(
         del bootstrapped_means, se, ci_lower, ci_upper
 
         fname_out = fname_mat.copy().update(subject='average')
+        fname_out.parent.mkdir(exist_ok=True, parents=True)
         savemat(fname_out, contrast_score_stats)
         del contrast_score_stats, fname_out
 

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -380,6 +380,7 @@ def average_full_epochs_decoding(
 def average_csp_decoding(
     cfg: SimpleNamespace,
     session: str,
+    subject: str,
     condition_1: str,
     condition_2: str,
 ):
@@ -622,7 +623,6 @@ def get_config(
     return cfg
 
 
-# pass 'average' subject for logging
 @failsafe_run()
 def run_group_average_sensor(
     *,
@@ -655,11 +655,12 @@ def run_group_average_sensor(
                 average_time_by_time_decoding(cfg, session)
         if cfg.decode and cfg.decoding_csp:
             parallel, run_func = parallel_func(
-                average_csp_decoding)
+                average_csp_decoding, exec_params=exec_params)
             parallel(
                 run_func(
                     cfg=cfg,
                     session=session,
+                    subject=subject,
                     condition_1=contrast[0],
                     condition_2=contrast[1]
                 )
@@ -670,6 +671,7 @@ def run_group_average_sensor(
         for session in sessions:
             run_report_average_sensor(
                 cfg=cfg,
+                exec_params=exec_params,
                 subject=subject,
                 session=session,
             )
@@ -677,7 +679,9 @@ def run_group_average_sensor(
 
 def main(*, config: SimpleNamespace) -> None:
     log = run_group_average_sensor(
-        cfg=get_config(config=config),
+        cfg=get_config(
+            config=config,
+        ),
         exec_params=config.exec_params,
         subject='average',
     )

--- a/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
+++ b/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
@@ -16,7 +16,7 @@ from ..._parallel import get_parallel_backend, parallel_func
 from ..._run import failsafe_run, save_logs
 
 
-def _get_bem_params(cfg):
+def _get_bem_params(cfg: SimpleNamespace):
     mri_dir = Path(cfg.fs_subjects_dir) / cfg.fs_subject / 'mri'
     flash_dir = mri_dir / 'flash' / 'parameter_maps'
     if cfg.bem_mri_images == 'FLASH' and not flash_dir.exists():
@@ -30,7 +30,11 @@ def _get_bem_params(cfg):
     return mri_images, mri_dir, flash_dir
 
 
-def get_input_fnames_make_bem_surfaces(*, cfg, subject):
+def get_input_fnames_make_bem_surfaces(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+) -> dict:
     in_files = dict()
     mri_images, mri_dir, flash_dir = _get_bem_params(cfg)
     in_files['t1'] = mri_dir / 'T1.mgz'
@@ -42,7 +46,11 @@ def get_input_fnames_make_bem_surfaces(*, cfg, subject):
     return in_files
 
 
-def get_output_fnames_make_bem_surfaces(*, cfg, subject):
+def get_output_fnames_make_bem_surfaces(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+) -> dict:
     out_files = dict()
     conductivity, _ = _get_bem_conductivity(cfg)
     n_layers = len(conductivity)
@@ -56,7 +64,13 @@ def get_output_fnames_make_bem_surfaces(*, cfg, subject):
     get_input_fnames=get_input_fnames_make_bem_surfaces,
     get_output_fnames=get_output_fnames_make_bem_surfaces,
 )
-def make_bem_surfaces(*, cfg, subject, in_files):
+def make_bem_surfaces(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    in_files: dict,
+) -> dict:
     mri_images, _, _ = _get_bem_params(cfg)
     in_files.clear()  # assume we use everything we add
     if mri_images == 'FLASH':
@@ -67,7 +81,7 @@ def make_bem_surfaces(*, cfg, subject, in_files):
                'watershed algorithm')
         bem_func = mne.bem.make_watershed_bem
     logger.info(**gen_log_kwargs(message=msg, subject=subject))
-    show = True if cfg.interactive else False
+    show = True if exec_params.interactive else False
     bem_func(
         subject=cfg.fs_subject,
         subjects_dir=cfg.fs_subjects_dir,
@@ -90,7 +104,6 @@ def get_config(
         fs_subject=get_fs_subject(config=config, subject=subject),
         fs_subjects_dir=get_fs_subjects_dir(config=config),
         bem_mri_images=config.bem_mri_images,
-        interactive=config.interactive,
         freesurfer_verbose=config.freesurfer_verbose,
         use_template_mri=config.use_template_mri,
         ch_types=config.ch_types,
@@ -122,6 +135,7 @@ def main(*, config) -> None:
                     config=config,
                     subject=subject,
                 ),
+                exec_params=config.exec_params,
                 subject=subject,
                 force_run=config.recreate_bem)
             for subject in get_subjects(config)

--- a/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
+++ b/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
@@ -96,11 +96,10 @@ def make_bem_surfaces(
 
 def get_config(
     *,
-    config,
+    config: SimpleNamespace,
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        exec_params=config.exec_params,
         fs_subject=get_fs_subject(config=config, subject=subject),
         fs_subjects_dir=get_fs_subjects_dir(config=config),
         bem_mri_images=config.bem_mri_images,
@@ -111,7 +110,7 @@ def get_config(
     return cfg
 
 
-def main(*, config) -> None:
+def main(*, config: SimpleNamespace) -> None:
     """Run BEM surface extraction."""
     if not config.run_source_estimation:
         msg = 'Skipping, run_source_estimation is set to False …'

--- a/mne_bids_pipeline/steps/source/_02_make_bem_solution.py
+++ b/mne_bids_pipeline/steps/source/_02_make_bem_solution.py
@@ -15,7 +15,11 @@ from ..._parallel import parallel_func, get_parallel_backend
 from ..._run import failsafe_run, save_logs
 
 
-def get_input_fnames_make_bem_solution(*, cfg, subject):
+def get_input_fnames_make_bem_solution(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+) -> dict:
     in_files = dict()
     conductivity, _ = _get_bem_conductivity(cfg)
     n_layers = len(conductivity)
@@ -25,7 +29,11 @@ def get_input_fnames_make_bem_solution(*, cfg, subject):
     return in_files
 
 
-def get_output_fnames_make_bem_solution(*, cfg, subject):
+def get_output_fnames_make_bem_solution(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+) -> dict:
     out_files = dict()
     bem_dir = Path(cfg.fs_subjects_dir) / cfg.fs_subject / 'bem'
     _, tag = _get_bem_conductivity(cfg)
@@ -38,7 +46,13 @@ def get_output_fnames_make_bem_solution(*, cfg, subject):
     get_input_fnames=get_input_fnames_make_bem_solution,
     get_output_fnames=get_output_fnames_make_bem_solution,
 )
-def make_bem_solution(*, cfg, subject, in_files):
+def make_bem_solution(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    in_files: dict,
+) -> dict:
     msg = 'Calculating BEM solution'
     logger.info(**gen_log_kwargs(message=msg, subject=subject))
     conductivity, _ = _get_bem_conductivity(cfg)
@@ -54,11 +68,10 @@ def make_bem_solution(*, cfg, subject, in_files):
 
 def get_config(
     *,
-    config,
+    config: SimpleNamespace,
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        exec_params=config.exec_params,
         fs_subject=get_fs_subject(config=config, subject=subject),
         fs_subjects_dir=get_fs_subjects_dir(config),
         ch_types=config.ch_types,
@@ -89,6 +102,7 @@ def main(*, config) -> None:
         logs = parallel(
             run_func(
                 cfg=get_config(config=config, subject=subject),
+                exec_params=config.exec_params,
                 subject=subject,
                 force_run=config.recreate_bem)
             for subject in get_subjects(config)

--- a/mne_bids_pipeline/steps/source/_03_setup_source_space.py
+++ b/mne_bids_pipeline/steps/source/_03_setup_source_space.py
@@ -48,11 +48,10 @@ def run_setup_source_space(*, cfg, subject, in_files):
 
 def get_config(
     *,
-    config,
+    config: SimpleNamespace,
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        exec_params=config.exec_params,
         spacing=config.spacing,
         use_template_mri=config.use_template_mri,
         fs_subject=get_fs_subject(config=config, subject=subject),
@@ -61,7 +60,7 @@ def get_config(
     return cfg
 
 
-def main(*, config) -> None:
+def main(*, config: SimpleNamespace) -> None:
     """Run forward."""
     if not config.run_source_estimation:
         msg = 'Skipping, run_source_estimation is set to False …'
@@ -82,7 +81,9 @@ def main(*, config) -> None:
             run_func(
                 cfg=get_config(
                     config=config,
-                    subject=subject),
+                    subject=subject,
+                ),
+                exec_params=config.exec_params,
                 subject=subject,
             )
             for subject in subjects

--- a/mne_bids_pipeline/steps/source/_03_setup_source_space.py
+++ b/mne_bids_pipeline/steps/source/_03_setup_source_space.py
@@ -34,7 +34,13 @@ def get_output_fnames_setup_source_space(*, cfg, subject):
     get_input_fnames=get_input_fnames_setup_source_space,
     get_output_fnames=get_output_fnames_setup_source_space,
 )
-def run_setup_source_space(*, cfg, subject, in_files):
+def run_setup_source_space(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    in_files: dict,
+) -> dict:
     msg = f'Creating source space with spacing {repr(cfg.spacing)}'
     logger.info(**gen_log_kwargs(message=msg, subject=subject))
     src = mne.setup_source_space(

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -21,7 +21,11 @@ from ..._report import _open_report
 from ..._run import failsafe_run, save_logs
 
 
-def _prepare_trans_template(cfg, info):
+def _prepare_trans_template(
+    *,
+    cfg: SimpleNamespace,
+    info: mne.Info,
+) -> mne.transforms.Transform:
     assert isinstance(cfg.use_template_mri, str)
     assert cfg.use_template_mri == cfg.fs_subject
 
@@ -47,7 +51,7 @@ def _prepare_trans(
     cfg: SimpleNamespace,
     exec_params: SimpleNamespace,
     bids_path: BIDSPath,
-):
+) -> mne.transforms.Transform:
     # Generate a head ↔ MRI transformation matrix from the
     # electrophysiological and MRI sidecar files, and save it to an MNE
     # "trans" file in the derivatives folder.
@@ -157,7 +161,10 @@ def run_forward(
 
     # trans
     if cfg.use_template_mri is not None:
-        trans = _prepare_trans_template(cfg, exec_params)
+        trans = _prepare_trans_template(
+            cfg=cfg,
+            info=info,
+        )
     else:
         trans = _prepare_trans(
             cfg=cfg,

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -181,6 +181,8 @@ def run_forward(
             exec_params=exec_params,
             subject=subject,
             session=session) as report:
+        msg = 'Adding forward information to report'
+        logger.info(**gen_log_kwargs(message=msg))
         msg = 'Rendering MRI slices with BEM contours.'
         logger.info(**gen_log_kwargs(message=msg))
         report.add_bem(
@@ -192,7 +194,7 @@ def run_forward(
             replace=True,
             n_jobs=1,  # prevent automatic parallelization
         )
-        msg = 'Rendering sensor alignment (coregistration).'
+        msg = 'Rendering sensor alignment (coregistration)'
         logger.info(**gen_log_kwargs(message=msg))
         report.add_trans(
             trans=trans,
@@ -203,7 +205,7 @@ def run_forward(
             alpha=1,
             replace=True,
         )
-        msg = 'Rendering forward solution.'
+        msg = 'Rendering forward solution'
         logger.info(**gen_log_kwargs(message=msg))
         report.add_forward(
             forward=fwd,

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -66,6 +66,8 @@ def run_inverse(
 ) -> dict:
     # TODO: Eventually we should maybe loop over ch_types, e.g., to create
     # MEG, EEG, and MEG+EEG inverses and STCs
+    msg = 'Computing inverse solutions'
+    logger.info(**gen_log_kwargs(message=msg))
     fname_fwd = in_files.pop('forward')
     out_files = dict()
     out_files['inverse'] = fname_fwd.copy().update(suffix='inv')
@@ -124,6 +126,8 @@ def run_inverse(
                 exec_params=exec_params,
                 subject=subject,
                 session=session) as report:
+            msg = 'Adding inverse information to report'
+            logger.info(**gen_log_kwargs(message=msg))
             for condition in conditions:
                 cond_str = sanitize_cond_name(condition)
                 key = f'{cond_str}+{method}+hemi'
@@ -152,11 +156,10 @@ def run_inverse(
 
 def get_config(
     *,
-    config,
-    subject,
+    config: SimpleNamespace,
+    subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        exec_params=config.exec_params,
         task=get_task(config),
         datatype=get_datatype(config),
         acq=config.acq,
@@ -179,7 +182,7 @@ def get_config(
     return cfg
 
 
-def main(*, config) -> None:
+def main(*, config: SimpleNamespace) -> None:
     """Run inv."""
     if not config.run_source_estimation:
         msg = 'Skipping, run_source_estimation is set to False …'
@@ -191,7 +194,11 @@ def main(*, config) -> None:
             run_inverse, exec_params=config.exec_params)
         logs = parallel(
             run_func(
-                cfg=get_config(config=config, subject=subject),
+                cfg=get_config(
+                    config=config,
+                    subject=subject,
+                ),
+                exec_params=config.exec_params,
                 subject=subject,
                 session=session,
             )

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -5,6 +5,7 @@ Compute and apply an inverse solution for each evoked data set.
 
 import pathlib
 from types import SimpleNamespace
+from typing import Optional
 
 import mne
 from mne.minimum_norm import (make_inverse_operator, apply_inverse,
@@ -21,7 +22,12 @@ from ..._report import _open_report, _sanitize_cond_tag
 from ..._run import failsafe_run, save_logs, _sanitize_callable
 
 
-def get_input_fnames_inverse(*, cfg, subject, session):
+def get_input_fnames_inverse(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+):
     bids_path = BIDSPath(subject=subject,
                          session=session,
                          task=cfg.task,
@@ -50,7 +56,14 @@ def get_input_fnames_inverse(*, cfg, subject, session):
 @failsafe_run(
     get_input_fnames=get_input_fnames_inverse,
 )
-def run_inverse(*, cfg, subject, session, in_files):
+def run_inverse(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+    in_files: dict,
+) -> dict:
     # TODO: Eventually we should maybe loop over ch_types, e.g., to create
     # MEG, EEG, and MEG+EEG inverses and STCs
     fname_fwd = in_files.pop('forward')
@@ -106,7 +119,11 @@ def run_inverse(*, cfg, subject, session, in_files):
             stc.save(out_files[key], overwrite=True)
             out_files[key] = pathlib.Path(str(out_files[key]) + '-lh.stc')
 
-        with _open_report(cfg=cfg, subject=subject, session=session) as report:
+        with _open_report(
+                cfg=cfg,
+                exec_params=exec_params,
+                subject=subject,
+                session=session) as report:
             for condition in conditions:
                 cond_str = sanitize_cond_name(condition)
                 key = f'{cond_str}+{method}+hemi'

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -189,7 +189,9 @@ def main(*, config: SimpleNamespace) -> None:
         return
 
     log = run_group_average_source(
-        cfg=get_config(config=config),
+        cfg=get_config(
+            config=config,
+        ),
         exec_params=config.exec_params,
         subject='average',
     )

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -4,6 +4,7 @@ Source estimates are morphed to the ``fsaverage`` brain.
 """
 
 from types import SimpleNamespace
+from typing import Optional, List
 
 import numpy as np
 
@@ -16,6 +17,7 @@ from ..._config_utils import (
 )
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import get_parallel_backend, parallel_func
+from ..._report import run_report_average_source
 from ..._run import failsafe_run, save_logs
 
 
@@ -67,8 +69,13 @@ def morph_stc(cfg, subject, fs_subject, session=None):
     return morphed_stcs
 
 
-def run_average(cfg, session, mean_morphed_stcs):
-    subject = 'average'
+def run_average(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+    session: Optional[str],
+    mean_morphed_stcs: List[mne.SourceEstimate],
+):
     bids_path = BIDSPath(subject=subject,
                          session=session,
                          task=cfg.task,
@@ -100,10 +107,9 @@ def run_average(cfg, session, mean_morphed_stcs):
 
 def get_config(
     *,
-    config,
+    config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        exec_params=config.exec_params,
         task=get_task(config),
         task_is_rest=config.task_is_rest,
         datatype=get_datatype(config),
@@ -125,23 +131,25 @@ def get_config(
         use_template_mri=config.use_template_mri,
         all_contrasts=get_all_contrasts(config),
         report_stc_n_time_points=config.report_stc_n_time_points,
-        # TODO: This deviates in the same way as the sensor group avg script
-        exec_params_inner=config.exec_params,
-        interactive=config.interactive,
     )
     return cfg
 
 
 # pass 'average' subject for logging
 @failsafe_run()
-def run_group_average_source(*, cfg, subject='average'):
+def run_group_average_source(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+) -> None:
     """Run group average in source space"""
 
     mne.datasets.fetch_fsaverage(subjects_dir=get_fs_subjects_dir(cfg))
 
-    with get_parallel_backend(cfg.exec_params_inner):
+    with get_parallel_backend(exec_params):
         parallel, run_func = parallel_func(
-            morph_stc, exec_params=cfg.exec_params_inner)
+            morph_stc, exec_params=exec_params)
         all_morphed_stcs = parallel(
             run_func(
                 cfg=cfg, subject=subject,
@@ -163,15 +171,26 @@ def run_group_average_source(*, cfg, subject='average'):
         run_average(
             cfg=cfg,
             session=session,
+            subject=subject,
             mean_morphed_stcs=mean_morphed_stcs
+        )
+        run_report_average_source(
+            cfg=cfg,
+            exec_params=exec_params,
+            subject=subject,
+            session=session,
         )
 
 
-def main(*, config) -> None:
+def main(*, config: SimpleNamespace) -> None:
     if not config.run_source_estimation:
         msg = 'Skipping, run_source_estimation is set to False …'
         logger.info(**gen_log_kwargs(message=msg, emoji='skip'))
         return
 
-    log = run_group_average_source(cfg=get_config(config=config))
+    log = run_group_average_source(
+        cfg=get_config(config=config),
+        exec_params=config.exec_params,
+        subject='average',
+    )
     save_logs(config=config, logs=[log])

--- a/mne_bids_pipeline/tests/configs/config_ds000117.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000117.py
@@ -15,7 +15,7 @@ acq = None
 subjects = ['01']
 
 resample_sfreq = 125.
-crop_runs = (0, 350)  # Reduce memory usage on CI system
+crop_runs = (0, 300)  # Reduce memory usage on CI system
 
 find_flat_channels_meg = False
 find_noisy_channels_meg = False

--- a/mne_bids_pipeline/tests/configs/config_ds000246.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000246.py
@@ -10,7 +10,7 @@ bids_root = '~/mne_data/ds000246'
 deriv_root = '~/mne_data/derivatives/mne-bids-pipeline/ds000246'
 
 runs = ['01']
-crop_runs = (0, 180)  # Reduce memory usage on CI system
+crop_runs = (0, 120)  # Reduce memory usage on CI system
 l_freq = 0.3
 h_freq = 100
 decim = 4
@@ -23,6 +23,7 @@ decode = True
 decoding_time_generalization = True
 decoding_time_generalization_decim = 4
 on_error = 'abort'
+plot_psd_for_runs = []  # too much memory on CIs
 
 parallel_backend = 'dask'
 dask_worker_memory_limit = '2G'

--- a/mne_bids_pipeline/tests/configs/config_ds003392.py
+++ b/mne_bids_pipeline/tests/configs/config_ds003392.py
@@ -16,6 +16,7 @@ ch_types = ['meg']
 l_freq = 1.
 h_freq = 40.
 resample_sfreq = 250
+crop_runs = (0, 180)
 
 # Artifact correction.
 spatial_filter = 'ica'

--- a/mne_bids_pipeline/tests/conftest.py
+++ b/mne_bids_pipeline/tests/conftest.py
@@ -24,6 +24,7 @@ def pytest_configure(config):
     always::ResourceWarning
     ignore:subprocess .* is still running:ResourceWarning
     ignore:`np.MachAr` is deprecated.*:DeprecationWarning
+    ignore:The get_cmap function will be deprecated.*:
     """
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "joblib >= 0.14",
     "threadpoolctl",
     "dask[distributed]",
-    "bokeh",  # for distributed dashboard
+    "bokeh < 3",  # for distributed dashboard
     "jupyter-server-proxy",  # to have dask and jupyter working together
     "scikit-learn",
     "pandas",


### PR DESCRIPTION
### Before merging …

- [x] Separate bad-finding into its own step
- [x] Add raw data plots to report (before preproc)
- [x] Fix logic with `exec_params` by including it in the kwargs, but excluding it from cache via `ignore` arg in `memory.cache(...)`.
- [x] Restore grand-average source space report that was missing/dropped accidentally
- [x] Add bad-channel finding and use for empty-room data
- [x] Changelog has been updated (`docs/source/changes.md`)

Closes #657

It (hopefully) simplifies a bit the file logic. Let's see what the CIs say.