### PR TITLE
Vendor external JavaScript with our documentation to better preserve users' privacy

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
 plugins:
     - search
     - macros
+    - privacy # https://squidfunk.github.io/mkdocs-material/plugins/privacy/
     - tags:
         tags_file: tags.md
     - include-markdown

--- a/docs/source/v1.10.md.inc
+++ b/docs/source/v1.10.md.inc
@@ -24,7 +24,7 @@
 ### :books: Documentation
 
 - Choose the theme (dark of light) automatically based on the user's operating system setting (#979 by @hoechenberger)
-- Bundle all previously-external JavaScript with out documentation to better preserve users' privacy (#982 by @hoechenberger)
+- Bundle all previously-external JavaScript to better preserve users' privacy (#982 by @hoechenberger)
 ### :medical_symbol: Code health
 
 - Switch from using relative to using absolute imports (#969 by @hoechenberger)

--- a/docs/source/v1.10.md.inc
+++ b/docs/source/v1.10.md.inc
@@ -24,7 +24,7 @@
 ### :books: Documentation
 
 - Choose the theme (dark of light) automatically based on the user's operating system setting (#979 by @hoechenberger)
-
+- Bundle all previously-external JavaScript with out documentation to better preserve users' privacy (#982 by @hoechenberger)
 ### :medical_symbol: Code health
 
 - Switch from using relative to using absolute imports (#969 by @hoechenberger)


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/changes.md`)
