### PR TITLE
MAINT: Dont use deprecated book API

### DIFF
--- a/docs/source/v1.3.md.inc
+++ b/docs/source/v1.3.md.inc
@@ -10,9 +10,9 @@
 
 [//]: # (- Whatever (#000 by @whoever))
 
-[//]: # (### :medical_symbol: Code health)
+### :medical_symbol: Code health
 
-[//]: # (- Whatever (#000 by @whoever))
+- Avoid using deprecated `openpyxl` API when working with Excel spreadsheets (#735 by @larsoner)
 
 ### :bug: Bug fixes)
 

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -15,7 +15,6 @@ from types import SimpleNamespace
 
 from joblib import Memory
 import json_tricks
-from openpyxl import load_workbook
 import pandas as pd
 from mne_bids import BIDSPath
 
@@ -301,24 +300,12 @@ def save_logs(*, config: SimpleNamespace, logs) -> None:  # TODO add type
 
     df = df[columns]
 
-    if fname.exists():
-        book = None
-        try:
-            book = load_workbook(fname)
-        except Exception:  # bad file
-            pass
-        else:
-            if sheet_name in book:
-                book.remove(book[sheet_name])
-        writer = pd.ExcelWriter(fname, engine="openpyxl")
-        if book is not None:
-            try:
-                writer.book = book
-            except Exception:
-                pass  # AttributeError: can't set attribute 'book' (?)
-    else:
-        writer = pd.ExcelWriter(fname, engine="openpyxl")
-
+    writer = pd.ExcelWriter(
+        fname,
+        engine="openpyxl",
+        mode="a",
+        if_sheet_exists="replace",
+    )
     with writer:
         df.to_excel(writer, sheet_name=sheet_name, index=False)
 

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -301,12 +301,13 @@ def save_logs(*, config: SimpleNamespace, logs) -> None:  # TODO add type
 
     df = df[columns]
 
+    append = fname.exists()
     with FileLock(fname.with_suffix(fname.suffix + ".lock")):
         writer = pd.ExcelWriter(
             fname,
             engine="openpyxl",
-            mode="a" if fname.exists() else "w",
-            if_sheet_exists="replace",
+            mode="a" if append else "w",
+            if_sheet_exists="replace" if append else None,
         )
         with writer:
             df.to_excel(writer, sheet_name=sheet_name, index=False)

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -303,7 +303,7 @@ def save_logs(*, config: SimpleNamespace, logs) -> None:  # TODO add type
     writer = pd.ExcelWriter(
         fname,
         engine="openpyxl",
-        mode="a",
+        mode="a" if fname.exists() else "w",
         if_sheet_exists="replace",
     )
     with writer:

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -301,8 +301,8 @@ def save_logs(*, config: SimpleNamespace, logs) -> None:  # TODO add type
 
     df = df[columns]
 
-    append = fname.exists()
     with FileLock(fname.with_suffix(fname.suffix + ".lock")):
+        append = fname.exists()
         writer = pd.ExcelWriter(
             fname,
             engine="openpyxl",

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -13,6 +13,7 @@ import time
 from typing import Callable, Optional, Dict, List
 from types import SimpleNamespace
 
+from filelock import FileLock
 from joblib import Memory
 import json_tricks
 import pandas as pd
@@ -300,14 +301,15 @@ def save_logs(*, config: SimpleNamespace, logs) -> None:  # TODO add type
 
     df = df[columns]
 
-    writer = pd.ExcelWriter(
-        fname,
-        engine="openpyxl",
-        mode="a" if fname.exists() else "w",
-        if_sheet_exists="replace",
-    )
-    with writer:
-        df.to_excel(writer, sheet_name=sheet_name, index=False)
+    with FileLock(fname.with_suffix(fname.suffix + ".lock")):
+        writer = pd.ExcelWriter(
+            fname,
+            engine="openpyxl",
+            mode="a" if fname.exists() else "w",
+            if_sheet_exists="replace",
+        )
+        with writer:
+            df.to_excel(writer, sheet_name=sheet_name, index=False)
 
 
 def _update_for_splits(


### PR DESCRIPTION
I think this preserves the original intent: append anything that's new (`mode='a'`) but replace the given sheet name if it exists. `if_sheet_exists` is available as of Pandas 1.3 (July 2021) so it seems fine to use.

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

Closes #721