### PR TITLE
enhance documentation of caching, continuation of #914

### DIFF
--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -20,7 +20,7 @@
 
 - We removed the `Execution` section from configuration options documentation and
   replaced it with new, more explicit sections (namely, Caching, Parallelization,
-  Logging, and Error handling). (#914 by @hoechenberger)
+  Logging, and Error handling), and enhanced documentation. (#914 by @hoechenberger, #916 by @SophieHerbst)
 
 ### :bug: Bug fixes
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -2174,8 +2174,11 @@ If `None`, it defaults to the current default in MNE-Python.
 # %%
 # # Caching
 #
-# These settings control if and how pipeline output is being cached to avoid unnecessary
-# computations on a re-run.
+# Per default, the pipeline output is cached (temporarily stored),
+# to avoid unnecessary reruns of previously computed steps.
+# Yet, for consistency, changes in configuration parameters trigger
+# automatic reruns of previous steps.
+# To force rerunning a given step, run the pipeline with the option: --no-cache
 
 memory_location: PathLike | bool | None = True
 """

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -2178,7 +2178,8 @@ If `None`, it defaults to the current default in MNE-Python.
 # to avoid unnecessary reruns of previously computed steps.
 # Yet, for consistency, changes in configuration parameters trigger
 # automatic reruns of previous steps.
-# To force rerunning a given step, run the pipeline with the option: --no-cache
+# !!! info
+#     To force rerunning a given step, run the pipeline with the option: `--no-cache`.
 
 memory_location: PathLike | bool | None = True
 """


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
