### PR TITLE
ENH: Streamline ICA reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
             pip install --upgrade --progress-bar off pip
             pip install --upgrade --progress-bar off "autoreject @ https://api.github.com/repos/autoreject/autoreject/zipball/master" "mne[hdf5] @ git+https://github.com/mne-tools/mne-python@main" "mne-bids[full] @ https://api.github.com/repos/mne-tools/mne-bids/zipball/main" numba
             pip install -ve .[tests]
-            pip install "PyQt6!=6.6.1,!=6.6.2" "PyQt6-Qt6!=6.6.1,!=6.6.2"
+            pip install "PyQt6!=6.6.1" "PyQt6-Qt6!=6.6.1,!=6.6.2,!=6.6.3"
       - run:
           name: Check Qt
           command: |

--- a/.circleci/remove_examples.sh
+++ b/.circleci/remove_examples.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eo pipefail
+
+VER=$1
+if [ -z "$VER" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+ROOT="$PWD/$VER/examples/"
+if [ ! -d ${ROOT} ]; then
+  echo "Version directory does not exist or appears incorrect:"
+  echo
+  echo "$ROOT"
+  echo
+  echo "Are you on the gh-pages branch and is the ds000117 directory present?"
+  exit 1
+fi
+if [ ! -d ${ROOT}ds000117 ]; then
+  echo "Directory does not exist:"
+  echo
+  echo "${ROOT}ds000117"
+  echo
+  echo "Assuming already pruned and exiting."
+  exit 0
+fi
+echo "Pruning examples in ${ROOT} ..."
+
+find $ROOT -type d -name "*" | tail -n +2 | xargs rm -Rf
+find $ROOT -name "*.html" -exec sed -i /^\<h2\ id=\"generated-output\"\>Generated/,/^\ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ $/{d} {} \;
+find $ROOT -name "*.html" -exec sed -i '/^  <a href="#generated-output"/,/^  <\/a>$/{d}' {} \;
+
+echo "Done"

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -55,6 +55,7 @@ echo 'export MPLBACKEND=Agg' >> "$BASH_ENV"
 echo "source ~/python_env/bin/activate" >> "$BASH_ENV"
 echo "export MNE_3D_OPTION_MULTI_SAMPLES=1" >> "$BASH_ENV"
 echo "export MNE_BIDS_PIPELINE_FORCE_TERMINAL=true" >> "$BASH_ENV"
+echo "export FORCE_COLOR=1" >> "$BASH_ENV"  # for rich to use color in logs
 mkdir -p ~/.local/bin
 if [[ ! -f ~/.local/bin/python ]]; then
     ln -s ~/python_env/bin/python ~/.local/bin/python

--- a/docs/source/examples/gen_examples.py
+++ b/docs/source/examples/gen_examples.py
@@ -110,6 +110,18 @@ for test_name, test_dataset_options in TEST_SUITE.items():
         datasets_without_html.append(dataset_name)
         continue
 
+    # For ERP_CORE, cut down on what we show otherwise our website is huge
+    if "ERP_CORE" in test_name:
+        show = ["015", "average"]
+        orig_fnames = html_report_fnames
+        html_report_fnames = [
+            f
+            for f in html_report_fnames
+            if any(f"sub-{s}" in f.parts and f"sub-{s}" in f.name for s in show)
+        ]
+        assert len(html_report_fnames), orig_fnames
+        del orig_fnames
+
     fname_iter = tqdm(
         html_report_fnames,
         desc=f"  {test_name}",

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -4,9 +4,10 @@
 
 [//]: # (- Whatever (#000 by @whoever))
 
-[//]: # (### :warning: Behavior changes)
+### :warning: Behavior changes
 
-[//]: # (- Whatever (#000 by @whoever))
+- All ICA HTML reports have been consolidated in the standard subject `*_report.html`
+  file instead of producing separate files (#899 by @larsoner).
 
 [//]: # (### :package: Requirements)
 

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -10,8 +10,8 @@
 
 - All ICA HTML reports have been consolidated in the standard subject `*_report.html`
   file instead of producing separate files (#899 by @larsoner).
-- Changed default for `source_info_path_update` to `None`.  In `_04_make_forward.py` 
-  and `_05_make_inverse.py`, we retrieve the info from the file from which 
+- Changed default for `source_info_path_update` to `None`.  In `_04_make_forward.py`
+  and `_05_make_inverse.py`, we retrieve the info from the file from which
   the `noise_cov` is computed (#919 by @SophieHerbst)
 - The [`depth`][mne_bids_pipeline._config.depth] parameter doesn't accept `None`
   anymore. Please use `0` instead. (#915 by @hoechenberger)
@@ -33,6 +33,7 @@
   bad channels from the first pipeline run. Now, we ensure that the original bad channels would be used and the
   related section is removed from the report in this case. (#902 by @larsoner)
 - Fixed group-average decoding statistics were not updated in some cases, even if relevant configuration options had been changed. (#902 by @larsoner)
+- Fixed a compatibility bug with joblib 1.4.0
 
 ### :medical_symbol: Code health and infrastructure
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1126,6 +1126,16 @@ artifacts from the data. For ICA, the independent components related to
 EOG and ECG activity will be omitted during the signal reconstruction step in
 order to remove the artifacts. The ICA procedure can be configured in various
 ways using the configuration options you can find below.
+
+!!! warning "ICA requires manual intervention!"
+    After the automatic ICA component detection step, review each subject's
+    `*_report.html` report file check if the set of ICA components to be removed
+    is correct. Adjustments should be made to the `*_proc-ica_components.tsv`
+    file, which will then be used in the step that is applied during ICA.
+
+    ICA component order can be considered arbitrary, so any time the ICA is
+    re-fit – i.e., if you change any parameters that affect steps prior to
+    ICA fitting – this file will need to be updated!
 """
 
 min_ecg_epochs: Annotated[int, Ge(1)] = 5

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -277,7 +277,12 @@ class ConditionalStepMemory:
 
             # https://joblib.readthedocs.io/en/latest/memory.html#joblib.memory.MemorizedFunc.call  # noqa: E501
             if force_run or unknown_inputs or bad_out_files:
-                out_files, _ = memorized_func.call(*args, **kwargs)
+                # Joblib 1.4.0 only returns the output, but 1.3.2 returns both.
+                # Fortunately we can use tuple-ness to tell the difference (we always
+                # return None or a dict)
+                out_files = memorized_func.call(*args, **kwargs)
+                if isinstance(out_files, tuple):
+                    out_files = out_files[0]
             else:
                 out_files = memorized_func(*args, **kwargs)
             if self.require_output:

--- a/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
@@ -298,6 +298,7 @@ def find_ica_artifacts(
         session=session,
         task=cfg.task,
     ) as report:
+        logger.info(**gen_log_kwargs(message=f'Adding "{title}" to report.'))
         report.add_ica(
             ica=ica,
             title=title,
@@ -311,14 +312,9 @@ def find_ica_artifacts(
             tags=("ica",),  # the default but be explicit
         )
 
-    msg = (
-        f'Carefully review the extracted ICs in the "{title}" section of the '
-        "above report."
-    )
-    logger.info(**gen_log_kwargs(message=msg))
-    msg = "Mark components you wish to reject as 'bad' in:"
-    logger.info(**gen_log_kwargs(message=msg))
-    logger.info(**gen_log_kwargs(message=str(out_files_components)))
+    msg = 'Carefully review the extracted ICs and mark components "bad" in:'
+    logger.info(**gen_log_kwargs(message=msg, emoji="🛑"))
+    logger.info(**gen_log_kwargs(message=str(out_files_components), emoji="🛑"))
 
     assert len(in_files) == 0, in_files.keys()
     return _prep_out_files(exec_params=exec_params, out_files=out_files)

--- a/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
@@ -312,12 +312,13 @@ def find_ica_artifacts(
         )
 
     msg = (
-        f"Carefully review the extracted ICs in the section {repr(title)} of the "
-        "above report"
+        f'Carefully review the extracted ICs in the "{title}" section of the '
+        "above report."
     )
-    logger.warning(**gen_log_kwargs(message=msg))
-    msg = f"Mark components you wish to reject as 'bad' in: {out_files_components}"
-    logger.warning(**gen_log_kwargs(message=msg))
+    logger.info(**gen_log_kwargs(message=msg))
+    msg = "Mark components you wish to reject as 'bad' in:"
+    logger.info(**gen_log_kwargs(message=msg))
+    logger.info(**gen_log_kwargs(message=str(out_files_components)))
 
     assert len(in_files) == 0, in_files.keys()
     return _prep_out_files(exec_params=exec_params, out_files=out_files)

--- a/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
+++ b/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
@@ -1,6 +1,6 @@
 """ERP CORE.
 
-This example demonstrate how to process 5 participants from the
+This example demonstrates how to process 5 participants from the
 [ERP CORE](https://erpinfo.org/erp-core) dataset. It shows how to obtain 7 ERP
 components from a total of 6 experimental tasks:
 

--- a/mne_bids_pipeline/tests/conftest.py
+++ b/mne_bids_pipeline/tests/conftest.py
@@ -66,6 +66,10 @@ def pytest_configure(config):
     ignore:Persisting input arguments took.*:UserWarning
     # matplotlib needs to update
     ignore:Conversion of an array with ndim.*:DeprecationWarning
+    # scipy
+    ignore:nperseg .* is greater.*:UserWarning
+    # NumPy 2.0
+    ignore:__array_wrap__ must accept context.*:DeprecationWarning
     """
     for warning_line in warning_lines.split("\n"):
         warning_line = warning_line.strip()


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

1. Moved all ICA reports to the main report:

   ![image](https://github.com/mne-tools/mne-bids-pipeline/assets/2365790/ab1ab2cb-89ee-41f1-b759-d6585a34e448)

2. Added docs suggesting manual intervention is required (maybe it should be suggested instead?) when using ICA to take care of the doc part of #881
3. Add just one subject's data for `ERP_CORE` (plus the average) to the website to cut size down.
4. Add script to remove examples from old versions so we don't have to remove their docs anymore (they go down to like 6MB or something!).

Closes #880
