### PR TITLE
Improve logging output when rejecting epochs; and log number of reconstructed ICA and SSP epochs

### DIFF
--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -9,6 +9,7 @@
   [`epochs_metadata_tmin`][mne_bids_pipeline._config.epochs_metadata_tmin] and
   [`epochs_metadata_tmax`][mne_bids_pipeline._config.epochs_metadata_tmax]. (#873 by @hoechenberger)
 - If you requested processing of non-existing subjects, we will now provide a more helpful error message. (#928 by @hoechenberger)
+- We improved the logging output for automnated epochs rejection and cleaning via ICA and SSP. (#936 by @hoechenberger)
 
 ### :warning: Behavior changes
 

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -204,8 +204,8 @@ def run_ica(
         n_epochs_rejected = n_epochs_before_reject - n_epochs_after_reject
 
         msg = (
-            f"Removed {n_epochs_rejected} epochs via PTP rejection thresholds: "
-            f"{ica_reject}"
+            f"Removed {n_epochs_rejected} of {n_epochs_before_reject} epochs via PTP "
+            f"rejection thresholds: {ica_reject}"
         )
         logger.info(**gen_log_kwargs(message=msg))
         ar = None

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -177,9 +177,14 @@ def run_ica(
         ar.fit(epochs)
         ar_reject_log = ar.get_reject_log(epochs)
         epochs = epochs[~ar_reject_log.bad_epochs]
+
+        n_epochs_before_reject = len(epochs)
+        n_epochs_rejected = ar_reject_log.bad_epochs.sum()
+        n_epochs_after_reject = n_epochs_before_reject - n_epochs_rejected
+
         ar_n_interpolate_ = ar.n_interpolate_
         msg = (
-            f"autoreject marked {ar_reject_log.bad_epochs.sum()} epochs as bad "
+            f"autoreject marked {n_epochs_rejected} epochs as bad "
             f"(cross-validated n_interpolate limit: {ar_n_interpolate_})"
         )
         logger.info(**gen_log_kwargs(message=msg))
@@ -193,10 +198,32 @@ def run_ica(
             ch_types=cfg.ch_types,
             param="ica_reject",
         )
-        msg = f"Using PTP rejection thresholds: {ica_reject}"
-        logger.info(**gen_log_kwargs(message=msg))
+        n_epochs_before_reject = len(epochs)
         epochs.drop_bad(reject=ica_reject)
+        n_epochs_after_reject = len(epochs)
+        n_epochs_rejected = n_epochs_before_reject - n_epochs_after_reject
+
+        msg = (
+            f"Removed {n_epochs_rejected} epochs via PTP rejection thresholds: "
+            f"{ica_reject}"
+        )
+        logger.info(**gen_log_kwargs(message=msg))
         ar = None
+
+    if 0 < n_epochs_after_reject < 0.5 * n_epochs_before_reject:
+        msg = (
+            "More than 50% of all epochs rejected. Please check the "
+            "rejection thresholds."
+        )
+        logger.warning(**gen_log_kwargs(message=msg))
+    elif n_epochs_after_reject == 0:
+        rejection_type = (
+            cfg.ica_reject if cfg.ica_reject == "autoreject_local" else "PTP-based"
+        )
+        raise RuntimeError(
+            f"No epochs remaining after {rejection_type} rejection. Cannot continue."
+        )
+
     msg = "Saving ICA epochs to disk."
     logger.info(**gen_log_kwargs(message=msg))
     epochs.save(

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -224,7 +224,7 @@ def run_ica(
             f"No epochs remaining after {rejection_type} rejection. Cannot continue."
         )
 
-    msg = "Saving ICA epochs to disk."
+    msg = f"Saving {n_epochs_after_reject} ICA epochs to disk."
     logger.info(**gen_log_kwargs(message=msg))
     epochs.save(
         out_files["epochs"],

--- a/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
@@ -142,7 +142,7 @@ def apply_ica_epochs(
     logger.info(**gen_log_kwargs(message=msg))
     epochs_cleaned = ica.apply(epochs.copy())  # Copy b/c works in-place!
 
-    msg = "Saving reconstructed epochs after ICA."
+    msg = f"Saving {len(epochs)} reconstructed epochs after ICA."
     logger.info(**gen_log_kwargs(message=msg))
     epochs_cleaned.save(
         out_files["epochs"],

--- a/mne_bids_pipeline/steps/preprocessing/_08b_apply_ssp.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08b_apply_ssp.py
@@ -58,6 +58,10 @@ def apply_ssp_epochs(
     epochs = mne.read_epochs(in_files.pop("epochs"), preload=True)
     projs = mne.read_proj(in_files.pop("proj"))
     epochs_cleaned = epochs.copy().add_proj(projs).apply_proj()
+
+    msg = f"Saving {len(epochs_cleaned)} reconstructed epochs after SSP."
+    logger.info(**gen_log_kwargs(message=msg))
+
     epochs_cleaned.save(
         out_files["epochs"],
         overwrite=True,

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -171,7 +171,7 @@ def drop_ptp(
             f"No epochs remaining after {rejection_type} rejection. Cannot continue."
         )
 
-    msg = "Saving cleaned, baseline-corrected epochs …"
+    msg = f"Saving {n_epochs_after_reject} cleaned, baseline-corrected epochs …"
 
     epochs.apply_baseline(cfg.baseline)
     epochs.save(

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -151,7 +151,7 @@ def drop_ptp(
 
         msg = (
             f"Removed {n_epochs_rejected} of {n_epochs_before_reject} epochs via PTP "
-            f"rejection thresholds: {ica_reject}"
+            f"rejection thresholds: {reject}"
         )
         logger.info(**gen_log_kwargs(message=msg))
 

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -150,8 +150,8 @@ def drop_ptp(
         n_epochs_rejected = n_epochs_before_reject - n_epochs_after_reject
 
         msg = (
-            f"Removed {n_epochs_rejected} epochs via PTP rejection thresholds: "
-            f"{ica_reject}"
+            f"Removed {n_epochs_rejected} of {n_epochs_before_reject} epochs via PTP "
+            f"rejection thresholds: {ica_reject}"
         )
         logger.info(**gen_log_kwargs(message=msg))
 

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -142,14 +142,18 @@ def drop_ptp(
                     logger.info(**gen_log_kwargs(message=msg))
                     reject[ch_type] = threshold
 
-        msg = f"Using PTP rejection thresholds: {reject}"
-        logger.info(**gen_log_kwargs(message=msg))
-
         n_epochs_before_reject = len(epochs)
         epochs.reject_tmin = cfg.reject_tmin
         epochs.reject_tmax = cfg.reject_tmax
         epochs.drop_bad(reject=reject)
         n_epochs_after_reject = len(epochs)
+        n_epochs_rejected = n_epochs_before_reject - n_epochs_after_reject
+
+        msg = (
+            f"Removed {n_epochs_rejected} epochs via PTP rejection thresholds: "
+            f"{ica_reject}"
+        )
+        logger.info(**gen_log_kwargs(message=msg))
 
     if 0 < n_epochs_after_reject < 0.5 * n_epochs_before_reject:
         msg = (


### PR DESCRIPTION
quite some duplication … but Logging is better

```
┌────────┬ preprocessing/_09_ptp_reject ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
│21:45:35│ ⏳️ sub-005 Input:  sub-005_task-tasin_proc-ica_epo.fif
│21:45:35│ ⏳️ sub-005 Output: sub-005_task-tasin_proc-clean_epo.fif
│21:45:36│ ⏳️ sub-005 Removed 4 of 240 epochs via PTP rejection thresholds: {'eeg': 0.00025}
│21:45:36│ ⏳️ sub-005 Adding cleaned epochs to report.
```


### Before merging …

- [ ] Changelog has been updated (`docs/source/changes.md`)
