### PR TITLE
Always generate grand-averaged CSP decoding results if CSP was used on single-subject level

### DIFF
--- a/docs/source/v1.3.md.inc
+++ b/docs/source/v1.3.md.inc
@@ -16,3 +16,4 @@
 
 - Fix pandas 2.0 compatibility (#732 by @larsoner)
 - Fix bug with `mne.sys_info` insertion in reports (#732 by @larsoner)
+- Always generate CSP decdoing grand average analysis if CSP decoding was used on the single-subjec level (#733 by @hoechenberger)

--- a/docs/source/v1.3.md.inc
+++ b/docs/source/v1.3.md.inc
@@ -16,4 +16,4 @@
 
 - Fix pandas 2.0 compatibility (#732 by @larsoner)
 - Fix bug with `mne.sys_info` insertion in reports (#732 by @larsoner)
-- Always generate CSP decdoing grand average analysis if CSP decoding was used on the single-subjec level (#733 by @hoechenberger)
+- Always generate CSP decdoing grand average analysis if CSP decoding was used on the single-subject level (#733 by @hoechenberger)

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -665,7 +665,7 @@ def run_group_average_sensor(
             if cfg.decode:
                 average_full_epochs_decoding(cfg, session)
                 average_time_by_time_decoding(cfg, session)
-        if cfg.decode and cfg.decoding_csp:
+        if cfg.decoding_csp:
             parallel, run_func = parallel_func(
                 average_csp_decoding, exec_params=exec_params
             )


### PR DESCRIPTION
Fixes #731

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
