### PR TITLE
ENH: Add annotation of head velocity

### DIFF
--- a/docs/source/settings/preprocessing/maxfilter.md
+++ b/docs/source/settings/preprocessing/maxfilter.md
@@ -22,4 +22,6 @@ tags:
         - mf_mc_t_window
         - mf_mc_gof_limit
         - mf_mc_dist_limit
+        - mf_mc_rotation_velocity_limit
+        - mf_mc_translation_velocity_limit
         - mf_filter_chpi

--- a/docs/source/v1.5.md.inc
+++ b/docs/source/v1.5.md.inc
@@ -2,7 +2,7 @@
 
 ### :new: New features & enhancements
 
-- Added support for annotating bad segments based on for head movement velocity (#757 by @larsoner)
+- Added support for annotating bad segments based on head movement velocity (#757 by @larsoner)
 
 [//]: # (### :warning: Behavior changes)
 

--- a/docs/source/v1.5.md.inc
+++ b/docs/source/v1.5.md.inc
@@ -1,8 +1,8 @@
 ## v1.5.0 (unreleased)
 
-[//]: # (### :new: New features & enhancements)
+### :new: New features & enhancements
 
-[//]: # (- Whatever (#000 by @whoever))
+- Added support for annotating bad segments based on for head movement velocity (#757 by @larsoner)
 
 [//]: # (### :warning: Behavior changes)
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -707,6 +707,18 @@ mf_mc_dist_limit: float = 0.005
 Minimum distance (m) to accept for cHPI position fitting.
 """
 
+mf_mc_rotation_velocity_limit: Optional[float] = None
+"""
+The rotation velocity limit (degrees/second) to use when annotating
+movement-compensated data. If None, no annotations will be added.
+"""
+
+mf_mc_translation_velocity_limit: Optional[float] = None
+"""
+The translation velocity limit (meters/second) to use when annotating
+movement-compensated data. If None, no annotations will be added.
+"""
+
 mf_filter_chpi: Optional[bool] = None
 """
 Use mne.chpi.filter_chpi after Maxwell filtering. Can be None to use

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -710,13 +710,13 @@ Minimum distance (m) to accept for cHPI position fitting.
 mf_mc_rotation_velocity_limit: Optional[float] = None
 """
 The rotation velocity limit (degrees/second) to use when annotating
-movement-compensated data. If None, no annotations will be added.
+movement-compensated data. If `None`, no annotations will be added.
 """
 
 mf_mc_translation_velocity_limit: Optional[float] = None
 """
 The translation velocity limit (meters/second) to use when annotating
-movement-compensated data. If None, no annotations will be added.
+movement-compensated data. If `None`, no annotations will be added.
 """
 
 mf_filter_chpi: Optional[bool] = None

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -1198,6 +1198,7 @@ def _add_raw(
     title: str,
     tags: tuple = (),
     raw: Optional[BaseRaw] = None,
+    extra_html: Optional[str] = None,
 ):
     if bids_path_in.run is not None:
         title += f", run {repr(bids_path_in.run)}"
@@ -1208,13 +1209,22 @@ def _add_raw(
         or bids_path_in.run in cfg.plot_psd_for_runs
         or bids_path_in.task in cfg.plot_psd_for_runs
     )
+    tags = ("raw", f"run-{bids_path_in.run}") + tags
     with mne.use_log_level("error"):
         report.add_raw(
             raw=raw or bids_path_in,
             title=title,
             butterfly=5,
             psd=plot_raw_psd,
-            tags=("raw", f"run-{bids_path_in.run}") + tags,
+            tags=tags,
             # caption=bids_path_in.basename,  # TODO upstream
             replace=True,
         )
+        if extra_html is not None:
+            report.add_html(
+                extra_html,
+                title=title,
+                tags=tags,
+                section=title,
+                replace=True,
+            )

--- a/mne_bids_pipeline/tests/configs/config_ds004229.py
+++ b/mne_bids_pipeline/tests/configs/config_ds004229.py
@@ -27,6 +27,8 @@ mf_int_order = 6  # lower for smaller heads
 mf_mc_t_step_min = 0.5  # just for speed!
 mf_mc_t_window = 0.2  # cleaner cHPI filtering on this dataset
 mf_filter_chpi = False  # for speed, not needed as we low-pass anyway
+mf_mc_rotation_velocity_limit = 5.0  # deg/s for annotations
+mf_mc_translation_velocity_limit = 5e-3  # m/s
 ch_types = ["meg"]
 
 l_freq = None

--- a/mne_bids_pipeline/tests/configs/config_ds004229.py
+++ b/mne_bids_pipeline/tests/configs/config_ds004229.py
@@ -27,8 +27,8 @@ mf_int_order = 6  # lower for smaller heads
 mf_mc_t_step_min = 0.5  # just for speed!
 mf_mc_t_window = 0.2  # cleaner cHPI filtering on this dataset
 mf_filter_chpi = False  # for speed, not needed as we low-pass anyway
-mf_mc_rotation_velocity_limit = 5.0  # deg/s for annotations
-mf_mc_translation_velocity_limit = 5e-3  # m/s
+mf_mc_rotation_velocity_limit = 30.0  # deg/s for annotations
+mf_mc_translation_velocity_limit = 20e-3  # m/s
 ch_types = ["meg"]
 
 l_freq = None


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

With updated vals for `ds004229`:
```
mf_mc_rotation_velocity_limit = 30.0  # deg/s for annotations
mf_mc_translation_velocity_limit = 20e-3  # m/s
```
During the run we see:
```
[14:47:31] │ ⏳️ preprocessing/_03_maxfilter sub-102 Translation velocity exceeded 0.02 m/s limit for 5.5 s (1.8%)
[14:47:31] │ ⏳️ preprocessing/_03_maxfilter sub-102 Rotation velocity exceeded 30.0 °/s limit for 4.0 s (1.3%)
```
And in the report we get:

![Screenshot from 2023-07-05 14-49-41](https://github.com/mne-tools/mne-bids-pipeline/assets/2365790/fc400a43-b37b-4c42-bf1f-7cca36c85d33)

