### PR TITLE
Prepare for 1.5.0 release

### DIFF
--- a/docs/source/v1.5.md.inc
+++ b/docs/source/v1.5.md.inc
@@ -1,4 +1,4 @@
-## v1.5.0 (unreleased)
+## v1.5.0 (2023-11-30)
 
 This release contains a number of very important bug fixes that address problems related to decoding, time-frequency analysis, and inverse modeling.
 All users are encouraged to update.


### PR DESCRIPTION
I think this is all we did for 1.4 then cutting a release on GitHub should hopefully do the right thing.

Closes #783