### PR TITLE
Choose documentation color scheme automatically based on operating system setting

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -24,7 +24,7 @@ theme:
       - media: "(prefers-color-scheme)"
         toggle:
           icon: material/brightness-auto
-          name: Switch to light mode
+          name: Switch to system preference
 
       # Palette toggle for light mode
       - media: "(prefers-color-scheme: light)"
@@ -32,14 +32,14 @@ theme:
         primary: white
         toggle:
           icon: material/brightness-7
-          name: Switch to dark mode
+          name: Switch to light mode
 
       # Palette toggle for dark mode
       - media: "(prefers-color-scheme: dark)"
         scheme: slate
         toggle:
           icon: material/brightness-4
-          name: Switch to system preference
+          name: Switch to dark mode
 
     custom_dir: overrides
 extra:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -21,12 +21,10 @@ theme:
         - content.code.copy  # copy button
     palette:
       # Palette toggle for automated theme selection
-      # Currently only available to sponsors
-      #
-      # - media: "(prefers-color-scheme)"
-      #   toggle:
-      #     icon: material/brightness-auto
-      #     name: Switch to light mode
+      - media: "(prefers-color-scheme)"
+        toggle:
+          icon: material/brightness-auto
+          name: Switch to light mode
 
       # Palette toggle for light mode
       - media: "(prefers-color-scheme: light)"

--- a/docs/source/v1.10.md.inc
+++ b/docs/source/v1.10.md.inc
@@ -16,6 +16,10 @@
 
 [//]: # (- Whatever (#000 by @whoever))
 
+### :books: Documentation
+
+- Choose the theme (dark of light) automatically based on the user's operating system setting (#979 by @hoechenberger)
+
 ### :medical_symbol: Code health
 
 - Switch from using relative to using absolute imports (#969 by @hoechenberger)


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
