### PR TITLE
Render type annotations in the documentation again

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -152,6 +152,8 @@ plugins:
                     show_root_toc_entry: false
                     show_root_full_path: false
                     separate_signature: true
+                    show_signature_annotations: true
+                    signature_crossrefs: true
                     line_length: 88  # Black's default
                     show_bases: false
                     docstring_style: numpy


### PR DESCRIPTION
Not sure if it works…

### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
