### PR TITLE
Save ECG and EOG evokeds created during ICA artifact detection to disk

### DIFF
--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -10,6 +10,7 @@
   [`epochs_metadata_tmax`][mne_bids_pipeline._config.epochs_metadata_tmax]. (#873 by @hoechenberger)
 - If you requested processing of non-existing subjects, we will now provide a more helpful error message. (#928 by @hoechenberger)
 - We improved the logging output for automnated epochs rejection and cleaning via ICA and SSP. (#936 by @hoechenberger)
+- ECG and EOG signals created during ICA artifact detection are now saved to disk. (#938 by @hoechenberger)
 
 ### :warning: Behavior changes
 


### PR DESCRIPTION
I needed access to the EOG evoked for diagnostic purposes, but figured we didn't save this data anywhere … This PR now saves the evokeds of ECG and EOG data. I considered saving the epochs instead, but at least for my usecase, I would always want to average first anyway…

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
