### PR TITLE
change default for info to use for inverse #905

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ files: ^(.*\.(py|yaml))$
 exclude: ^(\.[^/]*cache/.*|.*/freesurfer/contrib/.*)$
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.3.5
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -7,6 +7,8 @@
   replaced `Union[X, Y]` with `X | Y` and `Optional[X]` with `X | None`. (#908, #911 by @hoechenberger)
 
 [//]: # (### :warning: Behavior changes)
+- Changed default for `source_info_path_update` to `None`.  In `_05_make_inverse.py`, 
+  we retrieve the info from the file from which the `noise_cov` is computed (#919 by @SophieHerbst)
 
 [//]: # (- Whatever (#000 by @whoever))
 

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -6,7 +6,7 @@
 - The type annotations in the default configuration file are now easier to read: We
   replaced `Union[X, Y]` with `X | Y` and `Optional[X]` with `X | None`. (#908, #911 by @hoechenberger)
 
-[//]: # (### :warning: Behavior changes)
+### :warning: Behavior changes
 - Changed default for `source_info_path_update` to `None`.  In `_04_make_forward.py` 
   and `_05_make_inverse.py`, we retrieve the info from the file from which 
   the `noise_cov` is computed (#919 by @SophieHerbst)

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -7,6 +7,7 @@
   replaced `Union[X, Y]` with `X | Y` and `Optional[X]` with `X | None`. (#908, #911 by @hoechenberger)
 
 ### :warning: Behavior changes
+
 - Changed default for `source_info_path_update` to `None`.  In `_04_make_forward.py` 
   and `_05_make_inverse.py`, we retrieve the info from the file from which 
   the `noise_cov` is computed (#919 by @SophieHerbst)

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -7,8 +7,9 @@
   replaced `Union[X, Y]` with `X | Y` and `Optional[X]` with `X | None`. (#908, #911 by @hoechenberger)
 
 [//]: # (### :warning: Behavior changes)
-- Changed default for `source_info_path_update` to `None`.  In `_05_make_inverse.py`, 
-  we retrieve the info from the file from which the `noise_cov` is computed (#919 by @SophieHerbst)
+- Changed default for `source_info_path_update` to `None`.  In `_04_make_forward.py` 
+  and `_05_make_inverse.py`, we retrieve the info from the file from which 
+  the `noise_cov` is computed (#919 by @SophieHerbst)
 
 [//]: # (- Whatever (#000 by @whoever))
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -2114,6 +2114,9 @@ file specified in `noise_cov`, or the cleaned epochs
                                 'suffix': 'raw',
                                 'task': 'rest'}
     ```
+    If you set `noise_cov = 'rest'` and `source_path_info = None`, then the behavior is identical
+    to that above (it will automatically use the resting state data).
+
 """
 
 inverse_targets: list[Literal["evoked"]] = ["evoked"]

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -2098,7 +2098,7 @@ This parameter allows you to explicitly specify from which file to retrieve the
 `mne.Info` object. Use this parameter to supply a dictionary to
 `BIDSPath.update()` during the forward and inverse processing steps.
 If set to `None` (default), the info will be retrieved either from the raw
-file specified in `noise_cov`, or the cleaned epochs
+file specified in `noise_cov`, or the cleaned evoked
 (if `noise_cov` is None or `ad-hoc`).
 
 ???+ example "Example"

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -2114,8 +2114,9 @@ file specified in `noise_cov`, or the cleaned evoked
                                 'suffix': 'raw',
                                 'task': 'rest'}
     ```
-    If you set `noise_cov = 'rest'` and `source_path_info = None`, then the behavior is identical
-    to that above (it will automatically use the resting state data).
+    If you set `noise_cov = 'rest'` and `source_path_info = None`,
+    then the behavior is identical to that above
+    (it will automatically use the resting state data).
 
 """
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -2091,14 +2091,14 @@ of `mne.compute_covariance` for details.
 
 source_info_path_update: dict[str, str] | None = None
 """
-When computing the forward and inverse solutions, it is important to 
+When computing the forward and inverse solutions, it is important to
 provide the `mne.Info` object from the data on which the noise covariance was
-computed, to avoid problems resulting from mismatching ranks. 
+computed, to avoid problems resulting from mismatching ranks.
 This parameter allows you to explicitly specify from which file to retrieve the
 `mne.Info` object. Use this parameter to supply a dictionary to
 `BIDSPath.update()` during the forward and inverse processing steps.
-If set to `None` (default), the info will be retrieved either from the raw 
-file specified in `noise_cov`, or the cleaned epochs 
+If set to `None` (default), the info will be retrieved either from the raw
+file specified in `noise_cov`, or the cleaned epochs
 (if `noise_cov` is None or `ad-hoc`).
 
 ???+ example "Example"

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -2089,21 +2089,30 @@ The noise covariance estimation method to use. See the MNE-Python documentation
 of `mne.compute_covariance` for details.
 """
 
-source_info_path_update: dict[str, str] | None = dict(suffix="ave")
+source_info_path_update: dict[str, str] | None = None
 """
-When computing the forward and inverse solutions, by default the pipeline
-retrieves the `mne.Info` object from the cleaned evoked data. However, in
-certain situations you may wish to use a different `Info`.
-
+When computing the forward and inverse solutions, it is important to 
+provide the `mne.Info` object from the data on which the noise covariance was
+computed, to avoid problems resulting from mismatching ranks. 
 This parameter allows you to explicitly specify from which file to retrieve the
 `mne.Info` object. Use this parameter to supply a dictionary to
 `BIDSPath.update()` during the forward and inverse processing steps.
+If set to `None` (default), the info will be retrieved either from the raw 
+file specified in `noise_cov`, or the cleaned epochs 
+(if `noise_cov` is None or `ad-hoc`).
 
 ???+ example "Example"
     Use the `Info` object stored in the cleaned epochs:
     ```python
     source_info_path_update = {'processing': 'clean',
                                'suffix': 'epo'}
+    ```
+
+    Use the `Info` object stored in a raw file (e.g. resting state):
+    ```python
+    source_info_path_update = {'processing': 'clean',
+                                'suffix': 'raw',
+                                'task': 'rest'}
     ```
 """
 

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -344,7 +344,6 @@ def _default_factory(key, val):
     allowlist = [
         {"n_mag": 1, "n_grad": 1, "n_eeg": 1},  # n_proj_*
         {"custom": (8, 24.0, 40)},  # decoding_csp_freqs
-        {"suffix": "ave"},  # source_info_path_update
         ["evoked"],  # inverse_targets
         [4, 8, 16],  # autoreject_n_interpolate
     ]

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -111,7 +111,6 @@ def get_input_fnames_forward(*, cfg, subject, session):
             )
         else:
             source_info_path_update = dict(suffix="ave")
-            # XXX is this the right solution also for noise_cov = 'ad-hoc'?
     else:
         source_info_path_update = cfg.source_info_path_update
     in_files["info"] = bids_path.copy().update(**source_info_path_update)

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -102,7 +102,22 @@ def get_input_fnames_forward(*, cfg, subject, session):
         check=False,
     )
     in_files = dict()
-    in_files["info"] = bids_path.copy().update(**cfg.source_info_path_update)
+    # for consistency with 05_make_inverse, read the info from the
+    # data used for the noise_cov
+    if cfg.source_info_path_update is None:
+        if cfg.noise_cov == "rest" | cfg.noise_cov == "noise":
+            source_info_path_update = dict(
+                'processing': 'clean',
+                'suffix': 'raw',
+                'task': cfg.noise_cov
+                )
+        else:
+            source_info_path_update = dict(suffix="ave")
+            # XXX is this the right solution also for noise_cov = 'ad-hoc'?
+    else:
+        source_info_path_update = cfg.source_info_path_update
+
+    in_files["info"] = bids_path.copy().update(source_info_path_update)
     bem_path = cfg.fs_subjects_dir / cfg.fs_subject / "bem"
     _, tag = _get_bem_conductivity(cfg)
     in_files["bem"] = bem_path / f"{cfg.fs_subject}-{tag}-bem-sol.fif"

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -107,9 +107,9 @@ def get_input_fnames_forward(*, cfg, subject, session):
     if cfg.source_info_path_update is None:
         if cfg.noise_cov == "rest" | cfg.noise_cov == "noise":
             source_info_path_update = dict(
-                'processing'='clean',
-                'suffix'='raw',
-                'task'=cfg.noise_cov
+                processing='clean',
+                suffix='raw',
+                task=cfg.noise_cov
                 )
         else:
             source_info_path_update = dict(suffix="ave")

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -105,7 +105,7 @@ def get_input_fnames_forward(*, cfg, subject, session):
     # for consistency with 05_make_inverse, read the info from the
     # data used for the noise_cov
     if cfg.source_info_path_update is None:
-        if cfg.noise_cov == "rest" | cfg.noise_cov == "noise":
+        if cfg.noise_cov in ("rest", "noise"):
             source_info_path_update = dict(
                 processing='clean',
                 suffix='raw',

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -116,8 +116,6 @@ def get_input_fnames_forward(*, cfg, subject, session):
             # XXX is this the right solution also for noise_cov = 'ad-hoc'?
     else:
         source_info_path_update = cfg.source_info_path_update
-
-    print(source_info_path_update)
     in_files["info"] = bids_path.copy().update(**source_info_path_update)
     bem_path = cfg.fs_subjects_dir / cfg.fs_subject / "bem"
     _, tag = _get_bem_conductivity(cfg)

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -117,7 +117,8 @@ def get_input_fnames_forward(*, cfg, subject, session):
     else:
         source_info_path_update = cfg.source_info_path_update
 
-    in_files["info"] = bids_path.copy().update(source_info_path_update)
+    print(source_info_path_update)
+    in_files["info"] = bids_path.copy().update(**source_info_path_update)
     bem_path = cfg.fs_subjects_dir / cfg.fs_subject / "bem"
     _, tag = _get_bem_conductivity(cfg)
     in_files["bem"] = bem_path / f"{cfg.fs_subject}-{tag}-bem-sol.fif"

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -23,7 +23,7 @@ from ..._config_utils import (
 from ..._logging import gen_log_kwargs, logger
 from ..._parallel import get_parallel_backend, parallel_func
 from ..._report import _open_report, _render_bem
-from ..._run import _prep_out_files, failsafe_run, save_logs
+from ..._run import _prep_out_files, _sanitize_callable, failsafe_run, save_logs
 
 
 def _prepare_trans_template(
@@ -257,6 +257,7 @@ def get_config(
         use_template_mri=config.use_template_mri,
         adjust_coreg=config.adjust_coreg,
         source_info_path_update=config.source_info_path_update,
+        noise_cov=_sanitize_callable(config.noise_cov),
         ch_types=config.ch_types,
         fs_subject=get_fs_subject(config=config, subject=subject),
         fs_subjects_dir=get_fs_subjects_dir(config),

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -107,9 +107,9 @@ def get_input_fnames_forward(*, cfg, subject, session):
     if cfg.source_info_path_update is None:
         if cfg.noise_cov == "rest" | cfg.noise_cov == "noise":
             source_info_path_update = dict(
-                'processing': 'clean',
-                'suffix': 'raw',
-                'task': cfg.noise_cov
+                'processing'='clean',
+                'suffix'='raw',
+                'task'=cfg.noise_cov
                 )
         else:
             source_info_path_update = dict(suffix="ave")

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -53,9 +53,9 @@ def get_input_fnames_inverse(
     if cfg.source_info_path_update is None:
         if cfg.noise_cov == "rest" | cfg.noise_cov == "noise":
             source_info_path_update = dict(
-                'processing': 'clean',
-                'suffix': 'raw',
-                'task': cfg.noise_cov
+                processing='clean',
+                suffix='raw',
+                task=cfg.noise_cov
                 )
         else:
             source_info_path_update = dict(suffix="ave")

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -66,7 +66,6 @@ def get_input_fnames_inverse(
         in_files["cov"] = get_noise_cov_bids_path(
             cfg=cfg, subject=subject, session=session
         )
-        dict(suffix="ave")
     if "evoked" in cfg.inverse_targets:
         in_files["evoked"] = bids_path.copy().update(suffix="ave")
     return in_files

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -50,11 +50,13 @@ def get_input_fnames_inverse(
     in_files = dict()
     # make sure the info matches the data from which the noise cov
     # is computed to avoid rank-mismatch
-    if cfg.source_info_path_update == None:
+    if cfg.source_info_path_update is None:
         if cfg.noise_cov == "rest" | cfg.noise_cov == "noise":
-            source_info_path_update = {'processing': 'clean',
-                            'suffix': 'raw',
-                            'task': cfg.noise_cov}
+            source_info_path_update = dict(
+                'processing': 'clean',
+                'suffix': 'raw',
+                'task': cfg.noise_cov
+                )
         else:
             source_info_path_update = dict(suffix="ave")
             # XXX is this the right solution also for noise_cov = 'ad-hoc'?

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -51,7 +51,7 @@ def get_input_fnames_inverse(
     # make sure the info matches the data from which the noise cov
     # is computed to avoid rank-mismatch
     if cfg.source_info_path_update is None:
-        if cfg.noise_cov == "rest" | cfg.noise_cov == "noise":
+        if cfg.noise_cov in ("rest", "noise"):
             source_info_path_update = dict(
                 processing='clean',
                 suffix='raw',
@@ -63,7 +63,7 @@ def get_input_fnames_inverse(
     else:
         source_info_path_update = cfg.source_info_path_update
 
-    in_files["info"] = bids_path.copy().update(source_info_path_update)
+    in_files["info"] = bids_path.copy().update(**source_info_path_update)
     in_files["forward"] = bids_path.copy().update(suffix="fwd")
     if cfg.noise_cov != "ad-hoc":
         in_files["cov"] = get_noise_cov_bids_path(

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -57,7 +57,7 @@ def get_input_fnames_inverse(
                             'task': cfg.noise_cov}
         else:
             source_info_path_update = dict(suffix="ave")
-            # XXX is this the good solution also for noise_cov = 'ad-hoc'?
+            # XXX is this the right solution also for noise_cov = 'ad-hoc'?
     else:
         source_info_path_update = cfg.source_info_path_update
 
@@ -68,10 +68,6 @@ def get_input_fnames_inverse(
             cfg=cfg, subject=subject, session=session
         )
         dict(suffix="ave")
-noise_cov = 'rest'
-source_info_path_update = {'processing': 'clean',
-                            'suffix': 'raw',
-                            'task': noise_cov}
     if "evoked" in cfg.inverse_targets:
         in_files["evoked"] = bids_path.copy().update(suffix="ave")
     return in_files

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -61,8 +61,7 @@ def get_input_fnames_inverse(
             source_info_path_update = dict(suffix="ave")
             # XXX is this the right solution also for noise_cov = 'ad-hoc'?
     else:
-        source_info_path_update = cfg.source_info_path_update
-
+        source_info_path_update = cfg.source_info_path_update    
     in_files["info"] = bids_path.copy().update(**source_info_path_update)
     in_files["forward"] = bids_path.copy().update(suffix="fwd")
     if cfg.noise_cov != "ad-hoc":

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -48,12 +48,30 @@ def get_input_fnames_inverse(
         check=False,
     )
     in_files = dict()
-    in_files["info"] = bids_path.copy().update(**cfg.source_info_path_update)
+    # make sure the info matches the data from which the noise cov
+    # is computed to avoid rank-mismatch
+    if cfg.source_info_path_update == None:
+        if cfg.noise_cov == "rest" | cfg.noise_cov == "noise":
+            source_info_path_update = {'processing': 'clean',
+                            'suffix': 'raw',
+                            'task': cfg.noise_cov}
+        else:
+            source_info_path_update = dict(suffix="ave")
+            # XXX is this the good solution also for noise_cov = 'ad-hoc'?
+    else:
+        source_info_path_update = cfg.source_info_path_update
+
+    in_files["info"] = bids_path.copy().update(source_info_path_update)
     in_files["forward"] = bids_path.copy().update(suffix="fwd")
     if cfg.noise_cov != "ad-hoc":
         in_files["cov"] = get_noise_cov_bids_path(
             cfg=cfg, subject=subject, session=session
         )
+        dict(suffix="ave")
+noise_cov = 'rest'
+source_info_path_update = {'processing': 'clean',
+                            'suffix': 'raw',
+                            'task': noise_cov}
     if "evoked" in cfg.inverse_targets:
         in_files["evoked"] = bids_path.copy().update(suffix="ave")
     return in_files


### PR DESCRIPTION
Change default for info given to 05_make_inverse.py (and for consistency 04_make_forward.py):
If set to `None` (default), the info will be retrieved either from the raw
file specified in `noise_cov`, or the cleaned epochs (if `noise_cov` is None or `ad-hoc`).

Closes #905
