### PR TITLE
In the report TOC, don't put the run numbers in quotation marks

### DIFF
--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -39,6 +39,7 @@
   related section is removed from the report in this case. (#902 by @larsoner)
 - Fixed group-average decoding statistics were not updated in some cases, even if relevant configuration options had been changed. (#902 by @larsoner)
 - Fixed a compatibility bug with joblib 1.4.0
+- In the report's table of contents, don't put the run numbers in quotation marks. (#933 by @hoechenberger)
 
 ### :medical_symbol: Code health and infrastructure
 

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -854,7 +854,7 @@ def _add_raw(
     extra_html: str | None = None,
 ):
     if bids_path_in.run is not None:
-        title += f", run {repr(bids_path_in.run)}"
+        title += f", run {bids_path_in.run}"
     elif bids_path_in.task in ("noise", "rest"):
         title += f", {bids_path_in.task}"
     plot_raw_psd = (


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)

`main`:
<img width="528" alt="Screenshot 2024-04-23 at 17 30 29" src="https://github.com/mne-tools/mne-bids-pipeline/assets/2046265/3788539d-e676-46ee-aeae-414eb2a8ea5c">


this PR:
<img width="210" alt="Screenshot 2024-04-23 at 17 31 29" src="https://github.com/mne-tools/mne-bids-pipeline/assets/2046265/62abd99e-9d85-47ed-a204-d4e64b230b95">
