### PR TITLE
Fix for documentation issue related to processing EEG separately in a combined M/EEG dataset

### DIFF
--- a/docs/source/v1.4.md.inc
+++ b/docs/source/v1.4.md.inc
@@ -19,3 +19,4 @@
 - Fix bug with too many JSON files found during empty room matching (#743 by @allermat)
 - Fix bug with outdated info on ch_types config option (#745 by @allermat)
 - Fix bug where SSP projectors were not added to the report (#747 by @larsoner)
+- Fix bug with documentation issue on data_type config option (#750 by @allermat)

--- a/docs/source/v1.4.md.inc
+++ b/docs/source/v1.4.md.inc
@@ -19,4 +19,4 @@
 - Fix bug with too many JSON files found during empty room matching (#743 by @allermat)
 - Fix bug with outdated info on ch_types config option (#745 by @allermat)
 - Fix bug where SSP projectors were not added to the report (#747 by @larsoner)
-- Fix bug with documentation issue on data_type config option (#750 by @allermat)
+- Fix bug with documentation issue on data_type config option (#751 by @allermat)

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -232,7 +232,7 @@ If `None`, we will assume that the data type matches the channel type.
 
     ```python
     ch_types = ['eeg']
-    data_type = 'eeg'
+    data_type = 'meg'
     ```
 
     The dataset contains simultaneous recordings of MEG and EEG, and we only


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
