### PR TITLE
Raise a more helpful error message when requested subjects are missing from the dataset

### DIFF
--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -8,7 +8,7 @@
 - Epochs metadata creation now supports variable time windows by specifying the names of events via
   [`epochs_metadata_tmin`][mne_bids_pipeline._config.epochs_metadata_tmin] and
   [`epochs_metadata_tmax`][mne_bids_pipeline._config.epochs_metadata_tmax]. (#873 by @hoechenberger)
-- If you requested processing of non-existing subjects, we will now provide a more helpful error message. (#927 by @hoechenberger)
+- If you requested processing of non-existing subjects, we will now provide a more helpful error message. (#928 by @hoechenberger)
 
 ### :warning: Behavior changes
 

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -8,6 +8,7 @@
 - Epochs metadata creation now supports variable time windows by specifying the names of events via
   [`epochs_metadata_tmin`][mne_bids_pipeline._config.epochs_metadata_tmin] and
   [`epochs_metadata_tmax`][mne_bids_pipeline._config.epochs_metadata_tmax]. (#873 by @hoechenberger)
+- If you requested processing of non-existing subjects, we will now provide a more helpful error message. (#927 by @hoechenberger)
 
 ### :warning: Behavior changes
 

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -95,6 +95,12 @@ def get_subjects(config: SimpleNamespace) -> list[str]:
         s = _valid_subjects
     else:
         s = config.subjects
+        missing_subjects = set(s) - set(_valid_subjects)
+        if missing_subjects:
+            raise FileNotFoundError(
+                "The following requested subject(s) were not found in the dataset: "
+                f"{', '.join(missing_subjects)}"
+            )
 
     # Preserve order and remove excluded subjects
     subjects = [

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -98,7 +98,7 @@ def get_subjects(config: SimpleNamespace) -> list[str]:
         missing_subjects = set(s) - set(_valid_subjects)
         if missing_subjects:
             raise FileNotFoundError(
-                "The following requested subject(s) were not found in the dataset: "
+                "The following requested subjects were not found in the dataset: "
                 f"{', '.join(missing_subjects)}"
             )
 


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

This PR:
```python
FileNotFoundError: The following requested subjects were not found in the dataset: 774
```

`main`:
```python
FileNotFoundError: Root directory does not exist: "/Users/richardhochenberger/Library/CloudStorage/OneDrive-dsm-firmenich/Documents/TasIn/data/raw_bids/sub-774"
```