### PR TITLE
BUG: Fix several bugs

### DIFF
--- a/docs/source/v1.6.md.inc
+++ b/docs/source/v1.6.md.inc
@@ -20,6 +20,7 @@
 - Fix minor issues with path handling for cross-talk and calibration files (#834 by @larsoner)
 - Fix bug where EEG `reject` params were not used for `ch_types = ["meg", "eeg"]` (#839 by @larsoner)
 - Fix bug where implicit `mf_reference_run` could change across invocations of `mne_bids_pipeline`, breaking caching (#839 by @larsoner)
+- Fix bug where `--no-cache` had no effect (#839 by @larsoner)
 
 ### :medical_symbol: Code health
 

--- a/docs/source/v1.6.md.inc
+++ b/docs/source/v1.6.md.inc
@@ -5,6 +5,7 @@
 :new: New features & enhancements
 
 - Added [`regress_artifact`][mne_bids_pipeline._config.regress_artifact] to allow artifact regression (e.g., of MEG reference sensors in KIT systems) (#837 by @larsoner)
+- Chosen `reject` parameters are now saved in the generated HTML reports (#839 by @larsoner)
 
 [//]: # (### :warning: Behavior changes)
 
@@ -17,6 +18,8 @@
 ### :bug: Bug fixes
 
 - Fix minor issues with path handling for cross-talk and calibration files (#834 by @larsoner)
+- Fix bug where EEG `reject` params were not used for `ch_types = ["meg", "eeg"]` (#839 by @larsoner)
+- Fix bug where implicit `mf_reference_run` could change across invocations of `mne_bids_pipeline`, breaking caching (#839 by @larsoner)
 
 ### :medical_symbol: Code health
 

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -369,7 +369,7 @@ def _pydantic_validate(
     if config_path is not None:
         name += f" from {config_path}"
     model_config = ConfigDict(
-        arbitrary_types_allowed=False,
+        arbitrary_types_allowed=True,  # needed in 2.6.0 to allow DigMontage for example
         validate_assignment=True,
         strict=True,  # do not allow float for int for example
         extra="forbid",

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -442,17 +442,6 @@ def _restrict_analyze_channels(
     return inst
 
 
-def _get_scalp_in_files(cfg: SimpleNamespace) -> dict[str, pathlib.Path]:
-    subject_path = pathlib.Path(cfg.subjects_dir) / cfg.fs_subject
-    seghead = subject_path / "surf" / "lh.seghead"
-    in_files = dict()
-    if seghead.is_file():
-        in_files["seghead"] = seghead
-    else:
-        in_files["t1"] = subject_path / "mri" / "T1.mgz"
-    return in_files
-
-
 def _get_bem_conductivity(cfg: SimpleNamespace) -> tuple[tuple[float], str]:
     if cfg.fs_subject in ("fsaverage", cfg.use_template_mri):
         conductivity = None  # should never be used

--- a/mne_bids_pipeline/_main.py
+++ b/mne_bids_pipeline/_main.py
@@ -141,7 +141,6 @@ def main():
         steps = (steps,)
 
     on_error = "debug" if debug else None
-    cache = "1" if cache else "0"
 
     processing_stages = []
     processing_steps = []

--- a/mne_bids_pipeline/_reject.py
+++ b/mne_bids_pipeline/_reject.py
@@ -45,11 +45,11 @@ def _get_reject(
 
     # Only keep thresholds for channel types of interest
     reject = reject.copy()
-    if ch_types == ["eeg"]:
-        ch_types_to_remove = ("mag", "grad")
-    else:
-        ch_types_to_remove = ("eeg",)
-
+    ch_types_to_remove = list()
+    if "meg" not in ch_types:
+        ch_types_to_remove.extend(("mag", "grad"))
+    if "eeg" not in ch_types:
+        ch_types_to_remove.append("eeg")
     for ch_type in ch_types_to_remove:
         try:
             del reject[ch_type]

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -380,6 +380,12 @@ def _prep_out_files(
     out_files: dict[str, BIDSPath],
 ):
     for key, fname in out_files.items():
+        # Sanity check that we only ever write to the derivatives directory
+        if not fname.fpath.is_relative_to(exec_params.deriv_root):
+            raise RuntimeError(
+                f"Output BIDSPath not relative to deriv_root {exec_params.deriv_root}:"
+                f"\n{fname}\n{fname.fpath}"
+            )
         out_files[key] = _path_to_str_hash(
             key,
             pathlib.Path(fname),

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -385,7 +385,7 @@ def _prep_out_files(
     for key, fname in out_files.items():
         # Sanity check that we only ever write to the derivatives directory
         fname = pathlib.Path(fname)
-        if check_relative and not fname.is_relative_to(exec_params.deriv_root):
+        if not fname.is_relative_to(check_relative):
             raise RuntimeError(
                 f"Output BIDSPath not relative to expected root {check_relative}:"
                 f"\n{fname}"

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -378,16 +378,16 @@ def _prep_out_files(
     *,
     exec_params: SimpleNamespace,
     out_files: dict[str, BIDSPath],
+    check_relative: Optional[pathlib.Path] = None,
 ):
-    # Don't look at just deriv_root as this ends with <path>/mne-bids-pipeline and
-    # sometimes we write stuff to <path>/freesurfer
-    rel_root = exec_params.deriv_root.parent
+    if check_relative is None:
+        check_relative = exec_params.deriv_root
     for key, fname in out_files.items():
         # Sanity check that we only ever write to the derivatives directory
         fname = pathlib.Path(fname)
-        if not fname.is_relative_to(rel_root):
+        if check_relative and not fname.is_relative_to(exec_params.deriv_root):
             raise RuntimeError(
-                f"Output BIDSPath not relative to deriv_root parent {rel_root}:"
+                f"Output BIDSPath not relative to expected root {check_relative}:"
                 f"\n{fname}"
             )
         out_files[key] = _path_to_str_hash(

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -379,12 +379,15 @@ def _prep_out_files(
     exec_params: SimpleNamespace,
     out_files: dict[str, BIDSPath],
 ):
+    # Don't look at just deriv_root as this ends with <path>/mne-bids-pipeline and
+    # sometimes we write stuff to <path>/freesurfer
+    rel_root = exec_params.deriv_root.parent
     for key, fname in out_files.items():
         # Sanity check that we only ever write to the derivatives directory
         fname = pathlib.Path(fname)
-        if not fname.is_relative_to(exec_params.deriv_root):
+        if not fname.is_relative_to(rel_root):
             raise RuntimeError(
-                f"Output BIDSPath not relative to deriv_root {exec_params.deriv_root}:"
+                f"Output BIDSPath not relative to deriv_root parent {rel_root}:"
                 f"\n{fname}"
             )
         out_files[key] = _path_to_str_hash(

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -237,7 +237,6 @@ class ConditionalStepMemory:
                                 f"Output file hash mismatch for {str(fname)}, "
                                 "will recompute …"
                             )
-                            raise RuntimeError("bar")
                             emoji = "🚫"
                             bad_out_files = True
                             break
@@ -382,14 +381,15 @@ def _prep_out_files(
 ):
     for key, fname in out_files.items():
         # Sanity check that we only ever write to the derivatives directory
-        if not fname.fpath.is_relative_to(exec_params.deriv_root):
+        fname = pathlib.Path(fname)
+        if not fname.is_relative_to(exec_params.deriv_root):
             raise RuntimeError(
                 f"Output BIDSPath not relative to deriv_root {exec_params.deriv_root}:"
-                f"\n{fname}\n{fname.fpath}"
+                f"\n{fname}"
             )
         out_files[key] = _path_to_str_hash(
             key,
-            pathlib.Path(fname),
+            fname,
             method=exec_params.memory_file_method,
             kind="out",
         )

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -237,6 +237,7 @@ class ConditionalStepMemory:
                                 f"Output file hash mismatch for {str(fname)}, "
                                 "will recompute …"
                             )
+                            raise RuntimeError("bar")
                             emoji = "🚫"
                             bad_out_files = True
                             break
@@ -407,7 +408,7 @@ def _path_to_str_hash(
     assert isinstance(v, pathlib.Path), f'Bad type {type(v)}: {kind}_files["{k}"] = {v}'
     assert v.exists(), f'missing {kind}_files["{k}"] = {v}'
     if method == "mtime":
-        this_hash = v.lstat().st_mtime
+        this_hash = v.stat().st_mtime
     else:
         assert method == "hash"  # guaranteed
         this_hash = hash_file_path(v)

--- a/mne_bids_pipeline/steps/preprocessing/_05_regress_artifact.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05_regress_artifact.py
@@ -76,7 +76,6 @@ def run_regress_artifact(
     out_files["regress"] = bids_path_in.copy().update(
         processing=None,
         split=None,
-        run=None,
         suffix="regress",
         extension=".h5",
     )

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -189,6 +189,7 @@ def drop_ptp(
         psd = 30
     tags = ("epochs", "reject")
     kind = cfg.reject if isinstance(cfg.reject, str) else "reject"
+    title = "Epochs: after cleaning"
     with _open_report(
         cfg=cfg, exec_params=exec_params, subject=subject, session=session
     ) as report:
@@ -206,6 +207,7 @@ def drop_ptp(
                 title=f"Epochs: {kind} cleaning",
                 caption=caption,
                 tags=tags,
+                section=title,
                 replace=True,
             )
             del caption
@@ -214,13 +216,14 @@ def drop_ptp(
             report.add_html(
                 html=html,
                 title=f"Epochs: {kind} thresholds",
+                section=title,
                 replace=True,
                 tags=tags,
             )
 
         report.add_epochs(
             epochs=epochs,
-            title="Epochs: after cleaning",
+            title=title,
             psd=psd,
             drop_log_ignore=(),
             tags=tags,

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -207,6 +207,14 @@ def drop_ptp(
                 replace=True,
             )
             del caption
+        else:
+            html = f"<p>Rejection thresholds: <code>{reject}</code></p>"
+            report.add_html(
+                html=html,
+                title="Epochs: reject setup",
+                replace=True,
+                tags=("epochs", "reject"),
+            )
 
         report.add_epochs(
             epochs=epochs,

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -187,6 +187,8 @@ def drop_ptp(
         psd = True
     else:
         psd = 30
+    tags = ("epochs", "reject")
+    kind = cfg.reject if isinstance(cfg.reject, str) else "reject"
     with _open_report(
         cfg=cfg, exec_params=exec_params, subject=subject, session=session
     ) as report:
@@ -201,9 +203,9 @@ def drop_ptp(
                 fig=reject_log.plot(
                     orientation="horizontal", aspect="auto", show=False
                 ),
-                title="Epochs: Autoreject cleaning",
+                title=f"Epochs: {kind} cleaning",
                 caption=caption,
-                tags=("epochs", "autoreject"),
+                tags=tags,
                 replace=True,
             )
             del caption
@@ -211,9 +213,9 @@ def drop_ptp(
             html = f"<p>Rejection thresholds: <code>{reject}</code></p>"
             report.add_html(
                 html=html,
-                title="Epochs: reject setup",
+                title=f"Epochs: {kind} thresholds",
                 replace=True,
-                tags=("epochs", "reject"),
+                tags=tags,
             )
 
         report.add_epochs(
@@ -221,6 +223,7 @@ def drop_ptp(
             title="Epochs: after cleaning",
             psd=psd,
             drop_log_ignore=(),
+            tags=tags,
             replace=True,
         )
     return _prep_out_files(exec_params=exec_params, out_files=out_files)

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -190,7 +190,6 @@ def drop_ptp(
     tags = ("epochs", "reject")
     kind = cfg.reject if isinstance(cfg.reject, str) else "Rejection"
     title = "Epochs: after cleaning"
-    kwargs = dict(section=title, tags=tags, replace=True)
     with _open_report(
         cfg=cfg, exec_params=exec_params, subject=subject, session=session
     ) as report:
@@ -207,14 +206,18 @@ def drop_ptp(
                 ),
                 title=f"{kind} cleaning",
                 caption=caption,
-                **kwargs,
+                section=title,
+                tags=tags,
+                replace=True,
             )
             del caption
         else:
             report.add_html(
                 html=f"<code>{reject}</code>",
                 title=f"{kind} thresholds",
-                **kwargs,
+                section=title,
+                replace=True,
+                tags=tags,
             )
 
         report.add_epochs(
@@ -222,7 +225,8 @@ def drop_ptp(
             title=title,
             psd=psd,
             drop_log_ignore=(),
-            **kwargs,
+            tags=tags,
+            replace=True,
         )
     return _prep_out_files(exec_params=exec_params, out_files=out_files)
 

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -188,8 +188,9 @@ def drop_ptp(
     else:
         psd = 30
     tags = ("epochs", "reject")
-    kind = cfg.reject if isinstance(cfg.reject, str) else "reject"
+    kind = cfg.reject if isinstance(cfg.reject, str) else "Rejection"
     title = "Epochs: after cleaning"
+    kwargs = dict(section=title, tags=tags, replace=True)
     with _open_report(
         cfg=cfg, exec_params=exec_params, subject=subject, session=session
     ) as report:
@@ -204,21 +205,16 @@ def drop_ptp(
                 fig=reject_log.plot(
                     orientation="horizontal", aspect="auto", show=False
                 ),
-                title=f"Epochs: {kind} cleaning",
+                title=f"{kind} cleaning",
                 caption=caption,
-                tags=tags,
-                section=title,
-                replace=True,
+                **kwargs,
             )
             del caption
         else:
-            html = f"<p>Rejection thresholds: <code>{reject}</code></p>"
             report.add_html(
-                html=html,
-                title=f"Epochs: {kind} thresholds",
-                section=title,
-                replace=True,
-                tags=tags,
+                html=f"<code>{reject}</code>",
+                title=f"{kind} thresholds",
+                **kwargs,
             )
 
         report.add_epochs(
@@ -226,8 +222,7 @@ def drop_ptp(
             title=title,
             psd=psd,
             drop_log_ignore=(),
-            tags=tags,
-            replace=True,
+            **kwargs,
         )
     return _prep_out_files(exec_params=exec_params, out_files=out_files)
 

--- a/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
+++ b/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
@@ -112,7 +112,9 @@ def make_bem_surfaces(
         subject=subject,
         session=session,
     )
-    return _prep_out_files(exec_params=exec_params, out_files=out_files)
+    return _prep_out_files(
+        exec_params=exec_params, out_files=out_files, check_relative=cfg.fs_subjects_dir
+    )
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/source/_02_make_bem_solution.py
+++ b/mne_bids_pipeline/steps/source/_02_make_bem_solution.py
@@ -69,7 +69,9 @@ def make_bem_solution(
     out_files = get_output_fnames_make_bem_solution(cfg=cfg, subject=subject)
     mne.write_bem_surfaces(out_files["model"], bem_model, overwrite=True)
     mne.write_bem_solution(out_files["sol"], bem_sol, overwrite=True)
-    return _prep_out_files(exec_params=exec_params, out_files=out_files)
+    return _prep_out_files(
+        exec_params=exec_params, out_files=out_files, check_relative=cfg.fs_subjects_dir
+    )
 
 
 def get_config(

--- a/mne_bids_pipeline/steps/source/_03_setup_source_space.py
+++ b/mne_bids_pipeline/steps/source/_03_setup_source_space.py
@@ -55,7 +55,9 @@ def run_setup_source_space(
     in_files.clear()  # all used by setup_source_space
     out_files = get_output_fnames_setup_source_space(cfg=cfg, subject=subject)
     mne.write_source_spaces(out_files["src"], src, overwrite=True)
-    return _prep_out_files(exec_params=exec_params, out_files=out_files)
+    return _prep_out_files(
+        exec_params=exec_params, out_files=out_files, check_relative=cfg.fs_subjects_dir
+    )
 
 
 def get_config(


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

I went to work on #831 but wanted to sort out a few little other bugs (and one minor enhancement) first:

1. Fix bug where using `mf_reference_run = None` could change the empty room file matched from run-to-run of `mne_bids_pipeline` due to use of `set`, whose order is not guaranteed. @hoechenberger I suspect this could be the actual root cause of #814 
2. Output the `reject` params in the reject step -- though this can be set in the config, it's sometimes calculated on-the-fly by `autoreject` and not saved anywhere. Even in the manual `dict` case it's nice to have it near the drop logs in the report in case you want to think about adjusting your thresholds:

   ![Screenshot from 2024-01-30 12-00-44](https://github.com/mne-tools/mne-bids-pipeline/assets/2365790/211ff9c3-9ced-4a23-9ee7-8340bc622beb)

4. Fix bug where `reject` was getting restricted incorrectly for M/EEG channels
5. Prefer `stat` to `lstat` because I'm pretty sure we *don't* want to use the symlink's own `mtime` but rather the `mtime` of whatever it points to. (This is apparently the only difference between `lstat` and `stat`.) Doubt anyone has actually hit this so no changelog needed, but better to have it in there I think.
6. Fix bug with `-regress` saving where instead of writing one for each run, a single filename was written to by every run (within-release change so no changelog needed).
7. Slightly better report tags for the cleaned epochs to make it clear that what's happened is the `reject` step