### PR TITLE
Re-enable the copy button for code blocks in the documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -17,6 +17,7 @@ theme:
         - navigation.tabs
         - navigation.instant  # Load pages via XMLHttpRequest (XHR)
         - navigation.tracking
+        - content.code.copy  # copy button
     palette:
       # Palette toggle for automated theme selection
       # Currently only available to sponsors


### PR DESCRIPTION
Fixes #730

Not sure if we need a changelog entry for this one?

### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
