### PR TITLE
ENH: Validate inputs with pydantic

### DIFF
--- a/docs/source/v1.5.md.inc
+++ b/docs/source/v1.5.md.inc
@@ -9,6 +9,7 @@
 - Output logging spacing improved (#764 by @larsoner)
 - Added caching of sensor and source average steps (#765 by @larsoner)
 - Improved logging of coregistration distances (#769 by @larsoner)
+- Input validation has been improved by leveraging [pydantic](https://docs.pydantic.dev) (#779 by @larsoner)
 
 [//]: # (### :warning: Behavior changes)
 
@@ -26,3 +27,4 @@
 - Fixed bug where cache would not invalidate properly based on output file changes and steps could be incorrectly skipped. All steps will automatically rerun to accommodate the new, safer caching scheme (#756 by @larsoner)
 - Fixed bug with parallelization across runs for Maxwell filtering (#761 by @larsoner)
 - Fixed bug where head position files were not written with a proper suffix and extension (#761 by @larsoner)
+- Fixed bug where default values for `decoding_csp_times` and `decoding_csp_freqs` were not set dynamically based on the data parameters (#779 by @larsoner)

--- a/docs/source/v1.5.md.inc
+++ b/docs/source/v1.5.md.inc
@@ -29,4 +29,4 @@
 - Fixed bug where cache would not invalidate properly based on output file changes and steps could be incorrectly skipped. All steps will automatically rerun to accommodate the new, safer caching scheme (#756 by @larsoner)
 - Fixed bug with parallelization across runs for Maxwell filtering (#761 by @larsoner)
 - Fixed bug where head position files were not written with a proper suffix and extension (#761 by @larsoner)
-- Fixed bug where default values for `decoding_csp_times` and `decoding_csp_freqs` were not set dynamically based on the data parameters (#779 by @larsoner)
+- Fixed bug where default values for `decoding_csp_times` and `decoding_csp_freqs` were not set dynamically based on the config parameters (#779 by @larsoner)

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -9,6 +9,7 @@ from mne_bids_pipeline.typing import (
     PathLike,
     ArbitraryContrast,
     FloatArrayLike,
+    DigMontageType,
 )
 
 
@@ -343,7 +344,7 @@ channel. To use multiple channels as reference, set to a list of channel names.
     ```
 """
 
-eeg_template_montage: Optional[str] = None
+eeg_template_montage: Optional[Union[str, DigMontageType]] = None
 """
 In situations where you wish to process EEG data and no individual
 digitization points (measured channel locations) are available, you can apply

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -2,13 +2,14 @@
 
 from typing import Optional, Union, Iterable, List, Tuple, Dict, Callable, Literal
 
-from numpy.typing import ArrayLike
-
-import mne
+from mne import Covariance
 from mne_bids import BIDSPath
-import numpy as np
 
-from mne_bids_pipeline.typing import PathLike, ArbitraryContrast
+from mne_bids_pipeline.typing import (
+    PathLike,
+    ArbitraryContrast,
+    FloatArrayLike,
+)
 
 
 ###############################################################################
@@ -594,7 +595,7 @@ The correlation limit for spatio-temporal SSS (tSSS).
     ```
 """
 
-mf_head_origin: Union[Literal["auto"], ArrayLike] = "auto"
+mf_head_origin: Union[Literal["auto"], FloatArrayLike] = "auto"
 """
 `mf_head_origin` : array-like, shape (3,) | 'auto'
 Origin of internal and external multipolar moment space in meters.
@@ -609,7 +610,7 @@ options or specifying the origin manually.
     ```
 """
 
-mf_destination: Union[Literal["reference_run"], ArrayLike] = "reference_run"
+mf_destination: Union[Literal["reference_run"], FloatArrayLike] = "reference_run"
 """
 Despite all possible care to avoid movements in the MEG, the participant
 will likely slowly drift down from the Dewar or slightly shift the head
@@ -1561,7 +1562,7 @@ Maximum frequency for the time frequency analysis, in Hz.
     ```
 """
 
-time_frequency_cycles: Optional[Union[float, ArrayLike]] = None
+time_frequency_cycles: Optional[Union[float, FloatArrayLike]] = None
 """
 The number of cycles to use in the Morlet wavelet. This can be a single number
 or one per frequency, where frequencies are calculated via
@@ -1592,9 +1593,7 @@ time and frequency ranges. This allows to obtain decoding scores defined over
 time and frequency.
 """
 
-decoding_csp_times: Optional[ArrayLike] = np.linspace(
-    max(0, epochs_tmin), epochs_tmax, num=6
-)
+decoding_csp_times: Optional[FloatArrayLike] = None
 """
 The edges of the time bins to use for CSP decoding.
 Must contain at least two elements. By default, 5 equally-spaced bins are
@@ -1614,13 +1613,7 @@ If `None`, do not perform **time-frequency** analysis, and only run CSP on
     ```
 """
 
-decoding_csp_freqs: Dict[str, ArrayLike] = {
-    "custom": [
-        time_frequency_freq_min,
-        (time_frequency_freq_max + time_frequency_freq_min) / 2,  # noqa: E501
-        time_frequency_freq_max,
-    ]
-}
+decoding_csp_freqs: Optional[Dict[str, FloatArrayLike]] = None
 """
 The edges of the frequency bins to use for CSP decoding.
 
@@ -1897,7 +1890,7 @@ solution.
 noise_cov: Union[
     Tuple[Optional[float], Optional[float]],
     Literal["emptyroom", "rest", "ad-hoc"],
-    Callable[[BIDSPath], mne.Covariance],
+    Callable[[BIDSPath], Covariance],
 ] = (None, 0)
 """
 Specify how to estimate the noise covariance matrix, which is used in

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -398,7 +398,7 @@ def _pydantic_validate(
         {"__annotations__": annotations, **attrs},
     )
     dataclass_config = dict(
-        arbitrary_types_allowed=True,
+        arbitrary_types_allowed=False,
         validate_assignment=True,
         strict=True,  # do not allow float for int for example
     )

--- a/mne_bids_pipeline/_decoding.py
+++ b/mne_bids_pipeline/_decoding.py
@@ -13,8 +13,21 @@ class LogReg(LogisticRegression):
             return super().fit(*args, **kwargs)
 
 
-def _handle_csp_args(decoding_csp_times, decoding_csp_freqs, decoding_metric):
-    _validate_type(decoding_csp_times, (list, tuple, np.ndarray), "decoding_csp_times")
+def _handle_csp_args(
+    decoding_csp_times,
+    decoding_csp_freqs,
+    decoding_metric,
+    *,
+    epochs_tmin,
+    epochs_tmax,
+    time_frequency_freq_min,
+    time_frequency_freq_max,
+):
+    _validate_type(
+        decoding_csp_times, (None, list, tuple, np.ndarray), "decoding_csp_times"
+    )
+    if decoding_csp_times is None:
+        decoding_csp_times = np.linspace(max(0, epochs_tmin), epochs_tmax, num=6)
     if len(decoding_csp_times) < 2:
         raise ValueError("decoding_csp_times should contain at least 2 values.")
     if not np.array_equal(decoding_csp_times, np.sort(decoding_csp_times)):
@@ -25,7 +38,15 @@ def _handle_csp_args(decoding_csp_times, decoding_csp_freqs, decoding_metric):
             f"decoding metric, but received "
             f'decoding_metric="{decoding_metric}"'
         )
-    _validate_type(decoding_csp_freqs, dict, "config.decoding_csp_freqs")
+    _validate_type(decoding_csp_freqs, (None, dict), "config.decoding_csp_freqs")
+    if decoding_csp_freqs is None:
+        decoding_csp_freqs = {
+            "custom": (
+                time_frequency_freq_min,
+                (time_frequency_freq_max + time_frequency_freq_min) / 2,  # noqa: E501
+                time_frequency_freq_max,
+            ),
+        }
     freq_name_to_bins_map = dict()
     for freq_range_name, edges in decoding_csp_freqs.items():
         _validate_type(freq_range_name, str, "config.decoding_csp_freqs key")

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -225,7 +225,7 @@ def _load_data(cfg: SimpleNamespace, bids_path: BIDSPath) -> mne.io.BaseRaw:
     subject = bids_path.subject
     raw = read_raw_bids(
         bids_path=bids_path,
-        extra_params=cfg.reader_extra_params,
+        extra_params=cfg.reader_extra_params or {},
         verbose=cfg.read_raw_bids_verbose,
     )
 
@@ -458,7 +458,7 @@ def import_er_data(
     # Load reference run plus its auto-bads
     raw_ref = read_raw_bids(
         bids_path_ref_in,
-        extra_params=cfg.reader_extra_params,
+        extra_params=cfg.reader_extra_params or {},
         verbose=cfg.read_raw_bids_verbose,
     )
     if bids_path_ref_bads_in is not None:

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -613,6 +613,10 @@ def add_csp_grand_average(
         cfg.decoding_csp_times,
         cfg.decoding_csp_freqs,
         cfg.decoding_metric,
+        epochs_tmin=cfg.epochs_tmin,
+        epochs_tmax=cfg.epochs_tmax,
+        time_frequency_freq_min=cfg.time_frequency_freq_min,
+        time_frequency_freq_max=cfg.time_frequency_freq_max,
     )
 
     freq_bin_starts = list()

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -835,11 +835,15 @@ def _agg_backend():
     import matplotlib
 
     backend = matplotlib.get_backend()
-    matplotlib.use("Agg", force=True)
+    matplotlib.use("agg", force=True)
     try:
         yield
     finally:
-        matplotlib.use(backend, force=True)
+        if backend.lower() != "agg":
+            import matplotlib.pyplot as plt
+
+            plt.close("all")
+            matplotlib.use(backend, force=True)
 
 
 def _add_raw(

--- a/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
+++ b/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
@@ -199,7 +199,13 @@ def one_subject_decoding(
 
     # Loop over frequencies (all time points lumped together)
     freq_name_to_bins_map = _handle_csp_args(
-        cfg.decoding_csp_times, cfg.decoding_csp_freqs, cfg.decoding_metric
+        cfg.decoding_csp_times,
+        cfg.decoding_csp_freqs,
+        cfg.decoding_metric,
+        epochs_tmin=cfg.epochs_tmin,
+        epochs_tmax=cfg.epochs_tmax,
+        time_frequency_freq_min=cfg.time_frequency_freq_min,
+        time_frequency_freq_max=cfg.time_frequency_freq_max,
     )
     freq_decoding_table_rows = []
     for freq_range_name, freq_bins in freq_name_to_bins_map.items():
@@ -365,6 +371,10 @@ def one_subject_decoding(
             cfg.decoding_csp_times,
             cfg.decoding_csp_freqs,
             cfg.decoding_metric,
+            epochs_tmin=cfg.epochs_tmin,
+            epochs_tmax=cfg.epochs_tmax,
+            time_frequency_freq_min=cfg.time_frequency_freq_min,
+            time_frequency_freq_max=cfg.time_frequency_freq_max,
         )
         all_csp_tf_results = dict()
         for contrast in cfg.decoding_contrasts:
@@ -517,6 +527,10 @@ def get_config(
         ch_types=config.ch_types,
         eeg_reference=get_eeg_reference(config),
         # Processing parameters
+        epochs_tmin=config.epochs_tmin,
+        epochs_tmax=config.epochs_tmax,
+        time_frequency_freq_min=config.time_frequency_freq_min,
+        time_frequency_freq_max=config.time_frequency_freq_max,
         time_frequency_subtract_evoked=config.time_frequency_subtract_evoked,
         decoding_metric=config.decoding_metric,
         decoding_csp_freqs=config.decoding_csp_freqs,

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -779,6 +779,8 @@ def average_csp_decoding(
         cfg.decoding_metric,
         epochs_tmin=cfg.epochs_tmin,
         epochs_tmax=cfg.epochs_tmax,
+        time_frequency_freq_min=cfg.time_frequency_freq_min,
+        time_frequency_freq_max=cfg.time_frequency_freq_max,
     )
     data_for_clustering = {}
     for freq_range_name in freq_name_to_bins_map:

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -777,8 +777,8 @@ def average_csp_decoding(
         cfg.decoding_csp_times,
         cfg.decoding_csp_freqs,
         cfg.decoding_metric,
-        epochs_tmin=cfg.decoding_epochs_tmin,
-        epochs_tmax=cfg.decoding_epochs_tmax,
+        epochs_tmin=cfg.epochs_tmin,
+        epochs_tmax=cfg.epochs_tmax,
     )
     data_for_clustering = {}
     for freq_range_name in freq_name_to_bins_map:

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -6,8 +6,9 @@ The M/EEG-channel data are averaged for group averages.
 import os
 import os.path as op
 from functools import partial
-from typing import Optional, TypedDict, List, Tuple
+from typing import Optional, List, Tuple
 from types import SimpleNamespace
+from ...typing import TypedDict
 
 import numpy as np
 import pandas as pd
@@ -773,7 +774,11 @@ def average_csp_decoding(
         time_bins = np.array(list(zip(time_bins[:-1], time_bins[1:])))
     time_bins = pd.DataFrame(time_bins, columns=["t_min", "t_max"])
     freq_name_to_bins_map = _handle_csp_args(
-        cfg.decoding_csp_times, cfg.decoding_csp_freqs, cfg.decoding_metric
+        cfg.decoding_csp_times,
+        cfg.decoding_csp_freqs,
+        cfg.decoding_metric,
+        epochs_tmin=cfg.decoding_epochs_tmin,
+        epochs_tmax=cfg.decoding_epochs_tmax,
     )
     data_for_clustering = {}
     for freq_range_name in freq_name_to_bins_map:
@@ -937,6 +942,10 @@ def get_config(
         task_is_rest=config.task_is_rest,
         conditions=config.conditions,
         contrasts=config.contrasts,
+        epochs_tmin=config.epochs_tmin,
+        epochs_tmax=config.epochs_tmax,
+        time_frequency_freq_min=config.time_frequency_freq_min,
+        time_frequency_freq_max=config.time_frequency_freq_max,
         decode=config.decode,
         decoding_metric=config.decoding_metric,
         decoding_n_splits=config.decoding_n_splits,

--- a/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
+++ b/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
@@ -24,7 +24,6 @@ components from a total of 6 experimental tasks:
                 [https://doi.org/10.1016/j.neuroimage.2020.117465](https://doi.org/10.1016/j.neuroimage.2020.117465)
 """
 import argparse
-import mne
 import sys
 
 study_name = "ERP-CORE"
@@ -50,7 +49,7 @@ raw_resample_sfreq = 128
 # Suppress "Data file name in EEG.data (sub-019_task-ERN_eeg.fdt) is incorrect..."
 read_raw_bids_verbose = "error"
 
-eeg_template_montage = mne.channels.make_standard_montage("standard_1005")
+eeg_template_montage = "standard_1005"
 eeg_bipolar_channels = {
     "HEOG": ("HEOG_left", "HEOG_right"),
     "VEOG": ("VEOG_lower", "FP2"),

--- a/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
+++ b/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
@@ -24,6 +24,7 @@ components from a total of 6 experimental tasks:
                 [https://doi.org/10.1016/j.neuroimage.2020.117465](https://doi.org/10.1016/j.neuroimage.2020.117465)
 """
 import argparse
+import mne
 import sys
 
 study_name = "ERP-CORE"
@@ -49,7 +50,7 @@ raw_resample_sfreq = 128
 # Suppress "Data file name in EEG.data (sub-019_task-ERN_eeg.fdt) is incorrect..."
 read_raw_bids_verbose = "error"
 
-eeg_template_montage = "standard_1005"
+eeg_template_montage = mne.channels.make_standard_montage("standard_1005")
 eeg_bipolar_channels = {
     "HEOG": ("HEOG_left", "HEOG_right"),
     "VEOG": ("VEOG_lower", "FP2"),

--- a/mne_bids_pipeline/typing.py
+++ b/mne_bids_pipeline/typing.py
@@ -1,8 +1,18 @@
 """Typing."""
 
 import pathlib
-from typing import Union, List, Dict, TypedDict
+import sys
+from typing import Union, List, Dict
+from typing_extensions import Annotated
 
+if sys.version_info < (3, 12):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
+
+import numpy as np
+from numpy.typing import ArrayLike
+from pydantic import PlainValidator
 import mne
 
 PathLike = Union[str, pathlib.Path]
@@ -22,3 +32,16 @@ class LogKwargsT(TypedDict):
 class ReferenceRunParams(TypedDict):
     montage: mne.channels.DigMontage
     dev_head_t: mne.Transform
+
+
+def assert_float_array_like(val):
+    # https://docs.pydantic.dev/latest/errors/errors/#custom-errors
+    # Should raise ValueError or AssertionError... NumPy should do this for us
+    return np.array(val, dtype="float")
+
+
+FloatArrayLike = Annotated[
+    ArrayLike,
+    # PlainValidator will skip internal validation attempts for ArrayLike
+    PlainValidator(assert_float_array_like),
+]

--- a/mne_bids_pipeline/typing.py
+++ b/mne_bids_pipeline/typing.py
@@ -45,3 +45,14 @@ FloatArrayLike = Annotated[
     # PlainValidator will skip internal validation attempts for ArrayLike
     PlainValidator(assert_float_array_like),
 ]
+
+
+def assert_dig_montage(val):
+    assert isinstance(val, mne.channels.DigMontage)
+    return val
+
+
+DigMontageType = Annotated[
+    mne.channels.DigMontage,
+    PlainValidator(assert_dig_montage),
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pandas",
     "seaborn",
     "json_tricks",
+    "pydantic >= 2.0.0",
     "rich",
     "python-picard",
     "qtpy",


### PR DESCRIPTION
### Before merging …

- [x] Validate inputs with `pydantic` after adding as a dependency (2.0 seems to be the min useable version for us based on local testing)
- [x] Fix bugs where defaults for `decoding_csp_times` and `decoding_csp_freqs` didn't do what we said they did (they were set once statically based on the defaults rather than being computed dynamically based on the variable values)
- [x] Changelog has been updated (`docs/source/changes.md`)

Locally it seems to work -- adding `config_validation = "foo"` to `config_ds003392.py` for example produces:
```
$ pytest mne_bids_pipeline -xk 003392
...
mne_bids_pipeline/_config_import.py:410: in _pydantic_validate
    raise ValueError(str(err)) from None
E   ValueError: 1 validation error for user configuration from /home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/tests/configs/config_ds003392.py
E   config_validation
E     Input should be 'raise', 'warn' or 'ignore' [type=literal_error, input_value='foo', input_type=str]
E       For further information visit https://errors.pydantic.dev/2.1/v/literal_error
```
or when setting `mf_destination = "foo"` in `config_ds003392.py` which allows a specific Literal or a FloatArrayLike:
```
$ pytest mne_bids_pipeline -xk 004229
...
mne_bids_pipeline/_config_import.py:410: in _pydantic_validate
    raise ValueError(str(err)) from None
E   ValueError: 2 validation errors for user configuration from /home/larsoner/python/mne-bids-pipeline/mne_bids_pipeline/tests/configs/config_ds004229.py
E   mf_destination.literal['reference_run']
E     Input should be 'reference_run' [type=literal_error, input_value='foo', input_type=str]
E       For further information visit https://errors.pydantic.dev/2.1/v/literal_error
E   mf_destination.function-plain[assert_float_array_like()]
E     Value error, could not convert string to float: 'foo' [type=value_error, input_value='foo', input_type=str]
E       For further information visit https://errors.pydantic.dev/2.1/v/value_error
```
Because of the `strict=True` I suspect there will be some `List`s that we will want to change to `FloatArrayLike` (or create a generic `CheckedArrayLike` that allows arbitrary dtypes or something) but this is maybe a good enough start!

Closes #766