### PR TITLE
MAINT: Use mike for doc deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1156,12 +1156,29 @@ jobs:
       - run:
           <<: *git
       - run:
-          name: Install "gh-pages" CLI app
-          command: |
-            npm install -g --silent gh-pages@3.0.0  # Work around https://github.com/tschaub/gh-pages/issues/354
+          <<: *bashenv
       - run:
           name: Deploy docs to gh-pages branch
-          command: gh-pages --no-history --message "[skip ci] Update docs" --dist docs/site
+          # https://github.com/jimporter/mike
+          command: |
+            git config --global user.email "circle@mne.com"
+            git config --global user.name "Circle CI"
+            # Arguments used in all mike commands
+            ARGS="--push --config-file docs/mkdocs.yml --message=\"[skip ci] Update docs\""
+            echo "Deploying dev"
+            mike deploy dev $ARGS
+            # If it's tagged as v*, deploy as "v*" and "stable" as well
+            if git describe --tags --exact-match $(git rev-parse HEAD); then
+              VERSION="$(git describe --tags --exact-match $(git rev-parse HEAD))"
+              if [[ "$VERSION" == "v"* ]]; then
+                # Trim v1.0.0 to 1.0
+                DEPLOY_VERSION=$(echo $VERSION | sed -nE 's/^v([0-9]+\.[0-9]+).*$$/\1/p')
+                echo "Setting default to \"stable\""
+                mike set-default $ARGS stable
+                echo "Deploying $VERSION as $DEPLOY_VERSION with alias \"stable\""
+                mike deploy $DEPLOY_VERSION stable --update-aliases $ARGS
+              fi
+            fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1164,7 +1164,7 @@ jobs:
             git config --global user.email "circle@mne.com"
             git config --global user.name "Circle CI"
             # Arguments used in all mike commands
-            ARGS="--push --config-file docs/mkdocs.yml --message=\"[skip ci] Update docs\""
+            ARGS="--push --config-file docs/mkdocs.yml"
             echo "Deploying dev"
             mike deploy dev $ARGS
             # If it's tagged as v*, deploy as "v*" and "stable" as well
@@ -1173,8 +1173,6 @@ jobs:
               if [[ "$VERSION" == "v"* ]]; then
                 # Trim v1.0.0 to 1.0
                 DEPLOY_VERSION=$(echo $VERSION | sed -nE 's/^v([0-9]+\.[0-9]+).*$$/\1/p')
-                echo "Setting default to \"stable\""
-                mike set-default $ARGS stable
                 echo "Deploying $VERSION as $DEPLOY_VERSION with alias \"stable\""
                 mike deploy $DEPLOY_VERSION stable --update-aliases $ARGS
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1164,19 +1164,30 @@ jobs:
             git config --global user.email "circle@mne.com"
             git config --global user.name "Circle CI"
             # Arguments used in all mike commands
-            ARGS="--push --config-file docs/mkdocs.yml"
+            ARGS="--config-file docs/mkdocs.yml"
             echo "Deploying dev"
-            mike deploy dev $ARGS
             # If it's tagged as v*, deploy as "v*" and "stable" as well
             if git describe --tags --exact-match $(git rev-parse HEAD); then
               VERSION="$(git describe --tags --exact-match $(git rev-parse HEAD))"
-              if [[ "$VERSION" == "v"* ]]; then
-                # Trim v1.0.0 to 1.0
-                DEPLOY_VERSION=$(echo $VERSION | sed -nE 's/^v([0-9]+\.[0-9]+).*$$/\1/p')
-                echo "Deploying $VERSION as $DEPLOY_VERSION with alias \"stable\""
-                mike deploy $DEPLOY_VERSION stable --update-aliases $ARGS
-              fi
+            else
+              VERSION=""
             fi
+            if [[ "$VERSION" == "v"* ]]; then
+              # Trim v1.0.0 to 1.0
+              KIND='stable'
+              DEPLOY_VERSION=$(echo $VERSION | sed -nE 's/^v([0-9]+\.[0-9]+).*$$/\1/p')
+              echo "Deploying $VERSION as $DEPLOY_VERSION with alias \"stable\""
+              mike deploy $DEPLOY_VERSION stable --update-aliases $ARGS
+            else
+              KIND='dev'
+              mike deploy dev $ARGS
+            fi
+            git checkout gh-pages
+            git reset --soft HEAD~2
+            git commit -qam '${KIND} squash and deploy [ci skip]'
+            git log -n1
+            git push origin --force gh-pages
+
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1183,8 +1183,7 @@ jobs:
               mike deploy dev $ARGS
             fi
             git checkout gh-pages
-            git reset --soft HEAD~2
-            git commit -qam '${KIND} squash and deploy [ci skip]'
+            git reset $(git commit-tree HEAD^{tree} -m "Deploy and squash docs [ci skip]")
             git log -n1
             git push origin --force gh-pages
 

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -16,9 +16,12 @@ echo "CIRCLE_REQUESTED_JOB=$CIRCLE_REQUESTED_JOB"
 # On a PR
 if [[ -v CIRCLE_PULL_REQUEST ]]; then
     # Skip if circle skip has been requested
-    if [[ "$CIRCLE_JOB" != "setup_env" && ( "$COMMIT_MESSAGE" == *"[skip circle]"* || "$COMMIT_MESSAGE" == *"[circle skip]"* ) ]]; then
+    if [[ "$COMMIT_MESSAGE" == *"[skip circle]"* || "$COMMIT_MESSAGE" == *"[circle skip]"* ]]; then
         echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
-        circleci-agent step halt
+        if [[ "$CIRCLE_JOB" != "setup_env" ]]; then
+            # only halt on other jobs -- for setup_env we need to persist stuff
+            circleci-agent step halt
+        fi
         exit 0
     # If no jobs have been specifically requested via [circle jobname], run all tests.
     elif [[ "$CIRCLE_JOB" != "setup_env" && "$CIRCLE_JOB" != "build_docs" && -n $CIRCLE_REQUESTED_JOB && "$CIRCLE_JOB" != *"$CIRCLE_REQUESTED_JOB"* ]]; then

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -6,53 +6,26 @@ set -o pipefail
 export COMMIT_MESSAGE=$(git log --format=oneline -n 1);
 COMMIT_MESSAGE_ESCAPED=${COMMIT_MESSAGE//\'/\\\'}  # escape '
 export COMMIT_MESSAGE_ESCAPED=${COMMIT_MESSAGE_ESCAPED//\"/\\\'}  # escape "
-export CIRCLE_REQUESTED_JOB=$(echo $COMMIT_MESSAGE_ESCAPED | sed -nE 's/^.*\[circle ([^]]+)\].*$/\1/p')
+export CIRCLE_REQUESTED_JOB=$(echo "$COMMIT_MESSAGE_ESCAPED" | sed -nE 's/^.*\[circle ([^]]+)\].*$/\1/p')
 
 echo "CIRCLE_JOB=$CIRCLE_JOB"
 echo "COMMIT_MESSAGE=$COMMIT_MESSAGE"
 echo "COMMIT_MESSAGE_ESCAPED=$COMMIT_MESSAGE_ESCAPED"
 echo "CIRCLE_REQUESTED_JOB=$CIRCLE_REQUESTED_JOB"
 
-# Leave here for reference. This only runs all jobs upon [circle full] in the
-# commit message, or jobs that were explicitly requersted.
-#
-# On a PR, only run setup_env, build_docs, and the requested job(s). If no
-# jobs have been specifically requested, run ds000247.
-# if [[
-#     -v CIRCLE_PULL_REQUEST &&
-#     "$CIRCLE_REQUESTED_JOB" != "full" &&
-#     "$CIRCLE_JOB" != "setup_env" &&
-#     "$CIRCLE_JOB" != "build_docs"
-#    ]] && [[
-#        (-n $CIRCLE_REQUESTED_JOB &&  # Specific job requested -> run only that one
-#         "$CIRCLE_JOB" != *"$CIRCLE_REQUESTED_JOB"*) ||
-#        (-z $CIRCLE_REQUESTED_JOB &&  # no specific job requested -> run only ds000247
-#         "$CIRCLE_JOB" != *"ds000247")
-#     ]]; then
-#         echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
-#         circleci-agent step halt
-# # Otherwise, run everything
-# elif [[ -v CIRCLE_PULL_REQUEST ]]; then
-#     echo "Running job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}"
-# else
-#     echo "Running job ${CIRCLE_JOB} for ${CIRCLE_BRANCH} branch"
-# fi
-
-# On a PR, only run setup_env, build_docs, and the requested job(s). If no
-# jobs have been specifically requested via [circle jobname], run all tests.
-if [[
-    -v CIRCLE_PULL_REQUEST &&
-    "$CIRCLE_JOB" != "setup_env" &&
-    "$CIRCLE_JOB" != "build_docs"
-   ]] && [[
-        -n $CIRCLE_REQUESTED_JOB &&  # Specific job requested -> run only that one
-        "$CIRCLE_JOB" != *"$CIRCLE_REQUESTED_JOB"*
-    ]]; then
+# On a PR
+if [[ -v CIRCLE_PULL_REQUEST ]]; then
+    # Skip if circle skip has been requested
+    if [[ "$COMMIT_MESSAGE" == *"[skip circle]"* || "$COMMIT_MESSAGE" == *"[circle skip]"* ]]; then
         echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
         circleci-agent step halt
         exit 0
-# Otherwise, run everything
-elif [[ -v CIRCLE_PULL_REQUEST ]]; then
+    # If no jobs have been specifically requested via [circle jobname], run all tests.
+    elif [[ "$CIRCLE_JOB" != "setup_env" && "$CIRCLE_JOB" != "build_docs" && -n $CIRCLE_REQUESTED_JOB && "$CIRCLE_JOB" != *"$CIRCLE_REQUESTED_JOB"* ]]; then
+        echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
+        circleci-agent step halt
+        exit 0
+    fi
     echo "Running job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}"
 else
     echo "Running job ${CIRCLE_JOB} for ${CIRCLE_BRANCH} branch"
@@ -62,8 +35,8 @@ fi
 sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0 /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
 wget -q -O- http://neuro.debian.net/lists/focal.us-tn.libre | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
 sudo apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com 0xA5D32F012649A5A9
-echo "export RUN_TESTS=\"pytest mne_bids_pipeline --junit-xml=test-results/junit-results.xml -k\"" >> $BASH_ENV
-echo "export DOWNLOAD_DATA=\"python -m mne_bids_pipeline._download\"" >> $BASH_ENV
+echo "export RUN_TESTS=\"pytest mne_bids_pipeline --junit-xml=test-results/junit-results.xml -k\"" >> "$BASH_ENV"
+echo "export DOWNLOAD_DATA=\"python -m mne_bids_pipeline._download\"" >> "$BASH_ENV"
 
 # Similar CircleCI setup to mne-python (Xvfb, venv, minimal commands, env vars)
 wget -q https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/setup_xvfb.sh
@@ -73,16 +46,16 @@ python3.10 -m venv ~/python_env
 wget -q https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/get_minimal_commands.sh
 source get_minimal_commands.sh
 mkdir -p ~/mne_data
-echo "set -e" >> $BASH_ENV;
-echo 'export OPENBLAS_NUM_THREADS=2' >> $BASH_ENV;
-echo 'shopt -s globstar' >> $BASH_ENV;  # Enable recursive globbing via **
-echo 'export MNE_DATA=$HOME/mne_data' >> $BASH_ENV;
-echo "export PATH=~/.local/bin/:$PATH" >> $BASH_ENV
-echo 'export DISPLAY=:99' >> $BASH_ENV;
-echo 'export XDG_RUNTIME_DIR=/tmp/runtime-circleci' >> $BASH_ENV;
-echo 'export MPLBACKEND=Agg' >> $BASH_ENV;
-echo "source ~/python_env/bin/activate" >> $BASH_ENV
-echo 'export MNE_3D_OPTION_MULTI_SAMPLES=1' >> $BASH_ENV;
+echo "set -e" >> "$BASH_ENV"
+echo 'export OPENBLAS_NUM_THREADS=2' >> "$BASH_ENV"
+echo 'shopt -s globstar' >> "$BASH_ENV"  # Enable recursive globbing via **
+echo 'export MNE_DATA=$HOME/mne_data' >> "$BASH_ENV"
+echo "export PATH=~/.local/bin/:$PATH" >> "$BASH_ENV"
+echo 'export DISPLAY=:99' >> "$BASH_ENV"
+echo 'export XDG_RUNTIME_DIR=/tmp/runtime-circleci' >> "$BASH_ENV"
+echo 'export MPLBACKEND=Agg' >> "$BASH_ENV"
+echo "source ~/python_env/bin/activate" >> "$BASH_ENV"
+echo "export MNE_3D_OPTION_MULTI_SAMPLES=1" >> "$BASH_ENV"
 mkdir -p ~/.local/bin
 if [[ ! -f ~/.local/bin/python ]]; then
     ln -s ~/python_env/bin/python ~/.local/bin/python

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -16,7 +16,7 @@ echo "CIRCLE_REQUESTED_JOB=$CIRCLE_REQUESTED_JOB"
 # On a PR
 if [[ -v CIRCLE_PULL_REQUEST ]]; then
     # Skip if circle skip has been requested
-    if [[ "$COMMIT_MESSAGE" == *"[skip circle]"* || "$COMMIT_MESSAGE" == *"[circle skip]"* ]]; then
+    if [[ "$CIRCLE_JOB" != "setup_env" && ( "$COMMIT_MESSAGE" == *"[skip circle]"* || "$COMMIT_MESSAGE" == *"[circle skip]"* ) ]]; then
         echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
         circleci-agent step halt
         exit 0

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -16,12 +16,9 @@ echo "CIRCLE_REQUESTED_JOB=$CIRCLE_REQUESTED_JOB"
 # On a PR
 if [[ -v CIRCLE_PULL_REQUEST ]]; then
     # Skip if circle skip has been requested
-    if [[ "$COMMIT_MESSAGE" == *"[skip circle]"* || "$COMMIT_MESSAGE" == *"[circle skip]"* ]]; then
+    if [[ "$CIRCLE_JOB" != "setup_env" && ( "$COMMIT_MESSAGE" == *"[skip circle]"* || "$COMMIT_MESSAGE" == *"[circle skip]"* ) ]]; then
         echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
-        if [[ "$CIRCLE_JOB" != "setup_env" ]]; then
-            # only halt on other jobs -- for setup_env we need to persist stuff
-            circleci-agent step halt
-        fi
+        circleci-agent step halt
         exit 0
     # If no jobs have been specifically requested via [circle jobname], run all tests.
     elif [[ "$CIRCLE_JOB" != "setup_env" && "$CIRCLE_JOB" != "build_docs" && -n $CIRCLE_REQUESTED_JOB && "$CIRCLE_JOB" != *"$CIRCLE_REQUESTED_JOB"* ]]; then

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
     - name: Install flake8 and codespell
-      run: pip install flake8 codespell tomli
+      run: pip install flake8 flake8-pyproject codespell tomli
     - run: make flake
     - run: make codespell-error
   check-doc:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ trailing-spaces:
 	find . -name "*.py" | xargs perl -pi -e 's/[ \t]*$$//'
 
 flake:
-	flake8 . --exclude "**/freesurfer/contrib,docs/,dist/,build/"
+	flake8
 	@echo "flake8 passed"
 
 codespell:  # running manually; auto-fix spelling mistakes

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -28,6 +28,9 @@ extra:
         - icon: fontawesome/brands/twitter
           link: https://twitter.com/mne_news
           name: MNE news on Twitter
+    version:
+        provider: mike
+        default: stable
 
 copyright: Copyright &copy; MNE-BIDS-Pipeline authors
 
@@ -106,6 +109,8 @@ plugins:
         watch:
             - .
             - ./mne_bids_pipeline/_config.py
+    - mike:
+        canonical_version: stable
 markdown_extensions:
     - admonition
     - abbr

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  You're not viewing the latest stable version of MNE-BIDS-Pipeline.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to stable.</strong>
+  </a>
+{% endblock %}

--- a/docs/source/examples/gen_examples.py
+++ b/docs/source/examples/gen_examples.py
@@ -13,6 +13,7 @@ from mne_bids_pipeline._config_import import _import_config
 import mne_bids_pipeline.tests.datasets
 from mne_bids_pipeline.tests.test_run import TEST_SUITE
 from mne_bids_pipeline.tests.datasets import DATASET_OPTIONS
+from tqdm import tqdm
 
 this_dir = Path(__file__).parent
 root = Path(mne_bids_pipeline.__file__).parent.resolve(strict=True)
@@ -87,6 +88,7 @@ def _gen_demonstrated_funcs(example_config_path: Path) -> dict:
 
 # Copy reports to the correct place.
 datasets_without_html = []
+logger.warning(f'  Copying reports to {this_dir}/<dataset_name> …')
 for test_name, test_dataset_options in TEST_SUITE.items():
     if 'ERP_CORE' in test_name:
         dataset_name = test_dataset_options['dataset']
@@ -107,13 +109,25 @@ for test_name, test_dataset_options in TEST_SUITE.items():
         datasets_without_html.append(dataset_name)
         continue
 
-    for fname in html_report_fnames:
-        logger.info(f'Copying {fname} to {example_target_dir}')
+    fname_iter = tqdm(
+        html_report_fnames,
+        desc=f'  {test_name}',
+        unit='file',
+        leave=False,
+    )
+    for fname in fname_iter:
         shutil.copy(src=fname, dst=example_target_dir)
 
 # Now, generate the respective markdown example descriptions.
 all_demonstrated = dict()
-for test_dataset_name, test_dataset_options in TEST_SUITE.items():
+logger.warning('  Generating example markdown files …')
+ds_iter = tqdm(
+    list(TEST_SUITE.items()),
+    desc='  ',
+    unit='file',
+    leave=False,
+)
+for test_dataset_name, test_dataset_options in ds_iter:
     if 'ERP_CORE' in test_dataset_name:
         dataset_name = test_dataset_options['dataset']
     else:
@@ -132,8 +146,6 @@ for test_dataset_name, test_dataset_options in TEST_SUITE.items():
     if dataset_name in datasets_without_html:
         logger.warning(f'Dataset {dataset_name} has no HTML report.')
         continue
-
-    logger.warning(f'Generating markdown file for dataset: {dataset_name}')
 
     options = DATASET_OPTIONS[dataset_options_key]
 

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -592,7 +592,7 @@ def run_report_average_sensor(
         #
         if all_evokeds:
             msg = (
-                f'Adding {len(evokeds)} evoked signals and contrasts to '
+                f'Adding {len(all_evokeds)} evoked signals and contrasts to '
                 'the report.'
             )
         else:

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -578,6 +578,14 @@ def run_report_average_sensor(
         #
         # Visualize evoked responses.
         #
+        if all_evokeds:
+            msg = (
+                f'Adding {len(evokeds)} evoked signals and contrasts to '
+                'the report.'
+            )
+        else:
+            msg = 'No evoked conditions or contrasts found.'
+        logger.info(**gen_log_kwargs(message=msg))
         for condition, evoked in all_evokeds.items():
             tags = ('evoked', _sanitize_cond_tag(condition))
             if condition in cfg.conditions:
@@ -602,11 +610,15 @@ def run_report_average_sensor(
         # Visualize decoding results.
         #
         if cfg.decode and cfg.decoding_contrasts:
+            msg = 'Adding decoding results.'
+            logger.info(**gen_log_kwargs(message=msg))
             add_decoding_grand_average(
                 session=session, cfg=cfg, report=report
             )
 
         if cfg.decode and cfg.decoding_csp:
+            # No need for a separate message here because these are very quick
+            # and the general message above is sufficient
             add_csp_grand_average(
                 session=session, cfg=cfg, report=report
             )

--- a/mne_bids_pipeline/tests/conftest.py
+++ b/mne_bids_pipeline/tests/conftest.py
@@ -25,6 +25,7 @@ def pytest_configure(config):
     ignore:subprocess .* is still running:ResourceWarning
     ignore:`np.MachAr` is deprecated.*:DeprecationWarning
     ignore:The get_cmap function will be deprecated.*:
+    ignore:make_current is deprecated.*:DeprecationWarning
     """
     for warning_line in warning_lines.split('\n'):
         warning_line = warning_line.strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ tests = [
     "pytest-cov",
     "psutil",
     "datalad",
+    "flake8",
+    "flake8-pyproject",
     "mkdocs",
     "mkdocs-material",
     "mkdocs-material-extensions",
@@ -101,3 +103,6 @@ testpaths = [
     "mne_bids_pipeline",
 ]
 junit_family = "xunit2"
+
+[tool.flake8]
+exclude = "**/freesurfer/contrib,docs/,dist/,build/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ tests = [
     "mkdocs-macros-plugin",
     "mkdocs-include-markdown-plugin",
     "mkdocstrings-python",
+    "mike",
     "jinja2",
     "black",  # function signature formatting
     "livereload",


### PR DESCRIPTION
My plan is to first build and deploy two versions of the docs (`1.0`/`stable` and `dev`) with:
```
$ rm -rf ~/mne_data/derivatives/mne-bids-pipeline  # clean runs
$ git checkout v1.0.0       # so that the correct version shows up in sys_info in the reports
$ pip install --no-build-isolation -ve .
...
Successfully installed mne-bids-pipeline-1.0.0
$ pytest mne_bids_pipeline --pdb # build all report HTMLs (without dask)
$ git checkout mike         # switch to this PR's branch so docs build with correct dropdowns, etc
$ ./docs/build_docs.sh  # get one clean update
$ ARGS="--config-file docs/mkdocs.yml --remote=upstream"
$ mike delete --all $ARGS
$ mike deploy 1.0 stable --update-aliases $ARGS
$ mike set-default $ARGS stable
$ mike deploy dev $ARGS
$ mike serve $ ARGS  # visual inspection
$ git checkout gh-pages
$ git reset $(git commit-tree HEAD^{tree} -m "Deploy and squash docs [ci skip]")
$ git push upstream -f gh-pages  # old commit was 2804f662fa839cc90af26b2926f7e0ef368c89ca
```
Then I can examine the docs to make sure they look okay, then `git push` the `gh-pages` branch.

Once that works, this can be merged and we can see the `dev` docs deploy on their own :crossed_fingers: In theory the next tagged release should also work but we'll have to find out the hard way when we release the next `vX.Y.Z`.

Closes #636
Closes #673
Closes #201

No need for `doc/changes.md` update since it's all infra.