### PR TITLE
Rework how we apply EEG montages

### DIFF
--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -10,7 +10,7 @@
   [`epochs_metadata_tmax`][mne_bids_pipeline._config.epochs_metadata_tmax]. (#873 by @hoechenberger)
 - If you requested processing of non-existing subjects, we will now provide a more helpful error message. (#928 by @hoechenberger)
 - We improved the logging output for automnated epochs rejection and cleaning via ICA and SSP. (#936, #937 by @hoechenberger)
-- ECG and EOG signals created during ICA artifact detection are now saved to disk. (#936 by @hoechenberger)
+- ECG and EOG signals created during ICA artifact detection are now saved to disk. (#938 by @hoechenberger)
 
 ### :warning: Behavior changes
 

--- a/docs/source/v1.9.md.inc
+++ b/docs/source/v1.9.md.inc
@@ -10,7 +10,7 @@
   [`epochs_metadata_tmax`][mne_bids_pipeline._config.epochs_metadata_tmax]. (#873 by @hoechenberger)
 - If you requested processing of non-existing subjects, we will now provide a more helpful error message. (#928 by @hoechenberger)
 - We improved the logging output for automnated epochs rejection and cleaning via ICA and SSP. (#936, #937 by @hoechenberger)
-- ECG and EOG signals created during ICA artifact detection are now saved to disk. (#938 by @hoechenberger)
+- ECG and EOG signals created during ICA artifact detection are now saved to disk. (#936 by @hoechenberger)
 
 ### :warning: Behavior changes
 
@@ -25,6 +25,11 @@
   had previously already been marked as bad in the dataset. Resulting entries in the TSV file may now look like:
   `"pre-existing (before MNE-BIDS-pipeline was run) & auto-noisy"` (previously: only `"auto-noisy"`). (#930 by @hoechenberger)
 - The `ica_ctps_ecg_threshold` has been renamed to [`ica_ecg_threshold`][mne_bids_pipeline._config.ica_ecg_threshold]. (#935 by @hoechenberger)
+- We changed the behavior when setting an EEG montage:
+  - When applying the montage, we now also check for channel aliases (e.g. `M1 -> TP9`).
+  - If the data contains a channel that is not present in the montage, we now abort with an exception (previously, we emitted a warning).
+    This is to prevent silent errors. To proceed in this situation, select a different montage, or drop the respective channels via
+    the [`drop_channels`][mne_bids_pipeline._config.drop_channels] configuration option. (#960 by @hoechenberger)
 
 ### :package: Requirements
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -348,7 +348,7 @@ https://mne.tools/stable/generated/mne.channels.make_standard_montage.html
 
 !!! warning
     If the data contains channel names that are not part of the template montage, the
-     pipeline run will fail with an error message. You must either pick a different
+    pipeline run will fail with an error message. You must either pick a different
     montage or remove those channels via
     [`drop_channels`][mne_bids_pipeline._config.drop_channels] to continue.
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -346,6 +346,13 @@ name of a built-in template montage in MNE-Python.
 You can find an overview of supported template montages at
 https://mne.tools/stable/generated/mne.channels.make_standard_montage.html
 
+!!! warning
+    If the data contains channel names that are not part of the template montage, the
+     pipeline run will fail with an error message. You must either pick a different
+    montage or remove those channels via
+    [`drop_channels`][mne_bids_pipeline._config.drop_channels] to continue.
+
+
 ???+ example "Example"
     Do not apply template montage:
     ```python
@@ -362,7 +369,8 @@ drop_channels: Sequence[str] = []
 """
 Names of channels to remove from the data. This can be useful, for example,
 if you have added a new bipolar channel via `eeg_bipolar_channels` and now wish
-to remove the anode, cathode, or both.
+to remove the anode, cathode, or both; or if your selected EEG template montage
+doesn't contain coordinates for some channels.
 
 ???+ example "Example"
     Exclude channels `Fp1` and `Cz` from processing:

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -326,14 +326,10 @@ def _set_eeg_montage(
     Modifies ``raw`` in-place.
     """
     montage = cfg.eeg_template_montage
-    is_mne_montage = isinstance(montage, mne.channels.montage.DigMontage)
-    montage_name = "custom_montage" if is_mne_montage else montage
     if cfg.datatype == "eeg" and montage:
         msg = f"Setting EEG channel locations to template montage: " f"{montage}."
         logger.info(**gen_log_kwargs(message=msg))
-        if not is_mne_montage:
-            montage = mne.channels.make_standard_montage(montage_name)
-        raw.set_montage(montage, match_case=False, on_missing="warn")
+        raw.set_montage(montage, match_case=False, match_alias=True)
 
 
 def _fix_stim_artifact_func(cfg: SimpleNamespace, raw: mne.io.BaseRaw) -> None:


### PR DESCRIPTION
- When applying montages, check for channel aliases, too (e.g. `M1 -> TP9`).
- Raise an exception (not just a warning) if the data contains channels that are not part of the montage.

Reported in #958

### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
