### PR TITLE
Do not interpolate bad segments using autoreject before ICA

### DIFF
--- a/docs/source/v1.5.md.inc
+++ b/docs/source/v1.5.md.inc
@@ -19,9 +19,9 @@ All users are encouraged to update.
   per-epoch basis as the last preprocessing step; this can be enabled by setting [`reject`][mne_bids_pipeline._config.reject]
   to `"autoreject_local"`. The behavior can further be controlled via the new setting
   [`autoreject_n_interpolate`][mne_bids_pipeline._config.autoreject_n_interpolate]. (#807 by @hoechenberger)
-- Added support for "local" [`autoreject`](https://autoreject.github.io) to find (and repair) bad channels on a per-epoch
-  basis before submitting them to ICA fitting. This can be enabled by setting [`ica_reject`][mne_bids_pipeline._config.ica_reject]
-  to `"autoreject_local"`. (#810 by @hoechenberger)
+- Added support for "local" [`autoreject`](https://autoreject.github.io) to remove bad epochs
+  before submitting the data to ICA fitting. This can be enabled by setting [`ica_reject`][mne_bids_pipeline._config.ica_reject]
+  to `"autoreject_local"`. (#810, #816 by @hoechenberger)
 - Website documentation tables can now be sorted (e.g., to find examples that use a specific feature) (#808 by @larsoner)
 
 [//]: # (### :warning: Behavior changes)

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1240,7 +1240,9 @@ remove strong transient artifacts from the epochs used for fitting ICA, which co
 negatively affect ICA performance. 
 
 The parameter values are the same as for [`reject`][mne_bids_pipeline._config.reject],
-but `"autoreject_global"` is not supported.
+but `"autoreject_global"` is not supported. `"autoreject_local"` here behaves
+differently, too: it is only used to exclude bad epochs from ICA fitting; we do not
+perform any interpolation.
 
 ???+ info
     We don't support `"autoreject_global"` here (as opposed to

--- a/mne_bids_pipeline/steps/preprocessing/_08_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08_ptp_reject.py
@@ -84,7 +84,10 @@ def drop_ptp(
     epochs = mne.read_epochs(in_files.pop("epochs"), preload=True)
 
     if cfg.reject == "autoreject_local":
-        msg = "Using autoreject to find and repair bad epochs"
+        msg = (
+            "Using autoreject to find and repair bad epochs (interpolating bad "
+            "segments)"
+        )
         logger.info(**gen_log_kwargs(message=msg))
 
         ar = autoreject.AutoReject(


### PR DESCRIPTION
This is a fixup for #810

There, not only did we remove bad epochs, but also interpolated data before submission to ICA fitting. However, this is not what is recommended in the autoreject documentation: there, the suggestion is to [only remove the bad epochs](https://autoreject.github.io/stable/auto_examples/plot_autoreject_workflow.html#ica), not interpolate.

This PR fixes the behavior accordingly and updates the documentation and log messages.

I tested on a set of noise EEG data and I'm actually getting better results with this approach for the majority participants .

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
