### PR TITLE
ENH: Doc config in sheet

### DIFF
--- a/docs/source/v1.6.md.inc
+++ b/docs/source/v1.6.md.inc
@@ -11,6 +11,7 @@
 - Added [`noise_cov_method`][mne_bids_pipeline._config.noise_cov_method] to allow for the use of methods other than `"shrunk"` for noise covariance estimation (#854 by @larsoner)
 - Added option to pass `image_kwargs` to [`mne.Report.add_epochs`] to allow adjusting e.g. `"vmin"` and `"vmax"` of the epochs image in the report via [`report_add_epochs_image_kwargs`][mne_bids_pipeline._config.report_add_epochs_image_kwargs] (#848 by @SophieHerbst)
 - Split ICA fitting and artifact detection into separate steps. This means that now, ICA is split into a total of three consecutive steps: fitting, artifact detection, and the actual data cleaning step ("applying ICA"). This makes it easier to experiment with different settings for artifact detection without needing to re-fit ICA. (#865 by @larsoner)
+- The configuration used for the pipeline is now saved in a separate spreadsheet in the `.xlsx` log file (#869 by @larsoner)
 
 [//]: # (### :warning: Behavior changes)
 

--- a/docs/source/v1.6.md.inc
+++ b/docs/source/v1.6.md.inc
@@ -9,7 +9,7 @@
 - Added saving of clean raw data in addition to epochs (#840 by @larsoner)
 - Added saving of detected blink and cardiac events used to calculate SSP projectors (#840 by @larsoner)
 - Added [`noise_cov_method`][mne_bids_pipeline._config.noise_cov_method] to allow for the use of methods other than `"shrunk"` for noise covariance estimation (#854 by @larsoner)
-- Added option to pass `image_kwargs` to [`mne.Report.add_epochs`] to allow adjusting e.g. `"vmin"` and `"vmax"` of the epochs image in the report via [`report_add_epochs_image_kwargs`][mne_bids_pipeline._config.report_add_epochs_image_kwargs] (#848 by @SophieHerbst)
+- Added option to pass `image_kwargs` to [`mne.Report.add_epochs`] to allow adjusting e.g. `"vmin"` and `"vmax"` of the epochs image in the report via [`report_add_epochs_image_kwargs`][mne_bids_pipeline._config.report_add_epochs_image_kwargs]. This feature requires MNE-Python 1.7 or newer. (#848 by @SophieHerbst)
 - Split ICA fitting and artifact detection into separate steps. This means that now, ICA is split into a total of three consecutive steps: fitting, artifact detection, and the actual data cleaning step ("applying ICA"). This makes it easier to experiment with different settings for artifact detection without needing to re-fit ICA. (#865 by @larsoner)
 - The configuration used for the pipeline is now saved in a separate spreadsheet in the `.xlsx` log file (#869 by @larsoner)
 

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -59,6 +59,7 @@ def _import_config(
             config_path=extra_config,
         )
         extra_exec_params_keys = ("_n_jobs",)
+    keep_names.extend(extra_exec_params_keys)
 
     # Check it
     if check:
@@ -70,10 +71,8 @@ def _import_config(
             config_validation=config.config_validation,
         )
 
-    # Finally, reduce to our actual supported params
-    config = SimpleNamespace(
-        **{k: getattr(config, k) for k in keep_names if hasattr(config, k)}
-    )
+    # Finally, reduce to our actual supported params (all keep_names should be present)
+    config = SimpleNamespace(**{k: getattr(config, k) for k in keep_names})
 
     # Take some standard actions
     mne.set_log_level(verbose=config.mne_log_level.upper())

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -294,6 +294,14 @@ def save_logs(*, config: SimpleNamespace, logs: list[pd.Series]) -> None:
         assert isinstance(config, SimpleNamespace), type(config)
         cf_df = dict()
         for key, val in config.__dict__.items():
+            # We need to be careful about functions, json_tricks does not work with them
+            if inspect.isfunction(val):
+                new_val = ""
+                if func_file := inspect.getfile(val):
+                    new_val += f"{func_file}:"
+                if getattr(val, "__qualname__", None):
+                    new_val += val.__qualname__
+                val = "custom callable" if not new_val else new_val
             val = json_tricks.dumps(val, indent=4, sort_keys=False)
             # 32767 char limit per cell (could split over lines but if something is
             # this long, you'll probably get the gist from the first 32k chars)


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

Closes #868

Result:

@hoechenberger in principle we *could* split this into multiple rows, but I think it's perhaps nicer this way -- if you want to see a multiline value you click in the cell and you can see it, select, copy-paste etc. If we put in multiple rows it might not be as easy to do that.

![image](https://github.com/mne-tools/mne-bids-pipeline/assets/2365790/feab932b-9ae2-440b-a820-3689b007d87b)

The truncation code is still present, but it really only applies to the `DigMontage` because its `json_tricks` dump is so long (contains all channel locations, coord frame, etc from `DigMontage`.).

Also this contains *all* config values, both those supplied by the user and those that are defaults. I think it's nice because it shows all values that are used. If people want to know which values they supplied, that complementary information is in the `_report.html` files.