### PR TITLE
ENH: Add T1 and FLASH BEM to website

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,7 +582,11 @@ jobs:
       - run:
           name: test BEM from FLASH
           command: |
-            $RUN_TESTS ds000248_FLASH_BEM
+            DS=ds000248_FLASH_BEM
+            $RUN_TESTS ${DS}
+            mkdir -p ~/reports/${DS}
+            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
+            cp ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
             ls -al test-results/*.xml
       - codecov/upload
       - store_test_results:
@@ -590,6 +594,13 @@ jobs:
       - store_artifacts:
           path: ./test-results
           destination: test-results
+      - store_artifacts:
+          path: /home/circleci/reports/ds000248_FLASH_BEM
+          destination: reports/ds000248_FLASH_BEM
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - mne_data/derivatives/mne-bids-pipeline/ds000248_FLASH_BEM/*/*/*.html
 
   test_ds000248_T1_BEM:
     <<: *imageconfig
@@ -604,7 +615,11 @@ jobs:
           name: test BEM from T1 (watershed)
           no_output_timeout: 20m
           command: |
-            $RUN_TESTS ds000248_T1_BEM
+            DS=ds000248_T1_BEM
+            $RUN_TESTS ${DS}
+            mkdir -p ~/reports/${DS}
+            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
+            cp ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
             ls -al test-results/*.xml
       - codecov/upload
       - store_test_results:
@@ -612,6 +627,13 @@ jobs:
       - store_artifacts:
           path: ./test-results
           destination: test-results
+      - store_artifacts:
+          path: /home/circleci/reports/ds000248_T1_BEM
+          destination: reports/ds000248_T1_BEM
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - mne_data/derivatives/mne-bids-pipeline/ds000248_T1_BEM/*/*/*.html
 
   test_ds000248_coreg_surfaces:
     <<: *imageconfig
@@ -650,7 +672,7 @@ jobs:
             $RUN_TESTS ${DS}
             mkdir -p ~/reports/${DS}
             cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
-            cp  ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
+            cp ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
             ls -al test-results/*.xml
       - codecov/upload
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,7 +529,7 @@ jobs:
             - data-cache-ds000248-4
       - run:
           name: test BEM from FLASH
-          command: .circleci/copy_files.sh ds000248_FLASH_BEM
+          command: $RUN_TESTS ds000248_FLASH_BEM
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -582,7 +582,7 @@ jobs:
             - data-cache-ds000248-4
       - run:
           name: test head surface creation for MNE coregistration
-          command: $RUN_TESTS ds000248_coreg_surfaces
+          command: $RUN_TESTS ds000248_coreg_surfaces ds000248_coreg_surfaces --no-copy
       - codecov/upload
       - store_test_results:
           path: ./test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,13 +315,7 @@ jobs:
             - data-cache-ds000117-2
       - run:
           name: test ds000117
-          command: |
-            DS=ds000117
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds000117
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -347,13 +341,7 @@ jobs:
             - data-cache-ds003775-2
       - run:
           name: test ds003775
-          command: |
-            DS=ds003775
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds003775
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -379,13 +367,7 @@ jobs:
             - data-cache-ds001971-2
       - run:
           name: test ds001971
-          command: |
-            DS=ds001971
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds001971
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -412,13 +394,7 @@ jobs:
             - data-cache-ds004107-2
       - run:
           name: test ds004107
-          command: |
-            DS=ds004107
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds004107
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -445,14 +421,7 @@ jobs:
       - run:
           name: test ds000246
           no_output_timeout: 15m
-          command: |
-            DS=ds000246
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.tsv ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds000246
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -479,13 +448,7 @@ jobs:
             - data-cache-ds000247-2
       - run:
           name: test ds000247
-          command: |
-            DS=ds000247
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds000247
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -511,15 +474,7 @@ jobs:
             - data-cache-ds000248-4
       - run:
           name: test ds000248_base
-          command: |
-            DS=ds000248_base
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.json ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.tsv ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds000248_base
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -547,14 +502,7 @@ jobs:
             - data-cache-ds000248-4
       - run:
           name: test ds000248_ica
-          command: |
-            DS=ds000248_ica
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.tsv ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds000248_ica
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -581,13 +529,7 @@ jobs:
             - data-cache-ds000248-4
       - run:
           name: test BEM from FLASH
-          command: |
-            DS=ds000248_FLASH_BEM
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
-            cp ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: .circleci/copy_files.sh ds000248_FLASH_BEM
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -614,13 +556,7 @@ jobs:
       - run:
           name: test BEM from T1 (watershed)
           no_output_timeout: 20m
-          command: |
-            DS=ds000248_T1_BEM
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
-            cp ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds000248_T1_BEM
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -646,9 +582,7 @@ jobs:
             - data-cache-ds000248-4
       - run:
           name: test head surface creation for MNE coregistration
-          command: |
-            $RUN_TESTS ds000248_coreg_surfaces
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds000248_coreg_surfaces
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -667,13 +601,7 @@ jobs:
             - data-cache-ds000248-4
       - run:
           name: test ds000248_no_mri
-          command: |
-            DS=ds000248_no_mri
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
-            cp ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds000248_no_mri
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -700,13 +628,7 @@ jobs:
             - data-cache-ds001810-2
       - run:
           name: test ds001810
-          command: |
-            DS=ds001810
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds001810
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -732,13 +654,7 @@ jobs:
             - data-cache-ds003104-2
       - run:
           name: test ds003104
-          command: |
-            DS=ds003104
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds003104
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -764,15 +680,7 @@ jobs:
             - data-cache-ds003392-2
       - run:
           name: test ds003392
-          command: |
-            DS=ds003392
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.json ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.tsv ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds003392
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -801,15 +709,7 @@ jobs:
             - data-cache-ds004229-2
       - run:
           name: test ds004229
-          command: |
-            DS=ds004229
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.json ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.tsv ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ds004229
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -837,13 +737,7 @@ jobs:
             - data-cache-eeg_matchingpennies-1
       - run:
           name: test eeg_matchingpennies
-          command: |
-            DS=eeg_matchingpennies
-            $RUN_TESTS ${DS}
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS eeg_matchingpennies
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -878,13 +772,7 @@ jobs:
             google-chrome --version
       - run:
           name: test ERP CORE N400
-          command: |
-            DS=ERP_CORE
-            $RUN_TESTS ${DS}_N400
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*N400*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*N400*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ERP_CORE_N400 ERP_CORE
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -914,13 +802,7 @@ jobs:
           command: mkdir -p /home/circleci/.local/share/pyvista
       - run:
           name: test ERP CORE ERN
-          command: |
-            DS=ERP_CORE
-            $RUN_TESTS ${DS}_ERN
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*ERN*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*ERN*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ERP_CORE_ERN ERP_CORE
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -950,13 +832,7 @@ jobs:
           command: mkdir -p /home/circleci/.local/share/pyvista
       - run:
           name: test ERP CORE LRP
-          command: |
-            DS=ERP_CORE
-            $RUN_TESTS ${DS}_LRP
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*LRP*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*LRP*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ERP_CORE_LRP ERP_CORE
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -986,13 +862,7 @@ jobs:
           command: mkdir -p /home/circleci/.local/share/pyvista
       - run:
           name: test ERP CORE MMN
-          command: |
-            DS=ERP_CORE
-            $RUN_TESTS ${DS}_MMN
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*MMN*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*MMN*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ERP_CORE_MMN ERP_CORE
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -1022,13 +892,7 @@ jobs:
           command: mkdir -p /home/circleci/.local/share/pyvista
       - run:
           name: test ERP CORE N2pc
-          command: |
-            DS=ERP_CORE
-            $RUN_TESTS ${DS}_N2pc
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*N2pc*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*N2pc*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ERP_CORE_N2pc ERP_CORE
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -1058,13 +922,7 @@ jobs:
           command: mkdir -p /home/circleci/.local/share/pyvista
       - run:
           name: test ERP CORE N170
-          command: |
-            DS=ERP_CORE
-            $RUN_TESTS ${DS}_N170
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*N170*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*N170*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: ERP_CORE_N170 ERP_CORE
       - codecov/upload
       - store_test_results:
           path: ./test-results
@@ -1094,13 +952,7 @@ jobs:
           command: mkdir -p /home/circleci/.local/share/pyvista
       - run:
           name: test ERP CORE P3
-          command: |
-            DS=ERP_CORE
-            $RUN_TESTS ${DS}_P3
-            mkdir -p ~/reports/${DS}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*P3*.html ~/reports/${DS}/
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*P3*.xlsx ~/reports/${DS}/
-            ls -al test-results/*.xml
+          command: $RUN_TESTS ERP_CORE_P3 ERP_CORE
       - codecov/upload
       - store_test_results:
           path: ./test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -922,7 +922,7 @@ jobs:
           command: mkdir -p /home/circleci/.local/share/pyvista
       - run:
           name: test ERP CORE N170
-          command: ERP_CORE_N170 ERP_CORE
+          command: $RUN_TESTS ERP_CORE_N170 ERP_CORE
       - codecov/upload
       - store_test_results:
           path: ./test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -976,6 +976,8 @@ jobs:
       - run:
           name: Build documentation
           command: |
+            set -eo pipefail
+            ls ~/mne_data/derivatives/mne-bids-pipeline/*/*/*/*.html
             make doc
       - store_artifacts:
           path: docs/site
@@ -1220,6 +1222,8 @@ workflows:
             - test_ds000248_base
             - test_ds000248_ica
             - test_ds000248_no_mri
+            - test_ds000248_T1_BEM
+            - test_ds000248_FLASH_BEM
             - test_ds001810
             - test_ds003104
             - test_ds003392

--- a/.circleci/run_dataset_and_copy_files.sh
+++ b/.circleci/run_dataset_and_copy_files.sh
@@ -8,10 +8,22 @@ if [[ "$2" == "" ]]; then
 else
   DS="$2"
 fi
+if [[ "$3" == "--no-copy" ]]; then
+  COPY_FILES="false"
+else
+  COPY_FILES="true"
+fi
+
 pytest mne_bids_pipeline --junit-xml=test-results/junit-results.xml -k ${DS_RUN}
+
+if [[ "$COPY_FILES" == "false" ]]; then
+  exit 0
+fi
 mkdir -p ~/reports/${DS}
+# these should always exist
 cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
-cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.json ~/reports/${DS}/
-cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.tsv ~/reports/${DS}/
 cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
+# these are allowed to be optional
+cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.json ~/reports/${DS}/ || :
+cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.tsv ~/reports/${DS}/ || :
 ls -al test-results/*.xml

--- a/.circleci/run_dataset_and_copy_files.sh
+++ b/.circleci/run_dataset_and_copy_files.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eo pipefail
+
+DS_RUN=$1
+if [[ "$2" == "" ]]; then
+  DS="$DS_RUN"
+else
+  DS="$2"
+fi
+pytest mne_bids_pipeline --junit-xml=test-results/junit-results.xml -k ${DS_RUN}
+mkdir -p ~/reports/${DS}
+cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
+cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.json ~/reports/${DS}/
+cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.tsv ~/reports/${DS}/
+cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
+ls -al test-results/*.xml

--- a/.circleci/run_dataset_and_copy_files.sh
+++ b/.circleci/run_dataset_and_copy_files.sh
@@ -21,9 +21,9 @@ if [[ "$COPY_FILES" == "false" ]]; then
 fi
 mkdir -p ~/reports/${DS}
 # these should always exist
-cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.html ~/reports/${DS}/
+cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.html ~/reports/${DS}/
 cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*.xlsx ~/reports/${DS}/
 # these are allowed to be optional
-cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.json ~/reports/${DS}/ || :
-cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/*/*.tsv ~/reports/${DS}/ || :
+cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.json ~/reports/${DS}/ || :
+cp -av ~/mne_data/derivatives/mne-bids-pipeline/${DS}/*/**/*.tsv ~/reports/${DS}/ || :
 ls -al test-results/*.xml

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -35,7 +35,7 @@ fi
 sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0 /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
 wget -q -O- http://neuro.debian.net/lists/focal.us-tn.libre | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
 sudo apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com 0xA5D32F012649A5A9
-echo "export RUN_TESTS=\"pytest mne_bids_pipeline --junit-xml=test-results/junit-results.xml -k\"" >> "$BASH_ENV"
+echo "export RUN_TESTS=\".circleci/run_dataset_and_copy_files.sh\"" >> "$BASH_ENV"
 echo "export DOWNLOAD_DATA=\"python -m mne_bids_pipeline._download\"" >> "$BASH_ENV"
 
 # Similar CircleCI setup to mne-python (Xvfb, venv, minimal commands, env vars)

--- a/.github/workflows/circleci-redirector.yml
+++ b/.github/workflows/circleci-redirector.yml
@@ -10,5 +10,6 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/site/index.html
           circleci-jobs: build_docs

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -107,8 +107,8 @@ nav:
         - examples/ds000247.md
         - examples/ds000248_base.md
         - examples/ds000248_ica.md
-        # - examples/ds000248_T1_BEM.md
-        # - examples/ds000248_FLASH_BEM.md
+        - examples/ds000248_T1_BEM.md
+        - examples/ds000248_FLASH_BEM.md
         - examples/ds000248_no_mri.md
         - examples/ds003104.md
         - examples/eeg_matchingpennies.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -127,6 +127,10 @@ plugins:
     - tags:
         tags_file: tags.md
     - include-markdown
+    - exclude:
+        glob:
+          - "*.py"  # Python scripts
+          - "*.inc"  # includes
     - mkdocstrings:
         default_handler: python
         handlers:

--- a/docs/source/v1.5.md.inc
+++ b/docs/source/v1.5.md.inc
@@ -3,6 +3,7 @@
 ### :new: New features & enhancements
 
 - Added support for annotating bad segments based on head movement velocity (#757 by @larsoner)
+- Added examples of T1 and FLASH BEM to website (#758 by @larsoner)
 
 [//]: # (### :warning: Behavior changes)
 

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -1228,3 +1228,22 @@ def _add_raw(
                 section=title,
                 replace=True,
             )
+
+
+def _render_bem(
+    *,
+    cfg: SimpleNamespace,
+    report: mne.report.Report,
+    subject: str,
+    session: Optional[str],
+):
+    logger.info(**gen_log_kwargs(message="Rendering MRI slices with BEM contours."))
+    report.add_bem(
+        subject=cfg.fs_subject,
+        subjects_dir=cfg.fs_subjects_dir,
+        title="BEM",
+        width=256,
+        decim=8,
+        replace=True,
+        n_jobs=1,  # prevent automatic parallelization
+    )

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -23,7 +23,7 @@ from ..._config_utils import (
 from ..._config_import import _import_config
 from ..._logging import logger, gen_log_kwargs
 from ..._parallel import get_parallel_backend, parallel_func
-from ..._report import _open_report
+from ..._report import _open_report, _render_bem
 from ..._run import failsafe_run, save_logs, _prep_out_files
 
 
@@ -200,17 +200,7 @@ def run_forward(
     ) as report:
         msg = "Adding forward information to report"
         logger.info(**gen_log_kwargs(message=msg))
-        msg = "Rendering MRI slices with BEM contours."
-        logger.info(**gen_log_kwargs(message=msg))
-        report.add_bem(
-            subject=cfg.fs_subject,
-            subjects_dir=cfg.fs_subjects_dir,
-            title="BEM",
-            width=256,
-            decim=8,
-            replace=True,
-            n_jobs=1,  # prevent automatic parallelization
-        )
+        _render_bem(report=report, cfg=cfg, subject=subject, session=session)
         msg = "Rendering sensor alignment (coregistration)"
         logger.info(**gen_log_kwargs(message=msg))
         report.add_trans(

--- a/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
+++ b/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
@@ -47,6 +47,8 @@ ch_types = ["eeg"]
 interactive = False
 
 raw_resample_sfreq = 128
+# Suppress "Data file name in EEG.data (sub-019_task-ERN_eeg.fdt) is incorrect..."
+read_raw_bids_verbose = "error"
 
 eeg_template_montage = mne.channels.make_standard_montage("standard_1005")
 eeg_bipolar_channels = {

--- a/mne_bids_pipeline/tests/conftest.py
+++ b/mne_bids_pipeline/tests/conftest.py
@@ -34,6 +34,8 @@ def pytest_configure(config):
     # seaborn calling tight layout, etc.
     ignore:The figure layout has changed to tight:UserWarning
     ignore:The \S+_cmap function was deprecated.*:DeprecationWarning
+    # Dask distributed with jsonschema 4.18
+    ignore:jsonschema\.RefResolver is deprecated.*:DeprecationWarning
     """
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()

--- a/mne_bids_pipeline/tests/test_documented.py
+++ b/mne_bids_pipeline/tests/test_documented.py
@@ -80,7 +80,7 @@ def test_datasets_in_doc():
     # make sure everything is consistent there (too much work), let's at least
     # check that we get the correct number using `.count`.
     counts = dict(ERP_CORE=7, ds000248=6)
-    counts_noartifact = dict(ds000248=3)  # 3 are actually tests, not for docs
+    counts_noartifact = dict(ds000248=1)  # 1 is actually a test, not for docs
     for name in sorted(caches):
         get = f"Get {name}"
         n_found = circle_yaml_src.count(get)
@@ -117,17 +117,11 @@ def test_datasets_in_doc():
         # jobs: test_*: steps: persist_to_workspace
         pw = re.compile(
             f"- mne_data/derivatives/mne-bids-pipeline/{name}[^\\.]+\\*.html"
-        )  # noqa: E501
+        )
         n_found = len(pw.findall(circle_yaml_src))
         assert n_found == this_count, f"{pw} ({n_found} != {this_count})"
         # jobs: test_*: steps: run test
-        cp = re.compile(
-            f"""\
-            DS={name}.*
-            \\$RUN_TESTS \\${{DS}}.*
-            mkdir -p ~/reports/\\${{DS}}
-            cp -av ~/mne_data/derivatives/mne-bids-pipeline/\\${{DS}}/[^\\.]+.html"""
-        )  # noqa: E501
+        cp = re.compile(rf" command: \$RUN_TESTS {name}.*")
         n_found = len(cp.findall(circle_yaml_src))
         assert n_found == this_count, f"{cp} ({n_found} != {this_count})"
 

--- a/mne_bids_pipeline/tests/test_documented.py
+++ b/mne_bids_pipeline/tests/test_documented.py
@@ -123,7 +123,7 @@ def test_datasets_in_doc():
         # jobs: test_*: steps: run test
         cp = re.compile(rf" command: \$RUN_TESTS {name}.*")
         n_found = len(cp.findall(circle_yaml_src))
-        assert n_found == this_count, f"{cp} ({n_found} != {this_count})"
+        assert n_found == count, f"{cp} ({n_found} != {count})"
 
     # 3. Read examples from docs (being careful about tags we can't read)
     class SafeLoaderIgnoreUnknown(yaml.SafeLoader):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ tests = [
     "mkdocs-material-extensions",
     "mkdocs-macros-plugin",
     "mkdocs-include-markdown-plugin",
+    "mkdocs-exclude",
     "mkdocstrings-python",
     "mike",
     "jinja2",


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

1. Refactor BEM report plotting as helper
2. Add it to the BEM surfaces step (will be replaced in the forward step e.g. if the BEM surfaces don't need to be made / already exist, which should be fine)
3. Add back T1_BEM and FLASH_BEM to website now that their reports exist
4. Add some ignores to `mkdocs` using `mkdocs-exclude` plugin to avoid some of the cruft visible here:

    ![image](https://github.com/mne-tools/mne-bids-pipeline/assets/2365790/6b2d2218-b57e-40b0-890d-621c22424f56)
