### PR TITLE
Better handling of virtual EOG channels during ICA

### DIFF
--- a/mne_bids_pipeline/steps/preprocessing/_06a_run_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a_run_ica.py
@@ -238,7 +238,7 @@ def drop_bads_virtual_eog_aware(
     reject: Dict[str, float],
     used_for: str,
 ) -> None:
-    """Drop bad channels, but correctly handle virtual EOG channels.
+    """Drop bad epochs, but correctly handle virtual EOG channels.
 
     Operates in-place.
     """


### PR DESCRIPTION
Make it such that when using "virtual" EOG channels (e.g., typically these would be frontal EEG channels), the PTP rejection with the thresholds specified in `ica_reject` will treat these channels as EOG.

### 📚 Background
I'm working with a set of EEG data where many participants have strong ocular contaminations in numerous frontal channels. I selected these channels for use as virtual EOG channels. I want to use ICA to remove the ocular artifacts from my data.

The problem is that since these channels are actually of type `"eeg"`, I have to supply extremely high values in `ica_reject = {"eeg": ...}`; otherwise, many epochs (both experimental epochs and automatically created EOG epochs) get rejected before ICA fitting. If that happens, ICA has no chance to "see" the ocular artifacts, and fails to remove them.

Yet, I don't want to be **too** lenient when setting `ica_reject`, because I don't want voltage spikes from other channels (e.g. from the occipital region) to interfere with ICA fitting.

So what I actually want is two sets of rejection thresholds: one for the channels that capture most of the EOG signal, and another for the remaining EEG channels.

### 🧑‍💻 This PR

- I can specify my virtual EOG channels like: `eog_channels = ["Fp1", "Fp2", "AF7", "AF8", "AF3", "AF4"]`
- Before performing PTP rejection on "experimental" and EOG epochs, we change the channel type of these channels to `"eog"`
- This allows us to apply EOG PTP thresholds to the virtual channels, and EEG threshold to the remaining channels: `ica_reject = {"eeg": 200e-6, "eog": 600e-6}`; or maybe even no limit for the virtual EOG channels at all, and only reject based on the remaining EEG channels `ica_reject = {"eeg": 200e-6}`
- After PTP rejection, the original channel types are restored again. These data can then be sent off to ICA fitting, and still contains many epochs with large ocular artifacts in the frontal (virtual EOG) channels. Which is exactly what I want: now ICA has a chance to learn about these artifacts.

I'd love to hear your feedback on this, @agramfort 

### 😫 ICA is hard
I feel I'm constantly struggling to hit the right balance between "don't feed too much crap into ICA, because the decomposition will not be good" and "If you don't feed **enough** bad data, ICA won't have a chance to detect those artifacts".

cc @larsoner, @mscheltienne

- [ ] Changelog has been updated (`docs/source/changes.md`)
