### PR TITLE
MAINT: Test MD5 hashing too

### DIFF
--- a/docs/source/v1.5.md.inc
+++ b/docs/source/v1.5.md.inc
@@ -15,6 +15,7 @@
 ### :medical_symbol: Code health
 
 - Fixed doc build errors and dependency specifications (#755 by @larsoner)
+- Ensure `memory_file_method = "hash"` is tested (#768 by @larsoner)
 
 ### :bug: Bug fixes
 

--- a/mne_bids_pipeline/tests/configs/config_ds001971.py
+++ b/mne_bids_pipeline/tests/configs/config_ds001971.py
@@ -28,3 +28,6 @@ decoding_csp_freqs = {
     "beta": [13, 20, 30],
 }
 decoding_csp_times = [-0.2, 0.0, 0.2, 0.4]
+
+# Just to test that MD5 works
+memory_file_method = "hash"


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

Looking at coverage I noticed that our MD5 hashing isn't used anywhere. This should increase our coverage a bit and make sure it actually works (including on re-run).