### PR TITLE
Improve documentation and config validation of `loose` and `depth` parameters; drop support for `loose=None`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1063,6 +1063,10 @@ jobs:
       - bash_env
       - gitconfig
       - run:
+          name: Install dependencies
+          command: |
+            pip install -ve .[docs]
+      - run:
           # This is a bit computationally inefficient, but it should be much
           # faster to "cp" directly on the machine rather than persist
           # 1GB doc build to workspace then go retrieve it

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -10,7 +10,7 @@
 
 ### :warning: Behavior changes
 
-- The [`loose`][mne_bids_pipeline._config.depth] parameter doesn't accept `"auto""`
+- The [`loose`][mne_bids_pipeline._config.loose] parameter doesn't accept `"auto""`
   anymore. Please use `0.2` instead (the default value). (#915 by @hoechenberger)
 
 - The [`depth`][mne_bids_pipeline._config.depth] parameter doesn't accept `None`

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -8,7 +8,13 @@
 
 [//]: # (- Whatever (#000 by @whoever))
 
-[//]: # (### :warning: Behavior changes)
+### :warning: Behavior changes
+
+- The [`loose`][mne_bids_pipeline._config.depth] parameter doesn't accept `"auto""`
+  anymore. Please use `0.2` instead (the default value). (#915 by @hoechenberger)
+
+- The [`depth`][mne_bids_pipeline._config.depth] parameter doesn't accept `None`
+  anymore. Please use `0` instead. (#915 by @hoechenberger)
 
 [//]: # (- Whatever (#000 by @whoever))
 

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -10,9 +10,6 @@
 
 ### :warning: Behavior changes
 
-- The [`loose`][mne_bids_pipeline._config.loose] parameter doesn't accept `"auto""`
-  anymore. Please use `0.2` instead (the default value). (#915 by @hoechenberger)
-
 - The [`depth`][mne_bids_pipeline._config.depth] parameter doesn't accept `None`
   anymore. Please use `0` instead. (#915 by @hoechenberger)
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1993,6 +1993,10 @@ orientation are considered.
 The default value, `0.2`, is suitable for surface-oriented source spaces.
 
 For volume or mixed source spaces, choose `1.0`.
+
+!!! info
+    Support for modeling volume and mixed source spaces will be added in a future
+    version of MNE-BIDS-Pipeline.
 """
 
 depth: Annotated[float, Interval(ge=0, le=1)] | dict = 0.8
@@ -2000,7 +2004,7 @@ depth: Annotated[float, Interval(ge=0, le=1)] | dict = 0.8
 If a number, it acts as the depth weighting exponent to use
 (must be between `0` and`1`), with`0` meaning no depth weighting is performed.
 
-Can also be a `dict` containing additional keyword arguments to pass to
+Can also be a dictionary containing additional keyword arguments to pass to
 `mne.forward.compute_depth_prior` (see docstring for details and defaults).
 """
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1979,9 +1979,9 @@ Exclude points closer than this distance (mm) to the bounding surface.
 
 # ## Inverse solution
 
-loose: float = 0.2
+loose: Annotated[float, Interval(ge=0, le=1)] = 0.2
 """
-A value that weights the source variances of the dipole components
+A value between 0 and 1 that weights the source variances of the dipole components
 that are parallel (tangential) to the cortical surface.
 
 If `0`, then the inverse solution is computed with **fixed orientation**, i.e.,
@@ -1990,16 +1990,18 @@ only dipole components perpendicular to the cortical surface are considered.
 If `1`, it corresponds to **free orientation**, i.e., dipole components with any
 orientation are considered.
 
-The default value, `0.2`, is suitable for most surface-oriented source spaces.
+The default value, `0.2`, is suitable for surface-oriented source spaces.
+
+For volume or mixed source spaces, choose `1.0`.
 """
 
-depth: float | dict = 0.8
+depth: Annotated[float, Interval(ge=0, le=1)] | dict = 0.8
 """
-If a float (default `0.8`), it acts as the depth weighting exponent (`exp`)
-to use (must be between `0` and `1`). `None` is equivalent to `0`, meaning no
-depth weighting is performed. Can also be a `dict` containing additional
-keyword arguments to pass to `mne.forward.compute_depth_prior`
-(see docstring for details and defaults).
+If a number, it acts as the depth weighting exponent to use
+(must be between `0` and`1`), with`0` meaning no depth weighting is performed.
+
+Can also be a `dict` containing additional keyword arguments to pass to
+`mne.forward.compute_depth_prior` (see docstring for details and defaults).
 """
 
 inverse_method: Literal["MNE", "dSPM", "sLORETA", "eLORETA"] = "dSPM"

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1987,8 +1987,8 @@ that are parallel (tangential) to the cortical surface.
 If `0`, then the inverse solution is computed with **fixed orientation**, i.e.,
 only dipole components perpendicular to the cortical surface are considered.
 
-If `1`, it corresponds to **free orientation**, i.e., dipole components with any orientation are
-considered.
+If `1`, it corresponds to **free orientation**, i.e., dipole components with any
+orientation are considered.
 
 The default value, `0.2`, is suitable for most surface-oriented source spaces.
 """

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1979,23 +1979,26 @@ Exclude points closer than this distance (mm) to the bounding surface.
 
 # ## Inverse solution
 
-loose: float | Literal["auto"] = 0.2
+loose: float = 0.2
 """
-Value that weights the source variances of the dipole components
-that are parallel (tangential) to the cortical surface. If `0`, then the
-inverse solution is computed with **fixed orientation.**
-If `1`, it corresponds to **free orientation.**
-The default value, `'auto'`, is set to `0.2` for surface-oriented source
-spaces, and to `1.0` for volumetric, discrete, or mixed source spaces,
-unless `fixed is True` in which case the value 0. is used.
+A value that weights the source variances of the dipole components
+that are parallel (tangential) to the cortical surface.
+
+If `0`, then the inverse solution is computed with **fixed orientation**, i.e.,
+only dipoles perpendicular to the cortical surface are considered.
+
+If `1`, it corresponds to **free orientation**, i.e., dipoles with any orientation are
+considered.
+
+The default value, `0.2`, is suitable for most surface-oriented source spaces.
 """
 
-depth: float | dict | None = 0.8
+depth: float | dict = 0.8
 """
-If float (default 0.8), it acts as the depth weighting exponent (`exp`)
-to use (must be between 0 and 1). None is equivalent to 0, meaning no
+If a float (default `0.8`), it acts as the depth weighting exponent (`exp`)
+to use (must be between `0` and `1`). `None` is equivalent to `0`, meaning no
 depth weighting is performed. Can also be a `dict` containing additional
-keyword arguments to pass to :func:`mne.forward.compute_depth_prior`
+keyword arguments to pass to `mne.forward.compute_depth_prior`
 (see docstring for details and defaults).
 """
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1985,9 +1985,9 @@ A value that weights the source variances of the dipole components
 that are parallel (tangential) to the cortical surface.
 
 If `0`, then the inverse solution is computed with **fixed orientation**, i.e.,
-only dipoles perpendicular to the cortical surface are considered.
+only dipole components perpendicular to the cortical surface are considered.
 
-If `1`, it corresponds to **free orientation**, i.e., dipoles with any orientation are
+If `1`, it corresponds to **free orientation**, i.e., dipole components with any orientation are
 considered.
 
 The default value, `0.2`, is suitable for most surface-oriented source spaces.

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1979,7 +1979,7 @@ Exclude points closer than this distance (mm) to the bounding surface.
 
 # ## Inverse solution
 
-loose: Annotated[float, Interval(ge=0, le=1)] = 0.2
+loose: Annotated[float, Interval(ge=0, le=1)] | Literal["auto"] = 0.2
 """
 A value between 0 and 1 that weights the source variances of the dipole components
 that are parallel (tangential) to the cortical surface.


### PR DESCRIPTION
@larsoner @SophieHerbst WDYT?

We currently don't support volumetric or mixed source spaces anyway, so I thought we could simplify things a little.

I was even considering entirely removing the `loose` and `depth` settings but then wasn't sure if some of you might be using them sometimes? Personally I never touch those.

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
