### PR TITLE
MAINT: Use rich instead of coloredlogs

### DIFF
--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -56,6 +56,7 @@ echo 'export XDG_RUNTIME_DIR=/tmp/runtime-circleci' >> "$BASH_ENV"
 echo 'export MPLBACKEND=Agg' >> "$BASH_ENV"
 echo "source ~/python_env/bin/activate" >> "$BASH_ENV"
 echo "export MNE_3D_OPTION_MULTI_SAMPLES=1" >> "$BASH_ENV"
+echo "export MNE_BIDS_PIPELINE_FORCE_TERMINAL=true" >> "$BASH_ENV"
 mkdir -p ~/.local/bin
 if [[ ! -f ~/.local/bin/python ]]; then
     ln -s ~/python_env/bin/python ~/.local/bin/python

--- a/docs/source/v1.3.md.inc
+++ b/docs/source/v1.3.md.inc
@@ -3,7 +3,7 @@
 ### :new: New features & enhancements
 
 - Provide a more helpful log message if the CSP decoding step is being skipped (#734 by @hoechenberger)
-- Use `rich` for improved logging control and styling (#736 by @larsoner)
+- Use `rich` for improved logging control and styling (#737 by @larsoner)
 
 [//]: # (- Whatever (#000 by @whoever))
 

--- a/docs/source/v1.3.md.inc
+++ b/docs/source/v1.3.md.inc
@@ -3,6 +3,7 @@
 ### :new: New features & enhancements
 
 - Provide a more helpful log message if the CSP decoding step is being skipped (#734 by @hoechenberger)
+- Use `rich` for improved logging control and styling (#736 by @larsoner)
 
 [//]: # (- Whatever (#000 by @whoever))
 

--- a/mne_bids_pipeline/_logging.py
+++ b/mne_bids_pipeline/_logging.py
@@ -2,6 +2,7 @@
 import datetime
 import inspect
 import logging
+import os
 from typing import Optional, Union
 
 import rich.console
@@ -23,7 +24,10 @@ class _MBPLogger:
         except AttributeError:
             pass  # need to instantiate it, continue
 
-        kwargs = dict(soft_wrap=True)
+        force_terminal = os.getenv("MNE_BIDS_PIPELINE_FORCE_TERMINAL", None)
+        if force_terminal is not None:
+            force_terminal = force_terminal.lower() in ("true", "1")
+        kwargs = dict(soft_wrap=True, force_terminal=force_terminal)
         kwargs["theme"] = rich.theme.Theme(
             dict(
                 default="white",

--- a/mne_bids_pipeline/_logging.py
+++ b/mne_bids_pipeline/_logging.py
@@ -1,97 +1,100 @@
 """Logging."""
+import datetime
 import inspect
 import logging
 from typing import Optional, Union
 
-import coloredlogs
+import rich.console
+import rich.theme
 
 from .typing import LogKwargsT
 
-logger = logging.getLogger("mne-bids-pipeline")
 
-log_level_styles = {
-    "info": {
-        "bright": True,
-        "bold": True,
-    },
-    "warning": {"color": 202, "bold": True},
-    "error": {"background": "red", "bold": True},
-    "critical": {"background": "red", "bold": True},
-}
-log_field_styles = {
-    "asctime": {"color": "green"},
-    "box": {
-        "color": "cyan",
-        "bold": True,
-        "bright": True,
-    },
-    "step": {
-        "color": "cyan",
-        "bold": True,
-        "bright": True,
-    },
-    "msg": {
-        "color": "cyan",
-        "bold": True,
-        "bright": False,
-    },
-    "subject": {
-        "color": "cyan",
-        "bright": True,
-        "bold": True,
-    },
-    "session": {
-        "color": "cyan",
-        "bold": True,
-        "bright": False,
-    },
-    "run": {
-        "color": "cyan",
-        "bold": True,
-        "bright": False,
-    },
-    "message": {
-        "color": "white",
-        "bold": True,
-        "bright": True,
-    },
-}
-log_fmt = "[%(asctime)s] %(box)s%(step)s%(subject)s%(session)s%(run)s%(message)s"
-log_date_fmt = "%H:%M:%S"
+class _MBPLogger:
+    def __init__(self):
+        self._level = logging.INFO
+
+    # Do lazy instantiation of _console so that pytest's output capture
+    # mechanics don't get messed up
+    @property
+    def _console(self):
+        try:
+            return self.__console
+        except AttributeError:
+            pass  # need to instantiate it, continue
+
+        kwargs = dict()
+        kwargs["theme"] = rich.theme.Theme(
+            dict(
+                default="white",
+                # Prefixes
+                asctime="green",
+                step="bold cyan",
+                # Messages
+                debug="dim",
+                info="bold",
+                warning="bold magenta",
+                error="bold red",
+            )
+        )
+        self.__console = rich.console.Console(**kwargs)
+        return self.__console
+
+    @property
+    def level(self):
+        return self._level
+
+    @level.setter
+    def level(self, level):
+        level = int(level)
+        self._level = level
+
+    def debug(self, msg: str, *, extra: Optional[LogKwargsT] = None) -> None:
+        self._log_message(kind="debug", msg=msg, **(extra or {}))
+
+    def info(self, msg: str, *, extra: Optional[LogKwargsT] = None) -> None:
+        self._log_message(kind="info", msg=msg, **(extra or {}))
+
+    def warning(self, msg: str, *, extra: Optional[LogKwargsT] = None) -> None:
+        self._log_message(kind="warning", msg=msg, **(extra or {}))
+
+    def error(self, msg: str, *, extra: Optional[LogKwargsT] = None) -> None:
+        self._log_message(kind="error", msg=msg, **(extra or {}))
+
+    def _log_message(
+        self,
+        kind: str,
+        msg: str,
+        subject: Optional[Union[str, int]] = None,
+        session: Optional[Union[str, int]] = None,
+        run: Optional[Union[str, int]] = None,
+        step: Optional[str] = None,
+        emoji: str = "",
+        box: str = "",
+    ):
+        this_level = getattr(logging, kind.upper())
+        if this_level < self.level:
+            return
+        if not subject:
+            subject = ""
+        if not session:
+            session = ""
+        if not run:
+            run = ""
+        if not step:
+            step = ""
+        if step and emoji:
+            step = f"{emoji} {step}"
+        asctime = datetime.datetime.now().strftime("[%H:%M:%S]")
+        msg = (
+            f"[asctime]{asctime}[/asctime] "
+            f"[step]{box}{step}{subject}{session}{run}[/step]"
+            f"[{kind}]{msg}[/{kind}]"
+        )
+        self._console.print(msg)
 
 
-class LogFilter(logging.Filter):
-    def filter(self, record):
-        if not hasattr(record, "step"):
-            record.step = ""
-        if not hasattr(record, "subject"):
-            record.subject = ""
-        if not hasattr(record, "session"):
-            record.session = ""
-        if not hasattr(record, "run"):
-            record.run = ""
-        if not hasattr(record, "box"):
-            record.box = "│ "
-
-        return True
-
-
-logger.addFilter(LogFilter())
-
-
-def _install_logs():
-    coloredlogs.DEFAULT_DATE_FORMAT = log_date_fmt
-    coloredlogs.install(
-        fmt=log_fmt,
-        level="info",
-        logger=logger,
-        level_styles=log_level_styles,
-        field_styles=log_field_styles,
-        date_fmt=log_date_fmt,
-    )
-
-
-_install_logs()
+logger = _MBPLogger()
 
 
 def gen_log_kwargs(

--- a/mne_bids_pipeline/_logging.py
+++ b/mne_bids_pipeline/_logging.py
@@ -23,7 +23,7 @@ class _MBPLogger:
         except AttributeError:
             pass  # need to instantiate it, continue
 
-        kwargs = dict()
+        kwargs = dict(soft_wrap=True)
         kwargs["theme"] = rich.theme.Theme(
             dict(
                 default="white",

--- a/mne_bids_pipeline/_main.py
+++ b/mne_bids_pipeline/_main.py
@@ -10,7 +10,7 @@ import numpy as np
 from ._config_utils import _get_step_modules
 from ._config_import import _import_config
 from ._config_template import create_template_config
-from ._logging import logger, gen_log_kwargs, _install_logs
+from ._logging import logger, gen_log_kwargs
 from ._run import _short_step_path
 
 
@@ -193,7 +193,6 @@ def main():
         # them twice.
         step_modules = [*STEP_MODULES["init"], *step_modules]
 
-    _install_logs()
     msg = "Welcome aboard the MNE BIDS Pipeline!"
     logger.info(**gen_log_kwargs(message=msg, emoji="👋", box="╶╴", step=""))
     msg = f"Using configuration: {config}"

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -82,13 +82,13 @@ def failsafe_run(
                         )
                     if os.getenv("_MNE_BIDS_STUDY_TESTING", "") == "true":
                         raise
-                    logger.critical(
+                    logger.error(
                         **gen_log_kwargs(message=message, **kwargs_copy, emoji="❌")
                     )
                     sys.exit(1)
                 elif on_error == "debug":
                     message += "\n\nStarting post-mortem debugger."
-                    logger.critical(
+                    logger.error(
                         **gen_log_kwargs(message=message, **kwargs_copy, emoji="🐛")
                     )
                     extype, value, tb = sys.exc_info()
@@ -97,7 +97,7 @@ def failsafe_run(
                     sys.exit(1)
                 else:
                     message += "\n\nContinuing pipeline run."
-                    logger.critical(
+                    logger.error(
                         **gen_log_kwargs(message=message, **kwargs_copy, emoji="🔂")
                     )
             log_info["time"] = round(time.time() - t0, ndigits=1)

--- a/mne_bids_pipeline/typing.py
+++ b/mne_bids_pipeline/typing.py
@@ -17,7 +17,6 @@ class ArbitraryContrast(TypedDict):
 class LogKwargsT(TypedDict):
     msg: str
     extra: Dict[str, str]
-    box: str
 
 
 class ReferenceRunParams(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pandas",
     "seaborn",
     "json_tricks",
-    "coloredlogs",
+    "rich",
     "python-picard",
     "qtpy",
     "pyvista",


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

For now I tried to keep the styling pretty similar. One immediate advantage is that `rich` autodetects filenames and makes them magenta, which is cool!

Follow-up PRs could use better box drawing, titling/horizontal ruling, etc. I'll leave that to you @hoechenberger :)

Closes #726