### PR TITLE
BUG: Fix bug with dev version numbering

### DIFF
--- a/mne_bids_pipeline/__init__.py
+++ b/mne_bids_pipeline/__init__.py
@@ -4,4 +4,4 @@ try:
     __version__ = version("mne_bids_pipeline")
 except PackageNotFoundError:
     # package is not installed
-    pass
+    __version__ = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 tag_regex = "^(?P<prefix>v)?(?P<version>[0-9.]+)(?P<suffix>.*)?$"
+version_scheme = "release-branch-semver"
 
 [tool.setuptools.packages.find]
 exclude = ["false"]  # on CircleCI this folder appears during pip install -ve. for an unknown reason


### PR DESCRIPTION
With this change I get `1.2.0.dev4+g12735039.d20230301` instead of `1.1.1.dev4+g12735039.d20230301` as the version (note the proper minor version bump).

Also a tiny change where `__version__` always gets set.

No need for `changelog` update I think since this is a dev-facing change