### PR TITLE
[MAINT] Switch to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
     needs: package
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    permissions:
+      id-token: write
     steps:
     - uses: actions/download-artifact@v4
       with:
@@ -51,6 +53,3 @@ jobs:
         path: dist
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Discussed with @larsoner: https://github.com/mne-tools/mne-connectivity/pull/200#issuecomment-2163383202

Switches releases to support PyPI trusted publishing.