### PR TITLE
Remove ancient config parameter `shortest_event`

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -214,7 +214,6 @@ class _ParseConfigSteps:
             "reader_extra_params",
             "read_raw_bids_verbose",
             "plot_psd_for_runs",
-            "shortest_event",
             "find_breaks",
             "min_break_duration",
             "t_break_annot_start_after_previous_event",

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -1,3 +1,5 @@
+{% include-markdown "./v1.8.md.inc" %}
+
 {% include-markdown "./v1.7.md.inc" %}
 
 {% include-markdown "./v1.6.md.inc" %}

--- a/docs/source/v1.8.md.inc
+++ b/docs/source/v1.8.md.inc
@@ -1,0 +1,24 @@
+## v1.8.0 (unreleased)
+
+[//]: # (### :new: New features & enhancements)
+
+[//]: # (- Whatever (#000 by @whoever))
+
+[//]: # (### :warning: Behavior changes)
+
+[//]: # (- Whatever (#000 by @whoever))
+
+[//]: # (### :package: Requirements)
+
+[//]: # (- Whatever (#000 by @whoever))
+
+[//]: # (### :bug: Bug fixes)
+
+[//]: # (- Whatever (#000 by @whoever))
+
+### :medical_symbol: Code health
+
+- We removed the unused setting `shortest_event`. It was a relic of early days of the pipeline
+  and hasn't been in use for a long time. (#888 by @hoechenberger)
+
+[//]: # (- Whatever (#000 by @whoever))

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -439,12 +439,6 @@ ensuring reproducible results. Set to `None` to avoid setting the RNG
 to a defined state.
 """
 
-shortest_event: int = 1
-"""
-Minimum number of samples an event must last. If the
-duration is less than this, an exception will be raised.
-"""
-
 # %%
 # # Preprocessing
 


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
