### PR TITLE
Set up Dependabot to automatically keep GitHub Actions up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependabot"
+    commit-message:
+      prefix: "[dependabot]"

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -1,3 +1,5 @@
+{% include-markdown "./v1.9.md.inc" %}
+
 {% include-markdown "./v1.8.md.inc" %}
 
 {% include-markdown "./v1.7.md.inc" %}

--- a/docs/source/v1.8.md.inc
+++ b/docs/source/v1.8.md.inc
@@ -1,4 +1,4 @@
-## v1.8.0 (unreleased)
+## v1.8.0 (2024-03-20)
 
 ### :new: New features & enhancements
 

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -1,0 +1,21 @@
+## v1.9.0
+
+[//]: # (### :new: New features & enhancements)
+
+[//]: # (- Whatever (#000 by @whoever))
+
+[//]: # (### :warning: Behavior changes)
+
+[//]: # (- Whatever (#000 by @whoever))
+
+[//]: # (### :package: Requirements)
+
+[//]: # (- Whatever (#000 by @whoever))
+
+[//]: # (### :bug: Bug fixes)
+
+[//]: # (- Whatever (#000 by @whoever))
+
+### :medical_symbol: Code health and infrastructure
+
+- Use GitHub's `dependabot` service to automatically keep GitHub Actions up-to-date. (#893 by @hoechenberger)


### PR DESCRIPTION
@larsoner I realized I **again** forgot to include the release data in the changelog. This consistently happens to me … So I now simply removed that part from the 1.9 changelog. Feel free to revert :D

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
