### PR TITLE
MAINT: Remove datalad

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,6 @@ jobs:
           keys:
             - data-cache-eeg_matchingpennies-1
       - bash_env
-      - gitconfig  # email address is needed for datalad
       - run:
           name: Get eeg_matchingpennies
           command: |
@@ -306,7 +305,6 @@ jobs:
           keys:
             - data-cache-MNE-phantom-KIT-data-1
       - bash_env
-      - gitconfig  # email address is needed for datalad
       - run:
           name: Get MNE-phantom-KIT-data
           command: |

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -33,15 +33,13 @@ fi
 
 # Set up image
 sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0 /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
-wget -q -O- http://neuro.debian.net/lists/focal.us-tn.libre | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
-sudo apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com 0xA5D32F012649A5A9
 echo "export RUN_TESTS=\".circleci/run_dataset_and_copy_files.sh\"" >> "$BASH_ENV"
 echo "export DOWNLOAD_DATA=\"coverage run -m mne_bids_pipeline._download\"" >> "$BASH_ENV"
 
 # Similar CircleCI setup to mne-python (Xvfb, venv, minimal commands, env vars)
 wget -q https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/setup_xvfb.sh
 bash setup_xvfb.sh
-sudo apt install -qq tcsh git-annex-standalone python3.10-venv python3-venv libxft2
+sudo apt install -qq tcsh python3.10-venv python3-venv libxft2
 python3.10 -m venv ~/python_env
 wget -q https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/get_minimal_commands.sh
 source get_minimal_commands.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,16 +11,10 @@ Once this is done, you should be able to run this in a terminal:
 
 `$ python -c "import mne; mne.sys_info()"`
 
-You can then install the following additional packages via `pip`. Note that
+You can then install the following additional package via `pip`. Note that
 the URL points to the bleeding edge version of `mne_bids`:
 
-`$ pip install datalad`
 `$ pip install https://github.com/mne-tools/mne-bids/zipball/main`
-
-To get the test data, you need to install `git-annex` on your system. If you
-installed MNE-Python via `conda`, you can simply call:
-
-`conda install -c conda-forge git-annex`
 
 Now, get the pipeline through git:
 

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ doc:
 
 check:
 	which python
-	git-annex version
-	datalad --version
 	openneuro-py --version
 	mri_convert --version
 	mne_bids --version

--- a/docs/source/examples/gen_examples.py
+++ b/docs/source/examples/gen_examples.py
@@ -203,21 +203,14 @@ for test_dataset_name, test_dataset_options in ds_iter:
             f"{fname.name} :fontawesome-solid-square-poll-vertical:</a>\n\n"
         )
 
-    assert (
-        sum(key in options for key in ("openneuro", "git", "web", "datalad", "mne"))
-        == 1
-    )
+    assert sum(key in options for key in ("openneuro", "web", "mne")) == 1
     if "openneuro" in options:
         url = f'https://openneuro.org/datasets/{options["openneuro"]}'
-    elif "git" in options:
-        url = options["git"]
     elif "web" in options:
         url = options["web"]
-    elif "mne" in options:
-        url = f"https://mne.tools/dev/generated/mne.datasets.{options['mne']}.data_path.html"  # noqa: E501
     else:
-        assert "datalad" in options  # guaranteed above
-        url = ""
+        assert "mne" in options
+        url = f"https://mne.tools/dev/generated/mne.datasets.{options['mne']}.data_path.html"  # noqa: E501
 
     source_str = (
         f"## Dataset source\n\nThis dataset was acquired from " f"[{url}]({url})\n"

--- a/docs/source/v1.6.md.inc
+++ b/docs/source/v1.6.md.inc
@@ -35,6 +35,7 @@
 ### :medical_symbol: Code health
 
 - The package build backend has been switched from `setuptools` to `hatchling`. (#825 by @hoechenberger)
+- Removed dependencies on `datalad` and `git-annex` for testing (#867 by @larsoner)
 - Code formatting now uses `ruff format` instead of `black` (#834, #838 by @larsoner)
 - Code caching is now tested using GitHub Actions (#836 by @larsoner)
 - Steps in the documentation are now automatically parsed into flowcharts (#859 by @larsoner)

--- a/mne_bids_pipeline/tests/datasets.py
+++ b/mne_bids_pipeline/tests/datasets.py
@@ -22,16 +22,6 @@ DATASET_OPTIONS: dict[str, DATASET_OPTIONS_T] = {
         "hash": "sha256:ddc94a7c9ba1922637f2770592dd51c019d341bf6bc8558e663e1979a4cb002f",  # noqa: E501
     },
     "eeg_matchingpennies": {
-        # This dataset started out on osf.io as dataset https://osf.io/cj2dr
-        # then moved to g-node.org. As of 2023/02/28 when we download it via
-        # datalad it's too (~200 kB/sec!) and times out at the end:
-        #
-        #   "git": "https://gin.g-node.org/sappelhoff/eeg_matchingpennies",
-        #   "web": "",
-        #   "include": ["sub-05"],
-        #
-        # So now we mirror this datalad-fetched git repo back on osf.io!
-        # original dataset: "osf": "cj2dr"
         "web": "https://osf.io/download/8rbfk?version=1",
         "hash": "sha256:06bfbe52c50b9343b6b8d2a5de3dd33e66ad9303f7f6bfbe6868c3c7c375fafd",  # noqa: E501
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ tests = [
   "pytest-cov",
   "pooch",
   "psutil",
-  "datalad",
   "ruff",
   "mkdocs",
   "mkdocs-material >= 9.0.4",


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

Lately it seems like a larger number of our CircleCI builds are [failing](https://app.circleci.com/pipelines/github/mne-tools/mne-bids-pipeline/4275/workflows/e2dc0447-b732-4a79-bab9-e54cdcbc4d35/jobs/58831) due to `git-annex-standalone` installation failing. We don't use it anymore (because it didn't work well!) and it doesn't sound super well maintained, so let's get rid of it. Removed some `"osf"` cruft, too. (FWIW `git` history makes it pretty easy to get this stuff back later if we really want it, but I'd assume YAGNI.)