### PR TITLE
Rename `ica_ctps_ecg_threshold` to `ica_ecg_threshold`

### DIFF
--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -22,6 +22,7 @@
 - When using automated bad channel detection, now indicate the generated `*_bads.tsv` files whether a channel
   had previously already been marked as bad in the dataset. Resulting entries in the TSV file may now look like:
   `"pre-existing (before MNE-BIDS-pipeline was run) & auto-noisy"` (previously: only `"auto-noisy"`). (#930 by @hoechenberger)
+- The `ica_ctps_ecg_threshold` has been renamed to [`ica_ecg_threshold`][`mne_bids_pipeline._config.ica_ecg_threshold]. (#935 by @hoechenberger)
 
 ### :package: Requirements
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1362,9 +1362,10 @@ it is to run but the less data you have to compute a good ICA. Set to
 `1` or `None` to not perform any decimation.
 """
 
-ica_ctps_ecg_threshold: float = 0.1
+ica_ecg_threshold: float = 0.1
 """
-The threshold parameter passed to `find_bads_ecg` method.
+The cross-trial phase statistics (CTPS) threshold parameter used for detecting
+ECG-related ICs.
 """
 
 ica_eog_threshold: float = 3.0

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -415,6 +415,9 @@ _REMOVED_NAMES = {
     "N_JOBS": dict(
         new_name="n_jobs",
     ),
+    "ica_ctps_ecg_threshold": dict(
+        new_name="ica_ecg_threshold",
+    ),
 }
 
 

--- a/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
@@ -60,14 +60,12 @@ def detect_bad_components(
         inds, scores = ica.find_bads_ecg(
             epochs,
             method="ctps",
-            threshold=cfg.ica_ctps_ecg_threshold,
+            threshold=cfg.ica_ecg_threshold,
             ch_name=ch_names,
         )
 
     if not inds:
-        adjust_setting = (
-            "ica_eog_threshold" if which == "eog" else "ica_ctps_ecg_threshold"
-        )
+        adjust_setting = "ica_eog_threshold" if which == "eog" else "ica_ecg_threshold"
         warn = (
             f"No {artifact}-related ICs detected, this is highly "
             f"suspicious. A manual check is suggested. You may wish to "
@@ -333,7 +331,7 @@ def get_config(
         ica_l_freq=config.ica_l_freq,
         ica_reject=config.ica_reject,
         ica_eog_threshold=config.ica_eog_threshold,
-        ica_ctps_ecg_threshold=config.ica_ctps_ecg_threshold,
+        ica_ecg_threshold=config.ica_ecg_threshold,
         autoreject_n_interpolate=config.autoreject_n_interpolate,
         random_state=config.random_state,
         ch_types=config.ch_types,

--- a/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
@@ -65,7 +65,7 @@ def detect_bad_components(
         )
 
     if not inds:
-        adjust_setting = "ica_eog_threshold" if which == "eog" else "ica_ecg_threshold"
+        adjust_setting = f"ica_{which}_threshold"
         warn = (
             f"No {artifact}-related ICs detected, this is highly "
             f"suspicious. A manual check is suggested. You may wish to "


### PR DESCRIPTION
- Consistency with `ica_eog_threshold`
- Allows us to later add support for additional ECG-detection methods

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
