### PR TITLE
ENH: Better logging of distances

### DIFF
--- a/docs/source/v1.5.md.inc
+++ b/docs/source/v1.5.md.inc
@@ -7,6 +7,7 @@
 - Added support for extended SSS (eSSS) in Maxwell filtering (#762 by @larsoner)
 - Output logging spacing improved (#764 by @larsoner)
 - Added caching of sensor and source average steps (#765 by @larsoner)
+- Improved logging of coregistration distances (#769 by @larsoner)
 
 [//]: # (### :warning: Behavior changes)
 


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

On `main` it prints something similar but not via our logging. Now we can control it and get nice logs:
```
┌────────┬ source/_04_make_forward ────────────────────────────────
│14:34:21│ ⏳️ sub-01 Matching template MRI using fiducials
│14:34:22│ ⏳️ sub-01 Median dig ↔ MRI distance:   4.57 mm
│14:34:22│ ⏳️ sub-01 Calculating forward solution
```
