### PR TITLE
MAINT: DRY kwarg passing

### DIFF
--- a/docs/source/v1.4.md.inc
+++ b/docs/source/v1.4.md.inc
@@ -8,9 +8,9 @@
 
 [//]: # (- Whatever (#000 by @whoever))
 
-[//]: # (### :medical_symbol: Code health)
+### :medical_symbol: Code health
 
-[//]: # (- Whatever (#000 by @whoever))
+- Refactor code to deduplicate keyword-passing (#746 by @larsoner)
 
 ### :bug: Bug fixes
 

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -557,3 +557,17 @@ def _get_step_modules() -> Dict[str, Tuple[ModuleType]]:
     )
 
     return STEP_MODULES
+
+
+def _bids_kwargs(*, config: SimpleNamespace) -> dict:
+    """Get the standard BIDS config entries."""
+    return dict(
+        proc=config.proc,
+        task=get_task(config),
+        datatype=get_datatype(config),
+        acq=config.acq,
+        rec=config.rec,
+        space=config.space,
+        bids_root=config.bids_root,
+        deriv_root=config.deriv_root,
+    )

--- a/mne_bids_pipeline/steps/init/_01_init_derivatives_dir.py
+++ b/mne_bids_pipeline/steps/init/_01_init_derivatives_dir.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from mne_bids.config import BIDS_VERSION
 from mne_bids.utils import _write_json
 
-from ..._config_utils import get_datatype, get_subjects, get_sessions
+from ..._config_utils import get_subjects, get_sessions, _bids_kwargs
 from ..._logging import gen_log_kwargs, logger
 from ..._run import failsafe_run
 
@@ -62,11 +62,10 @@ def get_config(
     config,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        datatype=get_datatype(config),
-        deriv_root=config.deriv_root,
         PIPELINE_NAME=config.PIPELINE_NAME,
         VERSION=config.VERSION,
         CODE_URL=config.CODE_URL,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/init/_02_find_empty_room.py
+++ b/mne_bids_pipeline/steps/init/_02_find_empty_room.py
@@ -8,10 +8,10 @@ from mne_bids import BIDSPath
 
 from ..._config_utils import (
     get_datatype,
-    get_task,
     get_sessions,
     get_subjects,
     get_runs,
+    _bids_kwargs,
 )
 from ..._io import _empty_room_match_path, _write_json
 from ..._logging import gen_log_kwargs, logger
@@ -21,7 +21,7 @@ from ..._run import _update_for_splits, failsafe_run, save_logs
 def get_input_fnames_find_empty_room(
     *, subject: str, session: Optional[str], run: Optional[str], cfg: SimpleNamespace
 ) -> Dict[str, BIDSPath]:
-    """Get paths of files required by filter_data function."""
+    """Get paths of files required by find_empty_room function."""
     bids_path_in = BIDSPath(
         subject=subject,
         run=run,
@@ -104,14 +104,7 @@ def get_config(
     config,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        proc=config.proc,
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        bids_root=config.bids_root,
-        deriv_root=config.deriv_root,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -15,9 +15,6 @@ from ..._config_utils import (
     get_subjects,
     get_sessions,
     get_runs,
-    get_task,
-    get_datatype,
-    get_mf_reference_run,
 )
 from ..._import_data import (
     _get_raw_paths,
@@ -25,6 +22,7 @@ from ..._import_data import (
     import_er_data,
     _bads_path,
     _auto_scores_path,
+    _import_data_kwargs,
 )
 from ..._io import _write_json
 from ..._logging import gen_log_kwargs, logger
@@ -294,40 +292,9 @@ def get_config(
         )
         extra_kwargs["mf_head_origin"] = config.mf_head_origin
     cfg = SimpleNamespace(
-        process_empty_room=config.process_empty_room,
-        process_rest=config.process_rest,
-        task_is_rest=config.task_is_rest,
-        runs=get_runs(config=config, subject=subject),
-        proc=config.proc,
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        bids_root=config.bids_root,
-        deriv_root=config.deriv_root,
-        reader_extra_params=config.reader_extra_params,
-        crop_runs=config.crop_runs,
-        rename_events=config.rename_events,
-        eeg_bipolar_channels=config.eeg_bipolar_channels,
-        eeg_template_montage=config.eeg_template_montage,
-        fix_stim_artifact=config.fix_stim_artifact,
-        stim_artifact_tmin=config.stim_artifact_tmin,
-        stim_artifact_tmax=config.stim_artifact_tmax,
         find_flat_channels_meg=config.find_flat_channels_meg,
         find_noisy_channels_meg=config.find_noisy_channels_meg,
-        drop_channels=config.drop_channels,
-        find_breaks=config.find_breaks,
-        min_break_duration=config.min_break_duration,
-        t_break_annot_start_after_previous_event=config.t_break_annot_start_after_previous_event,  # noqa:E501
-        t_break_annot_stop_before_next_event=config.t_break_annot_stop_before_next_event,  # noqa:E501
-        use_maxwell_filter=config.use_maxwell_filter,
-        mf_reference_run=get_mf_reference_run(config=config),
-        data_type=config.data_type,
-        ch_types=config.ch_types,
-        eog_channels=config.eog_channels,
-        on_rename_missing_events=config.on_rename_missing_events,
-        plot_psd_for_runs=config.plot_psd_for_runs,
+        **_import_data_kwargs(config=config, subject=subject),
         **extra_kwargs,
     )
     return cfg

--- a/mne_bids_pipeline/steps/preprocessing/_02_maxfilter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_02_maxfilter.py
@@ -27,15 +27,13 @@ from ..._config_utils import (
     get_subjects,
     get_sessions,
     get_runs,
-    get_task,
-    get_datatype,
-    get_mf_reference_run,
 )
 from ..._import_data import (
     import_experimental_data,
     import_er_data,
     _get_raw_paths,
     _add_bads_file,
+    _import_data_kwargs,
 )
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
@@ -303,7 +301,6 @@ def get_config(
     session: Optional[str],
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        reader_extra_params=config.reader_extra_params,
         mf_cal_fname=get_mf_cal_fname(
             config=config,
             subject=subject,
@@ -316,39 +313,7 @@ def get_config(
         ),
         mf_st_duration=config.mf_st_duration,
         mf_head_origin=config.mf_head_origin,
-        process_empty_room=config.process_empty_room,
-        process_rest=config.process_rest,
-        task_is_rest=config.task_is_rest,
-        # XXX needs to accept session!
-        runs=get_runs(config=config, subject=subject),
-        use_maxwell_filter=config.use_maxwell_filter,
-        proc=config.proc,
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        bids_root=config.bids_root,
-        deriv_root=config.deriv_root,
-        crop_runs=config.crop_runs,
-        rename_events=config.rename_events,
-        eeg_template_montage=config.eeg_template_montage,
-        fix_stim_artifact=config.fix_stim_artifact,
-        stim_artifact_tmin=config.stim_artifact_tmin,
-        stim_artifact_tmax=config.stim_artifact_tmax,
-        find_flat_channels_meg=config.find_flat_channels_meg,
-        find_noisy_channels_meg=config.find_noisy_channels_meg,
-        mf_reference_run=get_mf_reference_run(config),
-        drop_channels=config.drop_channels,
-        find_breaks=config.find_breaks,
-        min_break_duration=config.min_break_duration,
-        t_break_annot_start_after_previous_event=config.t_break_annot_start_after_previous_event,  # noqa:E501
-        t_break_annot_stop_before_next_event=config.t_break_annot_stop_before_next_event,  # noqa:E501
-        ch_types=config.ch_types,
-        data_type=config.data_type,
-        on_rename_missing_events=config.on_rename_missing_events,
-        plot_psd_for_runs=config.plot_psd_for_runs,
-        _raw_split_size=config._raw_split_size,
+        **_import_data_kwargs(config=config, subject=subject),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/preprocessing/_03_frequency_filter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_03_frequency_filter.py
@@ -24,14 +24,12 @@ from ..._config_utils import (
     get_sessions,
     get_runs,
     get_subjects,
-    get_task,
-    get_datatype,
-    get_mf_reference_run,
 )
 from ..._import_data import (
     import_experimental_data,
     import_er_data,
     _get_raw_paths,
+    _import_data_kwargs,
 )
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
@@ -66,13 +64,13 @@ def notch_filter(
     freqs: Optional[Union[float, Iterable[float]]],
     trans_bandwidth: Union[float, Literal["auto"]],
     notch_widths: Optional[Union[float, Iterable[float]]],
-    data_type: Literal["experimental", "empty-room", "resting-state"],
+    run_type: Literal["experimental", "empty-room", "resting-state"],
 ) -> None:
     """Filter data channels (MEG and EEG)."""
     if freqs is None:
-        msg = f"Not applying notch filter to {data_type} data."
+        msg = f"Not applying notch filter to {run_type} data."
     else:
-        msg = f"Notch filtering {data_type} data at {freqs} Hz."
+        msg = f"Notch filtering {run_type} data at {freqs} Hz."
 
     logger.info(**gen_log_kwargs(message=msg))
 
@@ -96,17 +94,17 @@ def bandpass_filter(
     h_freq: Optional[float],
     l_trans_bandwidth: Union[float, Literal["auto"]],
     h_trans_bandwidth: Union[float, Literal["auto"]],
-    data_type: Literal["experimental", "empty-room", "resting-state"],
+    run_type: Literal["experimental", "empty-room", "resting-state"],
 ) -> None:
     """Filter data channels (MEG and EEG)."""
     if l_freq is not None and h_freq is None:
-        msg = f"High-pass filtering {data_type} data; lower bound: " f"{l_freq} Hz"
+        msg = f"High-pass filtering {run_type} data; lower bound: " f"{l_freq} Hz"
     elif l_freq is None and h_freq is not None:
-        msg = f"Low-pass filtering {data_type} data; upper bound: " f"{h_freq} Hz"
+        msg = f"Low-pass filtering {run_type} data; upper bound: " f"{h_freq} Hz"
     elif l_freq is not None and h_freq is not None:
-        msg = f"Band-pass filtering {data_type} data; range: " f"{l_freq} – {h_freq} Hz"
+        msg = f"Band-pass filtering {run_type} data; range: " f"{l_freq} – {h_freq} Hz"
     else:
-        msg = f"Not applying frequency filtering to {data_type} data."
+        msg = f"Not applying frequency filtering to {run_type} data."
 
     logger.info(**gen_log_kwargs(message=msg))
 
@@ -128,12 +126,12 @@ def resample(
     session: Optional[str],
     run: str,
     sfreq: float,
-    data_type: Literal["experimental", "empty-room", "resting-state"],
+    run_type: Literal["experimental", "empty-room", "resting-state"],
 ) -> None:
     if not sfreq:
         return
 
-    msg = f"Resampling {data_type} data to {sfreq:.1f} Hz"
+    msg = f"Resampling {run_type} data to {sfreq:.1f} Hz"
     logger.info(**gen_log_kwargs(message=msg))
     raw.resample(sfreq, npad="auto")
 
@@ -185,7 +183,7 @@ def filter_data(
         freqs=cfg.notch_freq,
         trans_bandwidth=cfg.notch_trans_bandwidth,
         notch_widths=cfg.notch_widths,
-        data_type="experimental",
+        run_type="experimental",
     )
     bandpass_filter(
         raw=raw,
@@ -196,7 +194,7 @@ def filter_data(
         l_freq=cfg.l_freq,
         h_trans_bandwidth=cfg.h_trans_bandwidth,
         l_trans_bandwidth=cfg.l_trans_bandwidth,
-        data_type="experimental",
+        run_type="experimental",
     )
     resample(
         raw=raw,
@@ -204,7 +202,7 @@ def filter_data(
         session=session,
         run=run,
         sfreq=cfg.raw_resample_sfreq,
-        data_type="experimental",
+        run_type="experimental",
     )
 
     raw.save(
@@ -227,14 +225,14 @@ def filter_data(
         in_key = f"raw_{task}"
         if in_key not in in_files:
             continue
-        data_type = nice_names[task]
+        run_type = nice_names[task]
         bids_path_noise = in_files.pop(in_key)
         bids_path_noise_bads = in_files.pop(f"{in_key}-bads", None)
         if cfg.use_maxwell_filter:
-            msg = f"Reading {data_type} recording: " f"{bids_path_noise.basename}"
+            msg = f"Reading {run_type} recording: " f"{bids_path_noise.basename}"
             logger.info(**gen_log_kwargs(message=msg, run=task))
             raw_noise = mne.io.read_raw_fif(bids_path_noise)
-        elif data_type == "empty-room":
+        elif run_type == "empty-room":
             raw_noise = import_er_data(
                 cfg=cfg,
                 bids_path_er_in=bids_path_noise,
@@ -270,7 +268,7 @@ def filter_data(
             freqs=cfg.notch_freq,
             trans_bandwidth=cfg.notch_trans_bandwidth,
             notch_widths=cfg.notch_widths,
-            data_type=data_type,
+            run_type=run_type,
         )
         bandpass_filter(
             raw=raw_noise,
@@ -281,7 +279,7 @@ def filter_data(
             l_freq=cfg.l_freq,
             h_trans_bandwidth=cfg.h_trans_bandwidth,
             l_trans_bandwidth=cfg.l_trans_bandwidth,
-            data_type=data_type,
+            run_type=run_type,
         )
         resample(
             raw=raw_noise,
@@ -289,7 +287,7 @@ def filter_data(
             session=session,
             run=task,
             sfreq=cfg.raw_resample_sfreq,
-            data_type=data_type,
+            run_type=run_type,
         )
 
         raw_noise.save(
@@ -328,20 +326,6 @@ def get_config(
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        reader_extra_params=config.reader_extra_params,
-        process_empty_room=config.process_empty_room,
-        process_rest=config.process_rest,
-        task_is_rest=config.task_is_rest,
-        runs=get_runs(config=config, subject=subject),
-        use_maxwell_filter=config.use_maxwell_filter,
-        proc=config.proc,
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        bids_root=config.bids_root,
-        deriv_root=config.deriv_root,
         l_freq=config.l_freq,
         h_freq=config.h_freq,
         notch_freq=config.notch_freq,
@@ -350,27 +334,7 @@ def get_config(
         notch_trans_bandwidth=config.notch_trans_bandwidth,
         notch_widths=config.notch_widths,
         raw_resample_sfreq=config.raw_resample_sfreq,
-        crop_runs=config.crop_runs,
-        rename_events=config.rename_events,
-        eeg_bipolar_channels=config.eeg_bipolar_channels,
-        eeg_template_montage=config.eeg_template_montage,
-        fix_stim_artifact=config.fix_stim_artifact,
-        stim_artifact_tmin=config.stim_artifact_tmin,
-        stim_artifact_tmax=config.stim_artifact_tmax,
-        find_flat_channels_meg=config.find_flat_channels_meg,
-        find_noisy_channels_meg=config.find_noisy_channels_meg,
-        mf_reference_run=get_mf_reference_run(config),
-        drop_channels=config.drop_channels,
-        find_breaks=config.find_breaks,
-        min_break_duration=config.min_break_duration,
-        t_break_annot_start_after_previous_event=config.t_break_annot_start_after_previous_event,  # noqa:E501
-        t_break_annot_stop_before_next_event=config.t_break_annot_stop_before_next_event,  # noqa:E501
-        data_type=config.data_type,
-        ch_types=config.ch_types,
-        eog_channels=config.eog_channels,
-        on_rename_missing_events=config.on_rename_missing_events,
-        plot_psd_for_runs=config.plot_psd_for_runs,
-        _raw_split_size=config._raw_split_size,
+        **_import_data_kwargs(config=config, subject=subject),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/preprocessing/_04_make_epochs.py
+++ b/mne_bids_pipeline/steps/preprocessing/_04_make_epochs.py
@@ -14,12 +14,11 @@ import mne
 from mne_bids import BIDSPath
 
 from ..._config_utils import (
-    get_task,
     get_runs,
     get_subjects,
     get_eeg_reference,
     get_sessions,
-    get_datatype,
+    _bids_kwargs,
 )
 from ..._import_data import make_epochs, annotations_to_events
 from ..._logging import gen_log_kwargs, logger
@@ -303,16 +302,7 @@ def get_config(
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        runs=get_runs(config=config, subject=subject),
         use_maxwell_filter=config.use_maxwell_filter,
-        proc=config.proc,
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        bids_root=config.bids_root,
-        deriv_root=config.deriv_root,
         task_is_rest=config.task_is_rest,
         conditions=config.conditions,
         epochs_tmin=config.epochs_tmin,
@@ -330,6 +320,8 @@ def get_config(
         rest_epochs_duration=config.rest_epochs_duration,
         rest_epochs_overlap=config.rest_epochs_overlap,
         _epochs_split_size=config._epochs_split_size,
+        runs=get_runs(config=config, subject=subject),
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/preprocessing/_05a_run_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05a_run_ica.py
@@ -23,12 +23,11 @@ from mne.preprocessing import ICA, create_ecg_epochs, create_eog_epochs
 from mne_bids import BIDSPath
 
 from ..._config_utils import (
-    get_sessions,
     get_runs,
+    get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
     get_eeg_reference,
+    _bids_kwargs,
 )
 from ..._import_data import make_epochs, annotations_to_events
 from ..._logging import gen_log_kwargs, logger
@@ -539,14 +538,8 @@ def get_config(
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
         conditions=config.conditions,
-        task=get_task(config),
-        task_is_rest=config.task_is_rest,
-        datatype=get_datatype(config),
         runs=get_runs(config=config, subject=subject),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        deriv_root=config.deriv_root,
+        task_is_rest=config.task_is_rest,
         ica_l_freq=config.ica_l_freq,
         ica_algorithm=config.ica_algorithm,
         ica_n_components=config.ica_n_components,
@@ -572,6 +565,7 @@ def get_config(
         eog_channels=config.eog_channels,
         rest_epochs_duration=config.rest_epochs_duration,
         rest_epochs_overlap=config.rest_epochs_overlap,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/preprocessing/_05b_run_ssp.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05b_run_ssp.py
@@ -13,11 +13,10 @@ from mne_bids import BIDSPath
 from mne.utils import _pl
 
 from ..._config_utils import (
-    get_sessions,
     get_runs,
+    get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
+    _bids_kwargs,
 )
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
@@ -206,14 +205,7 @@ def get_config(
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        runs=get_runs(config=config, subject=subject),
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
         eog_channels=config.eog_channels,
-        deriv_root=config.deriv_root,
         ssp_reject_ecg=config.ssp_reject_ecg,
         ecg_proj_from_average=config.ecg_proj_from_average,
         ssp_reject_eog=config.ssp_reject_eog,
@@ -226,6 +218,8 @@ def get_config(
         ch_types=config.ch_types,
         epochs_decim=config.epochs_decim,
         use_maxwell_filter=config.use_maxwell_filter,
+        runs=get_runs(config=config, subject=subject),
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/preprocessing/_06a_apply_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a_apply_ica.py
@@ -24,8 +24,7 @@ from mne_bids import BIDSPath
 from ..._config_utils import (
     get_subjects,
     get_sessions,
-    get_task,
-    get_datatype,
+    _bids_kwargs,
 )
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
@@ -181,16 +180,11 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        deriv_root=config.deriv_root,
         baseline=config.baseline,
         ica_reject=config.ica_reject,
         ch_types=config.ch_types,
         _epochs_split_size=config._epochs_split_size,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/preprocessing/_06b_apply_ssp.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06b_apply_ssp.py
@@ -14,8 +14,7 @@ from mne_bids import BIDSPath
 from ..._config_utils import (
     get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
+    _bids_kwargs,
 )
 from ..._logging import gen_log_kwargs, logger
 from ..._run import failsafe_run, _update_for_splits, save_logs
@@ -88,13 +87,8 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        deriv_root=config.deriv_root,
         _epochs_split_size=config._epochs_split_size,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/preprocessing/_07_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_07_ptp_reject.py
@@ -17,8 +17,7 @@ from mne_bids import BIDSPath
 from ..._config_utils import (
     get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
+    _bids_kwargs,
 )
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
@@ -163,20 +162,15 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
         baseline=config.baseline,
         reject_tmin=config.reject_tmin,
         reject_tmax=config.reject_tmax,
         spatial_filter=config.spatial_filter,
         ica_reject=config.ica_reject,
-        deriv_root=config.deriv_root,
         reject=config.reject,
         ch_types=config.ch_types,
         _epochs_split_size=config._epochs_split_size,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/sensor/_01_make_evoked.py
+++ b/mne_bids_pipeline/steps/sensor/_01_make_evoked.py
@@ -9,9 +9,8 @@ from mne_bids import BIDSPath
 from ..._config_utils import (
     get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
     get_all_contrasts,
+    _bids_kwargs,
     _restrict_analyze_channels,
 )
 from ..._logging import gen_log_kwargs, logger
@@ -147,19 +146,13 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        deriv_root=config.deriv_root,
         conditions=config.conditions,
         contrasts=get_all_contrasts(config),
-        proc=config.proc,
         noise_cov=_sanitize_callable(config.noise_cov),
         analyze_channels=config.analyze_channels,
         ch_types=config.ch_types,
         report_evoked_n_time_points=config.report_evoked_n_time_points,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
+++ b/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
@@ -27,11 +27,10 @@ from mne_bids import BIDSPath
 from ..._config_utils import (
     get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
     get_eeg_reference,
-    _restrict_analyze_channels,
     get_decoding_contrasts,
+    _bids_kwargs,
+    _restrict_analyze_channels,
 )
 from ..._logging import gen_log_kwargs, logger
 from ..._decoding import LogReg
@@ -218,12 +217,6 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        deriv_root=config.deriv_root,
         conditions=config.conditions,
         contrasts=get_decoding_contrasts(config),
         decode=config.decode,
@@ -235,6 +228,7 @@ def get_config(
         analyze_channels=config.analyze_channels,
         ch_types=config.ch_types,
         eeg_reference=get_eeg_reference(config),
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
+++ b/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
@@ -31,11 +31,10 @@ from sklearn.model_selection import StratifiedKFold
 from ..._config_utils import (
     get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
     get_eeg_reference,
-    _restrict_analyze_channels,
     get_decoding_contrasts,
+    _bids_kwargs,
+    _restrict_analyze_channels,
 )
 from ..._decoding import LogReg
 from ..._logging import gen_log_kwargs, logger
@@ -295,12 +294,6 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        deriv_root=config.deriv_root,
         conditions=config.conditions,
         contrasts=get_decoding_contrasts(config),
         decode=config.decode,
@@ -312,6 +305,7 @@ def get_config(
         analyze_channels=config.analyze_channels,
         ch_types=config.ch_types,
         eeg_reference=get_eeg_reference(config),
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/sensor/_04_time_frequency.py
+++ b/mne_bids_pipeline/steps/sensor/_04_time_frequency.py
@@ -16,11 +16,10 @@ from mne_bids import BIDSPath
 from ..._config_utils import (
     get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
-    _restrict_analyze_channels,
     get_eeg_reference,
     sanitize_cond_name,
+    _bids_kwargs,
+    _restrict_analyze_channels,
 )
 from ..._logging import gen_log_kwargs, logger
 from ..._run import failsafe_run, save_logs
@@ -162,12 +161,6 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        deriv_root=config.deriv_root,
         time_frequency_conditions=config.time_frequency_conditions,
         analyze_channels=config.analyze_channels,
         spatial_filter=config.spatial_filter,
@@ -180,6 +173,7 @@ def get_config(
         time_frequency_baseline=config.time_frequency_baseline,
         time_frequency_baseline_mode=config.time_frequency_baseline_mode,
         time_frequency_crop=config.time_frequency_crop,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
+++ b/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
@@ -19,11 +19,10 @@ from sklearn.pipeline import make_pipeline
 from ..._config_utils import (
     get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
     get_eeg_reference,
-    _restrict_analyze_channels,
     get_decoding_contrasts,
+    _bids_kwargs,
+    _restrict_analyze_channels,
 )
 from ..._decoding import LogReg, _handle_csp_args
 from ..._logging import logger, gen_log_kwargs
@@ -513,12 +512,6 @@ def get_config(
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
         # Data parameters
-        datatype=get_datatype(config),
-        deriv_root=config.deriv_root,
-        task=get_task(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
         use_maxwell_filter=config.use_maxwell_filter,
         analyze_channels=config.analyze_channels,
         ch_types=config.ch_types,
@@ -532,6 +525,7 @@ def get_config(
         decoding_contrasts=get_decoding_contrasts(config),
         n_boot=config.n_boot,
         random_state=config.random_state,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/sensor/_06_make_cov.py
+++ b/mne_bids_pipeline/steps/sensor/_06_make_cov.py
@@ -12,9 +12,8 @@ from mne_bids import BIDSPath
 from ..._config_utils import (
     get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
     get_noise_cov_bids_path,
+    _bids_kwargs,
 )
 from ..._config_import import _import_config
 from ..._config_utils import _restrict_analyze_channels, get_all_contrasts
@@ -75,8 +74,8 @@ def get_input_fnames_cov(
             root=cfg.deriv_root,
             check=False,
         )
-        data_type = "resting-state" if cfg.noise_cov == "rest" else "empty-room"
-        if data_type == "resting-state":
+        run_type = "resting-state" if cfg.noise_cov == "rest" else "empty-room"
+        if run_type == "resting-state":
             bids_path_raw_noise.task = "rest"
         else:
             bids_path_raw_noise.task = "noise"
@@ -129,8 +128,8 @@ def compute_cov_from_raw(
     out_files: dict,
 ) -> mne.Covariance:
     fname_raw = in_files.pop("raw")
-    data_type = "resting-state" if fname_raw.task == "rest" else "empty-room"
-    msg = f"Computing regularized covariance based on {data_type} recording."
+    run_type = "resting-state" if fname_raw.task == "rest" else "empty-room"
+    msg = f"Computing regularized covariance based on {run_type} recording."
     logger.info(**gen_log_kwargs(message=msg))
     msg = f"Input:  {fname_raw.basename}"
     logger.info(**gen_log_kwargs(message=msg))
@@ -283,20 +282,14 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        proc=config.proc,
         spatial_filter=config.spatial_filter,
         ch_types=config.ch_types,
-        deriv_root=config.deriv_root,
         run_source_estimation=config.run_source_estimation,
         noise_cov=_sanitize_callable(config.noise_cov),
         conditions=config.conditions,
         all_contrasts=get_all_contrasts(config),
         analyze_channels=config.analyze_channels,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -19,11 +19,10 @@ from mne_bids import BIDSPath
 from ..._config_utils import (
     get_sessions,
     get_subjects,
-    get_task,
-    get_datatype,
     get_eeg_reference,
     get_decoding_contrasts,
     get_all_contrasts,
+    _bids_kwargs,
 )
 from ..._decoding import _handle_csp_args
 from ..._logging import gen_log_kwargs, logger
@@ -597,14 +596,7 @@ def get_config(
     dtg_decim = config.decoding_time_generalization_decim
     cfg = SimpleNamespace(
         subjects=get_subjects(config),
-        task=get_task(config),
         task_is_rest=config.task_is_rest,
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        proc=config.proc,
-        deriv_root=config.deriv_root,
         conditions=config.conditions,
         contrasts=get_all_contrasts(config),
         decode=config.decode,
@@ -625,12 +617,13 @@ def get_config(
         ch_types=config.ch_types,
         eeg_reference=get_eeg_reference(config),
         sessions=get_sessions(config),
-        bids_root=config.bids_root,
-        data_type=config.data_type,
         exclude_subjects=config.exclude_subjects,
         all_contrasts=get_all_contrasts(config),
         report_evoked_n_time_points=config.report_evoked_n_time_points,
         cluster_permutation_p_threshold=config.cluster_permutation_p_threshold,
+        # TODO: needed because get_datatype gets called again...
+        data_type=config.data_type,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -15,11 +15,10 @@ from ..._config_utils import (
     get_subjects,
     _get_bem_conductivity,
     get_fs_subjects_dir,
-    get_task,
     get_runs,
-    get_datatype,
     _meg_in_ch_types,
     get_sessions,
+    _bids_kwargs,
 )
 from ..._config_import import _import_config
 from ..._logging import logger, gen_log_kwargs
@@ -243,12 +242,7 @@ def get_config(
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
         runs=get_runs(config=config, subject=subject),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
         mindist=config.mindist,
         spacing=config.spacing,
         use_template_mri=config.use_template_mri,
@@ -257,8 +251,7 @@ def get_config(
         ch_types=config.ch_types,
         fs_subject=get_fs_subject(config=config, subject=subject),
         fs_subjects_dir=get_fs_subjects_dir(config),
-        deriv_root=config.deriv_root,
-        bids_root=config.bids_root,
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -19,11 +19,10 @@ from ..._config_utils import (
     get_noise_cov_bids_path,
     get_subjects,
     sanitize_cond_name,
-    get_task,
-    get_datatype,
     get_sessions,
     get_fs_subjects_dir,
     get_fs_subject,
+    _bids_kwargs,
 )
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import get_parallel_backend, parallel_func
@@ -162,12 +161,6 @@ def get_config(
     subject: str,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        proc=config.proc,
-        space=config.space,
         source_info_path_update=config.source_info_path_update,
         inverse_targets=config.inverse_targets,
         ch_types=config.ch_types,
@@ -175,11 +168,11 @@ def get_config(
         loose=config.loose,
         depth=config.depth,
         inverse_method=config.inverse_method,
-        deriv_root=config.deriv_root,
         noise_cov=_sanitize_callable(config.noise_cov),
         report_stc_n_time_points=config.report_stc_n_time_points,
         fs_subject=get_fs_subject(config=config, subject=subject),
         fs_subjects_dir=get_fs_subjects_dir(config),
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -16,10 +16,9 @@ from ..._config_utils import (
     get_subjects,
     sanitize_cond_name,
     get_fs_subject,
-    get_task,
-    get_datatype,
     get_sessions,
     get_all_contrasts,
+    _bids_kwargs,
 )
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import get_parallel_backend, parallel_func
@@ -126,20 +125,11 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task=get_task(config),
         task_is_rest=config.task_is_rest,
-        datatype=get_datatype(config),
-        acq=config.acq,
-        rec=config.rec,
-        space=config.space,
-        proc=config.proc,
         conditions=config.conditions,
         inverse_method=config.inverse_method,
         fs_subjects_dir=get_fs_subjects_dir(config),
-        deriv_root=config.deriv_root,
         subjects_dir=get_fs_subjects_dir(config),
-        bids_root=config.bids_root,
-        data_type=config.data_type,
         ch_types=config.ch_types,
         subjects=config.subjects,
         exclude_subjects=config.exclude_subjects,
@@ -147,6 +137,7 @@ def get_config(
         use_template_mri=config.use_template_mri,
         all_contrasts=get_all_contrasts(config),
         report_stc_n_time_points=config.report_stc_n_time_points,
+        *_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -137,6 +137,8 @@ def get_config(
         use_template_mri=config.use_template_mri,
         all_contrasts=get_all_contrasts(config),
         report_stc_n_time_points=config.report_stc_n_time_points,
+        # TODO: needed because get_datatype gets called again...
+        data_type=config.data_type,
         **_bids_kwargs(config=config),
     )
     return cfg

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -137,7 +137,7 @@ def get_config(
         use_template_mri=config.use_template_mri,
         all_contrasts=get_all_contrasts(config),
         report_stc_n_time_points=config.report_stc_n_time_points,
-        *_bids_kwargs(config=config),
+        **_bids_kwargs(config=config),
     )
     return cfg
 

--- a/mne_bids_pipeline/tests/conftest.py
+++ b/mne_bids_pipeline/tests/conftest.py
@@ -31,8 +31,9 @@ def pytest_configure(config):
     ignore:_SixMetaPathImporter\.find_spec.*:ImportWarning
     ignore:pkg_resources is deprecated.*:DeprecationWarning
     ignore:`product` is deprecated as of NumPy.*:DeprecationWarning
-    # seaborn calling tight layout
+    # seaborn calling tight layout, etc.
     ignore:The figure layout has changed to tight:UserWarning
+    ignore:The \S+_cmap function was deprecated.*:DeprecationWarning
     """
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

I went to work on #574 and the sheer volume of `kwargs` in `get_config` that must be used to `import_*_data` made it really hard to start from one of the `steps/preprocessing/*.py` files to add a new step. This PR is a no-op from the user standpoint but refactors to:

1. `_bids_kwargs` function that returns some standard BIDS kwargs like `cfg.space`. Eventually we should use this everywhere probably but I'm just starting with `steps/preprocessing` for now.
2. `_import_data_kwargs` function that gets the `config` params needed for reading raw data

Should be a lot more red than green here. I don't expect the first version to pass -- locally I've only run `ds004229` -- but hopefully it won't require many more iterations to get right!