### PR TITLE
MAINT: Remove URL-based reqs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,8 @@ jobs:
           name: Get Python running
           command: |
             pip install --upgrade --progress-bar off pip setuptools
-            pip install -ve .[tests,dev]
+            pip install --upgrade --progress-bar off "autoreject @ https://api.github.com/repos/autoreject/autoreject/zipball/master" "mne[hdf5] @ https://api.github.com/repos/mne-tools/mne-python/zipball/main" "mne-bids[full] @ https://api.github.com/repos/mne-tools/mne-bids/zipball/main"
+            pip install -ve .[tests]
             pip install PyQt6
       - run:
           name: Check Qt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+# Upload a Python Package using Twine when a release is created
+
+name: Build
+on:
+  release:
+    types: [published]
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+    - name: Build package
+      run: python -m build --sdist --wheel
+    - name: Check package
+      run: twine check --strict dist/*
+    - name: Check env vars
+      run: |
+        echo "Triggered by: ${{ github.event_name }}"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist
+
+  # PyPI on release
+  pypi:
+    needs: package
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-tag_regex = "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
+tag_regex = "^(?P<prefix>v)?(?P<version>[0-9.]+)(?P<suffix>.*)?$"
 
 [tool.setuptools.packages.find]
 exclude = ["false"]  # on CircleCI this folder appears during pip install -ve. for an unknown reason

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,6 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = [
-    "autoreject @ https://api.github.com/repos/autoreject/autoreject/zipball/master",
-    "mne[hdf5] @ https://api.github.com/repos/mne-tools/mne-python/zipball/main",
-    "mne-bids[full] @ https://api.github.com/repos/mne-tools/mne-bids/zipball/main",
-]
 tests = [
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-# can be left blank
+tag_regex = "^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 
 [tool.setuptools.packages.find]
 exclude = ["false"]  # on CircleCI this folder appears during pip install -ve. for an unknown reason


### PR DESCRIPTION
I tried to upload to PyPI and got:
```
Invalid value for requires_dist. Error: Can't have direct dependency: "autoreject @ https://api.github.com/repos/autoreject/autoreject/zipball/master ; extra == 'dev'"
```
It seems that PyPI does not want any requirements to be URL-based, so this PR removes the `dev` target that contained all URL-based `main` requirements.