### PR TITLE
BUG: Fix bug with cache invalidation

### DIFF
--- a/docs/source/v1.5.md.inc
+++ b/docs/source/v1.5.md.inc
@@ -12,6 +12,6 @@
 
 - Fixed doc build errors and dependency specifications (#755 by @larsoner)
 
-[//]: # (### :bug: Bug fixes)
+### :bug: Bug fixes
 
-[//]: # (- Whatever (#000 by @whoever))
+- Fixed bug where cache would not invalidate properly based on output file changes and steps could be incorrectly skipped. All steps will automatically rerun to accommodate the new, safer caching scheme (#756 by @larsoner)

--- a/mne_bids_pipeline/steps/freesurfer/_02_coreg_surfaces.py
+++ b/mne_bids_pipeline/steps/freesurfer/_02_coreg_surfaces.py
@@ -17,7 +17,7 @@ from ..._config_utils import (
 )
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import parallel_func, get_parallel_backend
-from ..._run import failsafe_run
+from ..._run import failsafe_run, _prep_out_files
 
 fs_bids_app = Path(__file__).parent / "contrib" / "run.py"
 
@@ -62,7 +62,7 @@ def make_coreg_surfaces(
         overwrite=True,
     )
     out_files = get_output_fnames_coreg_surfaces(cfg=cfg, subject=subject)
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(*, config, subject) -> SimpleNamespace:

--- a/mne_bids_pipeline/steps/init/_02_find_empty_room.py
+++ b/mne_bids_pipeline/steps/init/_02_find_empty_room.py
@@ -15,7 +15,7 @@ from ..._config_utils import (
 )
 from ..._io import _empty_room_match_path, _write_json
 from ..._logging import gen_log_kwargs, logger
-from ..._run import _update_for_splits, failsafe_run, save_logs
+from ..._run import _update_for_splits, failsafe_run, save_logs, _prep_out_files
 
 
 def get_input_fnames_find_empty_room(
@@ -96,7 +96,7 @@ def find_empty_room(
     out_files = dict()
     out_files["empty_room_match"] = _empty_room_match_path(raw_path, cfg)
     _write_json(out_files["empty_room_match"], dict(fname=fname))
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -30,7 +30,7 @@ from ..._io import _write_json
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
 from ..._report import _open_report, _add_raw
-from ..._run import failsafe_run, save_logs
+from ..._run import failsafe_run, save_logs, _prep_out_files
 from ..._viz import plot_auto_scores
 
 
@@ -140,7 +140,7 @@ def assess_data_quality(
                 plt.close(fig)
 
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def _find_bads_maxwell(

--- a/mne_bids_pipeline/steps/preprocessing/_02_head_pos.py
+++ b/mne_bids_pipeline/steps/preprocessing/_02_head_pos.py
@@ -18,7 +18,7 @@ from ..._import_data import (
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
 from ..._report import _open_report
-from ..._run import failsafe_run, save_logs
+from ..._run import failsafe_run, save_logs, _prep_out_files
 
 
 def get_input_fnames_head_pos(
@@ -140,7 +140,7 @@ def run_head_pos(
         plt.close(fig)
     del bids_path_in
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
@@ -40,7 +40,7 @@ from ..._import_data import (
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
 from ..._report import _open_report, _add_raw
-from ..._run import failsafe_run, save_logs, _update_for_splits
+from ..._run import failsafe_run, save_logs, _update_for_splits, _prep_out_files
 
 
 def get_input_fnames_maxwell_filter(
@@ -317,7 +317,7 @@ def run_maxwell_filter(
         )
 
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/preprocessing/_04_frequency_filter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_04_frequency_filter.py
@@ -34,7 +34,7 @@ from ..._import_data import (
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
 from ..._report import _open_report, _add_raw
-from ..._run import failsafe_run, save_logs, _update_for_splits
+from ..._run import failsafe_run, save_logs, _update_for_splits, _prep_out_files
 
 
 def get_input_fnames_frequency_filter(
@@ -265,7 +265,7 @@ def filter_data(
         )
 
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/preprocessing/_05_make_epochs.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05_make_epochs.py
@@ -28,6 +28,7 @@ from ..._run import (
     save_logs,
     _update_for_splits,
     _sanitize_callable,
+    _prep_out_files,
 )
 from ..._parallel import parallel_func, get_parallel_backend
 
@@ -262,7 +263,7 @@ def run_epochs(
         epochs.plot()
         epochs.plot_image(combine="gfp", sigma=2.0, cmap="YlGnBu_r")
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 # TODO: ideally we wouldn't need this anymore and could refactor the code above

--- a/mne_bids_pipeline/steps/preprocessing/_06a_run_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a_run_ica.py
@@ -34,7 +34,7 @@ from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
 from ..._reject import _get_reject
 from ..._report import _agg_backend
-from ..._run import failsafe_run, _update_for_splits, save_logs
+from ..._run import failsafe_run, _update_for_splits, save_logs, _prep_out_files
 
 
 def filter_for_ica(
@@ -527,7 +527,7 @@ def run_ica(
     )
 
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/preprocessing/_06b_run_ssp.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06b_run_ssp.py
@@ -22,7 +22,7 @@ from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
 from ..._reject import _get_reject
 from ..._report import _open_report
-from ..._run import failsafe_run, _update_for_splits, save_logs
+from ..._run import failsafe_run, _update_for_splits, save_logs, _prep_out_files
 
 
 def get_input_fnames_run_ssp(
@@ -205,7 +205,7 @@ def run_ssp(
                 replace=True,
             )
             plt.close(fig)
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/preprocessing/_07a_apply_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_07a_apply_ica.py
@@ -30,7 +30,7 @@ from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
 from ..._reject import _get_reject
 from ..._report import _open_report, _agg_backend
-from ..._run import failsafe_run, _update_for_splits, save_logs
+from ..._run import failsafe_run, _update_for_splits, save_logs, _prep_out_files
 
 
 def get_input_fnames_apply_ica(
@@ -172,7 +172,7 @@ def apply_ica(
                 replace=True,
             )
 
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/preprocessing/_07b_apply_ssp.py
+++ b/mne_bids_pipeline/steps/preprocessing/_07b_apply_ssp.py
@@ -17,7 +17,7 @@ from ..._config_utils import (
     _bids_kwargs,
 )
 from ..._logging import gen_log_kwargs, logger
-from ..._run import failsafe_run, _update_for_splits, save_logs
+from ..._run import failsafe_run, _update_for_splits, save_logs, _prep_out_files
 from ..._parallel import parallel_func, get_parallel_backend
 
 
@@ -79,7 +79,7 @@ def apply_ssp(
     )
     _update_for_splits(out_files, "epochs")
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/preprocessing/_08_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08_ptp_reject.py
@@ -23,7 +23,7 @@ from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
 from ..._reject import _get_reject
 from ..._report import _open_report
-from ..._run import failsafe_run, _update_for_splits, save_logs
+from ..._run import failsafe_run, _update_for_splits, save_logs, _prep_out_files
 
 
 def get_input_fnames_drop_ptp(
@@ -154,7 +154,7 @@ def drop_ptp(
             drop_log_ignore=(),
             replace=True,
         )
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/sensor/_01_make_evoked.py
+++ b/mne_bids_pipeline/steps/sensor/_01_make_evoked.py
@@ -16,7 +16,7 @@ from ..._config_utils import (
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import parallel_func, get_parallel_backend
 from ..._report import _open_report, _sanitize_cond_tag
-from ..._run import failsafe_run, save_logs, _sanitize_callable
+from ..._run import failsafe_run, save_logs, _sanitize_callable, _prep_out_files
 
 
 def get_input_fnames_evoked(
@@ -138,7 +138,7 @@ def run_evoked(
         #                       topomap_args=topomap_args)
     assert len(in_files) == 0, in_files.keys()
 
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
+++ b/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
@@ -35,7 +35,7 @@ from ..._config_utils import (
 from ..._logging import gen_log_kwargs, logger
 from ..._decoding import LogReg
 from ..._parallel import parallel_func, get_parallel_backend
-from ..._run import failsafe_run, save_logs
+from ..._run import failsafe_run, save_logs, _prep_out_files
 from ..._report import (
     _open_report,
     _contrasts_to_names,
@@ -209,7 +209,7 @@ def run_epochs_decoding(
         plt.close(fig)
 
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
+++ b/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
@@ -38,7 +38,7 @@ from ..._config_utils import (
 )
 from ..._decoding import LogReg
 from ..._logging import gen_log_kwargs, logger
-from ..._run import failsafe_run, save_logs
+from ..._run import failsafe_run, save_logs, _prep_out_files
 from ..._parallel import get_parallel_backend, get_parallel_backend_name
 from ..._report import (
     _open_report,
@@ -286,7 +286,7 @@ def run_time_decoding(
             del decoding_data, cond_1, cond_2, caption
 
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/sensor/_04_time_frequency.py
+++ b/mne_bids_pipeline/steps/sensor/_04_time_frequency.py
@@ -22,7 +22,7 @@ from ..._config_utils import (
     _restrict_analyze_channels,
 )
 from ..._logging import gen_log_kwargs, logger
-from ..._run import failsafe_run, save_logs
+from ..._run import failsafe_run, save_logs, _prep_out_files
 from ..._parallel import get_parallel_backend, parallel_func
 from ..._report import _open_report, _sanitize_cond_tag
 
@@ -153,7 +153,7 @@ def run_time_frequency(
             del itc
 
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
+++ b/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
@@ -27,7 +27,7 @@ from ..._config_utils import (
 from ..._decoding import LogReg, _handle_csp_args
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import parallel_func, get_parallel_backend
-from ..._run import failsafe_run, save_logs
+from ..._run import failsafe_run, save_logs, _prep_out_files
 from ..._report import (
     _open_report,
     _sanitize_cond_tag,
@@ -504,7 +504,7 @@ def one_subject_decoding(
             )
 
     assert len(in_files) == 0, in_files.keys()
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/sensor/_06_make_cov.py
+++ b/mne_bids_pipeline/steps/sensor/_06_make_cov.py
@@ -20,7 +20,7 @@ from ..._config_utils import _restrict_analyze_channels, get_all_contrasts
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import get_parallel_backend, parallel_func
 from ..._report import _open_report, _sanitize_cond_tag, _all_conditions
-from ..._run import failsafe_run, save_logs, _sanitize_callable
+from ..._run import failsafe_run, save_logs, _sanitize_callable, _prep_out_files
 
 
 def get_input_fnames_cov(
@@ -274,7 +274,7 @@ def run_covariance(
                 plt.close(fig)
 
     assert len(in_files) == 0, in_files
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
+++ b/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
@@ -17,7 +17,7 @@ from ..._config_utils import (
 )
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import get_parallel_backend, parallel_func
-from ..._run import failsafe_run, save_logs
+from ..._run import failsafe_run, save_logs, _prep_out_files
 
 
 def _get_bem_params(cfg: SimpleNamespace):
@@ -97,7 +97,7 @@ def make_bem_surfaces(
         verbose=cfg.freesurfer_verbose,
     )
     out_files = get_output_fnames_make_bem_surfaces(cfg=cfg, subject=subject)
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/source/_02_make_bem_solution.py
+++ b/mne_bids_pipeline/steps/source/_02_make_bem_solution.py
@@ -16,7 +16,7 @@ from ..._config_utils import (
 )
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import parallel_func, get_parallel_backend
-from ..._run import failsafe_run, save_logs
+from ..._run import failsafe_run, save_logs, _prep_out_files
 
 
 def get_input_fnames_make_bem_solution(
@@ -69,7 +69,7 @@ def make_bem_solution(
     out_files = get_output_fnames_make_bem_solution(cfg=cfg, subject=subject)
     mne.write_bem_surfaces(out_files["model"], bem_model, overwrite=True)
     mne.write_bem_solution(out_files["sol"], bem_sol, overwrite=True)
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/source/_03_setup_source_space.py
+++ b/mne_bids_pipeline/steps/source/_03_setup_source_space.py
@@ -9,7 +9,7 @@ import mne
 
 from ..._config_utils import get_fs_subject, get_fs_subjects_dir, get_subjects
 from ..._logging import logger, gen_log_kwargs
-from ..._run import failsafe_run, save_logs
+from ..._run import failsafe_run, save_logs, _prep_out_files
 from ..._parallel import parallel_func, get_parallel_backend
 
 
@@ -55,7 +55,7 @@ def run_setup_source_space(
     in_files.clear()  # all used by setup_source_space
     out_files = get_output_fnames_setup_source_space(cfg=cfg, subject=subject)
     mne.write_source_spaces(out_files["src"], src, overwrite=True)
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -24,7 +24,7 @@ from ..._config_import import _import_config
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import get_parallel_backend, parallel_func
 from ..._report import _open_report
-from ..._run import failsafe_run, save_logs
+from ..._run import failsafe_run, save_logs, _prep_out_files
 
 
 def _prepare_trans_template(
@@ -233,7 +233,7 @@ def run_forward(
         )
 
     assert len(in_files) == 0, in_files
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -27,7 +27,7 @@ from ..._config_utils import (
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import get_parallel_backend, parallel_func
 from ..._report import _open_report, _sanitize_cond_tag
-from ..._run import failsafe_run, save_logs, _sanitize_callable
+from ..._run import failsafe_run, save_logs, _sanitize_callable, _prep_out_files
 
 
 def get_input_fnames_inverse(
@@ -152,7 +152,7 @@ def run_inverse(
                 )
 
     assert len(in_files) == 0, in_files
-    return out_files
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
 def get_config(


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

Closes #748

First run of `ds004229` with the default `epochs_tmax=1`:
```
[13:04:08] ┌╴🚀 preprocessing/_05_make_epochs Now running  👇
[13:04:08] │ ⏳️ preprocessing/_05_make_epochs sub-102 Loading filtered raw data from sub-102_task-amnoise_proc-filt_raw.fif
[13:04:09] │ ⏳️ preprocessing/_05_make_epochs sub-102 Creating task-related epochs …
```
Next run correctly shows as cached:
```
[13:09:25] ┌╴🚀 preprocessing/_05_make_epochs Now running  👇
[13:09:25] │ ✅ preprocessing/_05_make_epochs sub-102 Computation unnecessary (cached) …
[13:09:25] └╴🎉 preprocessing/_05_make_epochs Done running  👆 [1s]
```
Change tmax to 2 it correctly re-runs:
```
[13:17:08] ┌╴🚀 preprocessing/_05_make_epochs Now running  👇
[13:17:08] │ ⏳️ preprocessing/_05_make_epochs sub-102 Loading filtered raw data from sub-102_task-amnoise_proc-filt_raw.fif
[13:17:09] │ ⏳️ preprocessing/_05_make_epochs sub-102 Creating task-related epochs …
```
On this PR, changing back to `1` correctly re-runs:
```
[13:18:29] ┌╴🚀 preprocessing/_05_make_epochs Now running  👇
[13:18:29] │ 🔂 preprocessing/_05_make_epochs sub-102 Output file hash mismatch, will recompute …
[13:18:29] │ ⏳️ preprocessing/_05_make_epochs sub-102 Loading filtered raw data from sub-102_task-amnoise_proc-filt_raw.fif
[13:18:30] │ ⏳️ preprocessing/_05_make_epochs sub-102 Creating task-related epochs …
```
