### PR TITLE
ENH: Full mypy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
 ### Before merging …
 
-- [ ] Changelog has been updated (`docs/source/vX.Y.md.inc`)
+- [ ] Changelog has been updated (`docs/source/dev.md.inc`)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,10 @@ repos:
       - id: mypy
         additional_dependencies:
           - types-PyYAML
+          - numpy
+          - pytest
+          - dask[distributed]
+          - types-tqdm
+          # TODO: Fix errors for pandas someday perhaps
+          # (though we don't use it a lot)
+          # - pandas-stubs

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -1,4 +1,4 @@
-{% include-markdown "./dev.inc" %}
+{% include-markdown "./dev.md.inc" %}
 
 {% include-markdown "./v1.9.md.inc" %}
 

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -1,4 +1,4 @@
-{% include-markdown "./v1.10.md.inc" %}
+{% include-markdown "./dev.inc" %}
 
 {% include-markdown "./v1.9.md.inc" %}
 

--- a/docs/source/dev.md.inc
+++ b/docs/source/dev.md.inc
@@ -33,7 +33,7 @@
 ### :medical_symbol: Code health
 
 - Switch from using relative to using absolute imports (#969 by @hoechenberger)
-- Enable strict type checking via mypy (#995, #1013 by @larsoner)
+- Enable strict type checking via mypy (#995, #1013, #1016 by @larsoner)
 
 ### :medical_symbol: Code health and infrastructure
 

--- a/docs/source/settings/gen_settings.py
+++ b/docs/source/settings/gen_settings.py
@@ -138,9 +138,9 @@ def main() -> None:
         line = line.rstrip()
         if line.startswith("# #"):  # a new (sub)section / file
             this_def = line[2:]
-            this_level = this_def.split()[0]
-            assert this_level.count("#") == len(this_level), this_level
-            this_level = this_level.count("#") - 1
+            this_level_str = this_def.split()[0]
+            assert this_level_str.count("#") == len(this_level_str), this_level_str
+            this_level: int = this_level_str.count("#") - 1
             if this_level == 2:
                 # flatten preprocessing/filtering/filter to preprocessing/filter
                 # for example

--- a/mne_bids_pipeline/_decoding.py
+++ b/mne_bids_pipeline/_decoding.py
@@ -34,7 +34,9 @@ def _handle_csp_args(
         decoding_csp_times, (None, list, tuple, np.ndarray), "decoding_csp_times"
     )
     if decoding_csp_times is None:
-        decoding_csp_times = np.linspace(max(0, epochs_tmin), epochs_tmax, num=6)
+        decoding_csp_times = np.linspace(
+            max(0, epochs_tmin), epochs_tmax, num=6, dtype=float
+        )
     else:
         decoding_csp_times = np.array(decoding_csp_times, float)
     assert isinstance(decoding_csp_times, np.ndarray)

--- a/mne_bids_pipeline/_docs.py
+++ b/mne_bids_pipeline/_docs.py
@@ -149,6 +149,7 @@ class _ParseConfigSteps:
             step = "/".join(module.__name__.split(".")[-2:])
             found = False  # found at least one?
             # Walk the module file for "get_config*" functions (can be multiple!)
+            assert module.__file__ is not None
             for func in ast.walk(ast.parse(Path(module.__file__).read_text("utf-8"))):
                 if not isinstance(func, ast.FunctionDef):
                     continue

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -19,7 +19,7 @@ from ._config_utils import (
 from ._io import _read_json
 from ._logging import gen_log_kwargs, logger
 from ._run import _update_for_splits
-from .typing import PathLike, RunKindT, RunTypeT
+from .typing import InFilesT, PathLike, RunKindT, RunTypeT
 
 
 def make_epochs(
@@ -565,7 +565,7 @@ def _get_run_path(
     add_bads: bool | None = None,
     allow_missing: bool = False,
     key: str | None = None,
-) -> dict[str, BIDSPath]:
+) -> InFilesT:
     bids_path_in = _get_bids_path_in(
         cfg=cfg,
         subject=subject,
@@ -593,7 +593,7 @@ def _get_rest_path(
     session: str | None,
     kind: RunKindT,
     add_bads: bool | None = None,
-) -> dict[str, BIDSPath]:
+) -> InFilesT:
     if not (cfg.process_rest and not cfg.task_is_rest):
         return dict()
     return _get_run_path(
@@ -616,7 +616,7 @@ def _get_noise_path(
     kind: RunKindT,
     mf_reference_run: str | None,
     add_bads: bool | None = None,
-) -> dict[str, BIDSPath]:
+) -> InFilesT:
     if not (cfg.process_empty_room and get_datatype(config=cfg) == "meg"):
         return dict()
     if kind != "orig":
@@ -664,7 +664,7 @@ def _get_run_rest_noise_path(
     kind: RunKindT,
     mf_reference_run: str | None,
     add_bads: bool | None = None,
-) -> dict[str, BIDSPath]:
+) -> InFilesT:
     if run is None and task in ("noise", "rest"):
         if task == "noise":
             path = _get_noise_path(
@@ -703,7 +703,7 @@ def _get_mf_reference_run_path(
     subject: str,
     session: str | None,
     add_bads: bool | None = None,
-) -> dict[str, BIDSPath]:
+) -> InFilesT:
     return _get_run_path(
         cfg=cfg,
         subject=subject,
@@ -732,7 +732,7 @@ def _path_dict(
     key: str | None = None,
     subject: str,
     session: str | None,
-) -> dict[str, BIDSPath]:
+) -> InFilesT:
     if add_bads is None:
         add_bads = kind == "orig" and _do_mf_autobad(cfg=cfg)
     in_files = dict()

--- a/mne_bids_pipeline/_logging.py
+++ b/mne_bids_pipeline/_logging.py
@@ -14,15 +14,14 @@ from .typing import LogKwargsT
 class _MBPLogger:
     def __init__(self) -> None:
         self._level = logging.INFO
+        self.__console: rich.console.Console | None = None
 
     # Do lazy instantiation of _console so that pytest's output capture
     # mechanics don't get messed up
     @property
     def _console(self) -> rich.console.Console:
-        try:
-            return self.__console  # type: ignore[has-type]
-        except AttributeError:
-            pass  # need to instantiate it, continue
+        if isinstance(self.__console, rich.console.Console):
+            return self.__console
 
         force_terminal: bool | None = None
         force_terminal_env = os.getenv("MNE_BIDS_PIPELINE_FORCE_TERMINAL", None)

--- a/mne_bids_pipeline/_parallel.py
+++ b/mne_bids_pipeline/_parallel.py
@@ -67,7 +67,7 @@ def setup_dask_client(*, exec_params: SimpleNamespace) -> None:
             "distributed.worker.memory.spill": False,
         }
     )
-    client = Client(
+    client = Client(  # type: ignore[no-untyped-call]
         memory_limit=exec_params.dask_worker_memory_limit,
         n_workers=n_workers,
         threads_per_worker=1,

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -572,17 +572,17 @@ def _sanitize_cond_tag(cond: str) -> str:
 
 
 def _imshow_tf(
-    vals: np.ndarray,
+    vals: FloatArrayT,
     ax: matplotlib.axes.Axes,
     *,
-    tmin: np.ndarray,
-    tmax: np.ndarray,
-    fmin: np.ndarray,
-    fmax: np.ndarray,
+    tmin: FloatArrayT,
+    tmax: FloatArrayT,
+    fmin: FloatArrayT,
+    fmax: FloatArrayT,
     vmin: float,
     vmax: float,
     cmap: str = "RdBu_r",
-    mask: np.ndarray | None = None,
+    mask: FloatArrayT | None = None,
     cmap_masked: Any | None = None,
 ) -> matplotlib.image.AxesImage:
     """Plot CSP TF decoding scores."""

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -21,7 +21,7 @@ from mne_bids import BIDSPath
 
 from ._config_utils import get_task
 from ._logging import _is_testing, gen_log_kwargs, logger
-from .typing import OutFilesT
+from .typing import InFilesT, OutFilesT
 
 
 def failsafe_run(
@@ -347,7 +347,7 @@ def save_logs(*, config: SimpleNamespace, logs: Iterable[pd.Series]) -> None:
 
 
 def _update_for_splits(
-    files_dict: dict[str, BIDSPath] | BIDSPath,
+    files_dict: InFilesT | BIDSPath,
     key: str | None,
     *,
     single: bool = False,
@@ -420,7 +420,7 @@ def _short_step_path(step_path: pathlib.Path) -> str:
 def _prep_out_files(
     *,
     exec_params: SimpleNamespace,
-    out_files: dict[str, BIDSPath],
+    out_files: InFilesT,
     check_relative: pathlib.Path | None = None,
     bids_only: bool = True,
 ) -> OutFilesT:

--- a/mne_bids_pipeline/steps/freesurfer/_02_coreg_surfaces.py
+++ b/mne_bids_pipeline/steps/freesurfer/_02_coreg_surfaces.py
@@ -19,11 +19,12 @@ from mne_bids_pipeline._config_utils import (
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._run import _prep_out_files, failsafe_run
+from mne_bids_pipeline.typing import InFilesPathT, OutFilesT
 
 fs_bids_app = Path(__file__).parent / "contrib" / "run.py"
 
 
-def _get_scalp_in_files(cfg: SimpleNamespace) -> dict[str, Path]:
+def _get_scalp_in_files(cfg: SimpleNamespace) -> InFilesPathT:
     subject_path = Path(cfg.fs_subjects_dir) / cfg.fs_subject
     seghead = subject_path / "surf" / "lh.seghead"
     in_files = dict()
@@ -38,11 +39,13 @@ def get_input_fnames_coreg_surfaces(
     *,
     cfg: SimpleNamespace,
     subject: str,
-) -> dict:
+) -> InFilesPathT:
     return _get_scalp_in_files(cfg)
 
 
-def get_output_fnames_coreg_surfaces(*, cfg: SimpleNamespace, subject: str) -> dict:
+def get_output_fnames_coreg_surfaces(
+    *, cfg: SimpleNamespace, subject: str
+) -> InFilesPathT:
     out_files = dict()
     subject_path = Path(cfg.fs_subjects_dir) / cfg.fs_subject
     out_files["seghead"] = subject_path / "surf" / "lh.seghead"
@@ -61,8 +64,8 @@ def make_coreg_surfaces(
     cfg: SimpleNamespace,
     exec_params: SimpleNamespace,
     subject: str,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesPathT,
+) -> OutFilesT:
     """Create head surfaces for use with MNE-Python coregistration tools."""
     msg = "Creating scalp surfaces for coregistration"
     logger.info(**gen_log_kwargs(message=msg))

--- a/mne_bids_pipeline/steps/init/_02_find_empty_room.py
+++ b/mne_bids_pipeline/steps/init/_02_find_empty_room.py
@@ -20,11 +20,12 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_find_empty_room(
     *, subject: str, session: str | None, run: str | None, cfg: SimpleNamespace
-) -> dict[str, BIDSPath]:
+) -> InFilesT:
     """Get paths of files required by find_empty_room function."""
     bids_path_in = BIDSPath(
         subject=subject,
@@ -39,7 +40,7 @@ def get_input_fnames_find_empty_room(
         root=cfg.bids_root,
         check=False,
     )
-    in_files: dict[str, BIDSPath] = dict()
+    in_files: InFilesT = dict()
     in_files[f"raw_run-{run}"] = bids_path_in
     _update_for_splits(in_files, f"raw_run-{run}", single=True)
     if hasattr(bids_path_in, "find_matching_sidecar"):
@@ -68,8 +69,8 @@ def find_empty_room(
     subject: str,
     session: str | None,
     run: str | None,
-    in_files: dict[str, BIDSPath],
-) -> dict[str, BIDSPath]:
+    in_files: InFilesT,
+) -> OutFilesT:
     raw_path = in_files.pop(f"raw_run-{run}")
     in_files.pop("sidecar", None)
     try:

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 
 import mne
 import pandas as pd
-from mne_bids import BIDSPath
 
 from mne_bids_pipeline._config_utils import (
     _do_mf_autobad,
@@ -29,6 +28,7 @@ from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._report import _add_raw, _open_report
 from mne_bids_pipeline._run import _prep_out_files, failsafe_run, save_logs
 from mne_bids_pipeline._viz import plot_auto_scores
+from mne_bids_pipeline.typing import AutoScoresT, InFilesT, OutFilesT
 
 
 def get_input_fnames_data_quality(
@@ -38,9 +38,9 @@ def get_input_fnames_data_quality(
     session: str | None,
     run: str | None,
     task: str | None,
-) -> dict:
+) -> InFilesT:
     """Get paths of files required by assess_data_quality function."""
-    in_files: dict[str, BIDSPath] = _get_run_rest_noise_path(
+    in_files: InFilesT = _get_run_rest_noise_path(
         run=run,
         task=task,
         kind="orig",
@@ -74,8 +74,8 @@ def assess_data_quality(
     session: str | None,
     run: str | None,
     task: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     """Assess data quality and find and mark bad channels."""
     import matplotlib.pyplot as plt
 
@@ -107,7 +107,7 @@ def assess_data_quality(
         )
     preexisting_bads = sorted(raw.info["bads"])
 
-    auto_scores: dict | None = None
+    auto_scores: AutoScoresT | None = None
     auto_noisy_chs: list[str] | None = None
     auto_flat_chs: list[str] | None = None
     if _do_mf_autobad(cfg=cfg):
@@ -242,7 +242,7 @@ def _find_bads_maxwell(
     session: str | None,
     run: str | None,
     task: str | None,
-) -> tuple[list[str], list[str], dict]:
+) -> tuple[list[str], list[str], AutoScoresT]:
     if cfg.find_flat_channels_meg:
         if cfg.find_noisy_channels_meg:
             msg = "Finding flat channels and noisy channels using Maxwell filtering."

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -28,7 +28,7 @@ from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._report import _add_raw, _open_report
 from mne_bids_pipeline._run import _prep_out_files, failsafe_run, save_logs
 from mne_bids_pipeline._viz import plot_auto_scores
-from mne_bids_pipeline.typing import AutoScoresT, InFilesT, OutFilesT
+from mne_bids_pipeline.typing import FloatArrayT, InFilesT, OutFilesT
 
 
 def get_input_fnames_data_quality(
@@ -107,7 +107,7 @@ def assess_data_quality(
         )
     preexisting_bads = sorted(raw.info["bads"])
 
-    auto_scores: AutoScoresT | None = None
+    auto_scores: dict[str, FloatArrayT] | None = None
     auto_noisy_chs: list[str] | None = None
     auto_flat_chs: list[str] | None = None
     if _do_mf_autobad(cfg=cfg):
@@ -242,7 +242,7 @@ def _find_bads_maxwell(
     session: str | None,
     run: str | None,
     task: str | None,
-) -> tuple[list[str], list[str], AutoScoresT]:
+) -> tuple[list[str], list[str], dict[str, FloatArrayT]]:
     if cfg.find_flat_channels_meg:
         if cfg.find_noisy_channels_meg:
             msg = "Finding flat channels and noisy channels using Maxwell filtering."

--- a/mne_bids_pipeline/steps/preprocessing/_02_head_pos.py
+++ b/mne_bids_pipeline/steps/preprocessing/_02_head_pos.py
@@ -14,6 +14,7 @@ from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._report import _open_report
 from mne_bids_pipeline._run import _prep_out_files, failsafe_run, save_logs
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_head_pos(
@@ -23,7 +24,7 @@ def get_input_fnames_head_pos(
     session: str | None,
     run: str | None,
     task: str | None,
-) -> dict:
+) -> InFilesT:
     """Get paths of files required by run_head_pos function."""
     return _get_run_rest_noise_path(
         cfg=cfg,
@@ -47,8 +48,8 @@ def run_head_pos(
     session: str | None,
     run: str | None,
     task: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     import matplotlib.pyplot as plt
 
     in_key = f"raw_task-{task}_run-{run}"

--- a/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 
 import mne
 import numpy as np
-from mne_bids import BIDSPath, read_raw_bids
+from mne_bids import read_raw_bids
 
 from mne_bids_pipeline._config_utils import (
     _pl,
@@ -46,6 +46,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 # %% eSSS
@@ -54,7 +55,7 @@ def get_input_fnames_esss(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     in_files = _get_run_rest_noise_path(
         run=None,
         task="noise",
@@ -83,8 +84,8 @@ def compute_esss_proj(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     import matplotlib.pyplot as plt
 
     run, task = None, "noise"
@@ -191,7 +192,7 @@ def get_input_fnames_maxwell_filter(
     session: str | None,
     run: str | None,
     task: str | None,
-) -> dict:
+) -> InFilesT:
     """Get paths of files required by maxwell_filter function."""
     in_files = _get_run_rest_noise_path(
         run=run,
@@ -288,8 +289,8 @@ def run_maxwell_filter(
     session: str | None,
     run: str | None,
     task: str | None,
-    in_files: dict[str, BIDSPath],
-) -> dict[str, BIDSPath]:
+    in_files: InFilesT,
+) -> OutFilesT:
     if cfg.proc and "sss" in cfg.proc and cfg.use_maxwell_filter:
         raise ValueError(
             f"You cannot set use_maxwell_filter to True "

--- a/mne_bids_pipeline/steps/preprocessing/_04_frequency_filter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_04_frequency_filter.py
@@ -40,7 +40,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
-from mne_bids_pipeline.typing import InFilesT, OutFilesT, RunKindT, RunTypeT
+from mne_bids_pipeline.typing import InFilesT, IntArrayT, OutFilesT, RunKindT, RunTypeT
 
 
 def get_input_fnames_frequency_filter(
@@ -74,7 +74,7 @@ def notch_filter(
     trans_bandwidth: float | Literal["auto"],
     notch_widths: float | Iterable[float] | None,
     run_type: RunTypeT,
-    picks: np.ndarray | None,
+    picks: IntArrayT | None,
 ) -> None:
     """Filter data channels (MEG and EEG)."""
     if freqs is None:
@@ -107,7 +107,7 @@ def bandpass_filter(
     l_trans_bandwidth: float | Literal["auto"],
     h_trans_bandwidth: float | Literal["auto"],
     run_type: RunTypeT,
-    picks: np.ndarray | None,
+    picks: IntArrayT | None,
 ) -> None:
     """Filter data channels (MEG and EEG)."""
     if l_freq is not None and h_freq is None:

--- a/mne_bids_pipeline/steps/preprocessing/_04_frequency_filter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_04_frequency_filter.py
@@ -40,7 +40,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
-from mne_bids_pipeline.typing import RunKindT, RunTypeT
+from mne_bids_pipeline.typing import InFilesT, OutFilesT, RunKindT, RunTypeT
 
 
 def get_input_fnames_frequency_filter(
@@ -50,7 +50,7 @@ def get_input_fnames_frequency_filter(
     session: str | None,
     run: str,
     task: str | None,
-) -> dict:
+) -> InFilesT:
     """Get paths of files required by filter_data function."""
     kind: RunKindT = "sss" if cfg.use_maxwell_filter else "orig"
     return _get_run_rest_noise_path(
@@ -162,8 +162,8 @@ def filter_data(
     session: str | None,
     run: str,
     task: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     """Filter data from a single subject."""
     out_files = dict()
     in_key = f"raw_task-{task}_run-{run}"

--- a/mne_bids_pipeline/steps/preprocessing/_05_regress_artifact.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05_regress_artifact.py
@@ -21,6 +21,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_regress_artifact(
@@ -30,7 +31,7 @@ def get_input_fnames_regress_artifact(
     session: str | None,
     run: str,
     task: str | None,
-) -> dict:
+) -> InFilesT:
     """Get paths of files required by regress_artifact function."""
     out = _get_run_rest_noise_path(
         cfg=cfg,
@@ -56,8 +57,8 @@ def run_regress_artifact(
     session: str | None,
     run: str,
     task: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     model = EOGRegression(proj=False, **cfg.regress_artifact)
     out_files = dict()
     in_key = f"raw_task-{task}_run-{run}"

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -34,6 +34,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_run_ica(
@@ -41,7 +42,7 @@ def get_input_fnames_run_ica(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     bids_basename = BIDSPath(
         subject=subject,
         session=session,
@@ -73,8 +74,8 @@ def run_ica(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     """Run ICA."""
     import matplotlib.pyplot as plt
 

--- a/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
@@ -31,7 +31,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
-from mne_bids_pipeline.typing import InFilesT, OutFilesT
+from mne_bids_pipeline.typing import FloatArrayT, InFilesT, OutFilesT
 
 
 def detect_bad_components(
@@ -43,7 +43,7 @@ def detect_bad_components(
     ch_names: list[str] | None,
     subject: str,
     session: str | None,
-) -> tuple[list[int], np.ndarray]:
+) -> tuple[list[int], FloatArrayT]:
     artifact = which.upper()
     if epochs is None:
         msg = (
@@ -156,7 +156,7 @@ def find_ica_artifacts(
     # ECG component detection
     epochs_ecg = None
     ecg_ics: list[int] = []
-    ecg_scores = np.zeros(0)
+    ecg_scores: FloatArrayT = np.zeros(0)
     for ri, raw_fname in enumerate(raw_fnames):
         # Have the channels needed to make ECG epochs
         raw = mne.io.read_raw(raw_fname, preload=False)

--- a/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
@@ -31,6 +31,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def detect_bad_components(
@@ -91,7 +92,7 @@ def get_input_fnames_find_ica_artifacts(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     bids_basename = BIDSPath(
         subject=subject,
         session=session,
@@ -126,8 +127,8 @@ def find_ica_artifacts(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     """Run ICA."""
     raw_fnames = [in_files.pop(f"raw_run-{run}") for run in cfg.runs]
     bids_basename = raw_fnames[0].copy().update(processing=None, split=None, run=None)

--- a/mne_bids_pipeline/steps/preprocessing/_06b_run_ssp.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06b_run_ssp.py
@@ -29,6 +29,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def _find_ecg_events(raw: mne.io.Raw, ch_name: str | None) -> np.ndarray:
@@ -41,7 +42,7 @@ def get_input_fnames_run_ssp(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     bids_basename = BIDSPath(
         subject=subject,
         session=session,
@@ -73,8 +74,8 @@ def run_ssp(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     import matplotlib.pyplot as plt
 
     # compute SSP on all runs of raw

--- a/mne_bids_pipeline/steps/preprocessing/_06b_run_ssp.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06b_run_ssp.py
@@ -7,7 +7,6 @@ These are often also referred to as PCA vectors.
 from types import SimpleNamespace
 
 import mne
-import numpy as np
 from mne import compute_proj_epochs, compute_proj_evoked
 from mne.preprocessing import find_ecg_events, find_eog_events
 from mne_bids import BIDSPath
@@ -29,12 +28,13 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
-from mne_bids_pipeline.typing import InFilesT, OutFilesT
+from mne_bids_pipeline.typing import InFilesT, IntArrayT, OutFilesT
 
 
-def _find_ecg_events(raw: mne.io.Raw, ch_name: str | None) -> np.ndarray:
+def _find_ecg_events(raw: mne.io.Raw, ch_name: str | None) -> IntArrayT:
     """Wrap find_ecg_events to use the same defaults as create_ecg_events."""
-    return find_ecg_events(raw, ch_name=ch_name, l_freq=8, h_freq=16)[0]
+    out: IntArrayT = find_ecg_events(raw, ch_name=ch_name, l_freq=8, h_freq=16)[0]
+    return out
 
 
 def get_input_fnames_run_ssp(

--- a/mne_bids_pipeline/steps/preprocessing/_07_make_epochs.py
+++ b/mne_bids_pipeline/steps/preprocessing/_07_make_epochs.py
@@ -12,7 +12,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import mne
-import numpy as np
 from mne_bids import BIDSPath
 
 from mne_bids_pipeline._config_utils import (
@@ -32,7 +31,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
-from mne_bids_pipeline.typing import InFilesT, OutFilesT
+from mne_bids_pipeline.typing import InFilesT, IntArrayT, OutFilesT
 
 
 def get_input_fnames_epochs(
@@ -280,7 +279,7 @@ def _add_epochs_image_kwargs(cfg: SimpleNamespace) -> dict[str, dict[str, Any]]:
 # TODO: ideally we wouldn't need this anymore and could refactor the code above
 def _get_events(
     cfg: SimpleNamespace, subject: str, session: str | None
-) -> tuple[np.ndarray, dict[str, int], float, int]:
+) -> tuple[IntArrayT, dict[str, int], float, int]:
     raws_filt = []
     raw_fname = BIDSPath(
         subject=subject,

--- a/mne_bids_pipeline/steps/preprocessing/_07_make_epochs.py
+++ b/mne_bids_pipeline/steps/preprocessing/_07_make_epochs.py
@@ -9,6 +9,7 @@ To save space, the epoch data can be decimated.
 
 import inspect
 from types import SimpleNamespace
+from typing import Any
 
 import mne
 import numpy as np
@@ -31,6 +32,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_epochs(
@@ -38,7 +40,7 @@ def get_input_fnames_epochs(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     """Get paths of files required by filter_data function."""
     # Construct the basenames of the files we wish to load, and of the empty-
     # room recording we wish to save.
@@ -79,8 +81,8 @@ def run_epochs(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     """Extract epochs for one subject."""
     raw_fnames = [in_files.pop(f"raw_run-{run}") for run in cfg.runs]
     bids_path_in = raw_fnames[0].copy().update(processing=None, run=None, split=None)
@@ -267,7 +269,7 @@ def run_epochs(
     return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
-def _add_epochs_image_kwargs(cfg: SimpleNamespace) -> dict:
+def _add_epochs_image_kwargs(cfg: SimpleNamespace) -> dict[str, dict[str, Any]]:
     arg_spec = inspect.getfullargspec(mne.Report.add_epochs)
     kwargs = dict()
     if cfg.report_add_epochs_image_kwargs and "image_kwargs" in arg_spec.kwonlyargs:
@@ -278,7 +280,7 @@ def _add_epochs_image_kwargs(cfg: SimpleNamespace) -> dict:
 # TODO: ideally we wouldn't need this anymore and could refactor the code above
 def _get_events(
     cfg: SimpleNamespace, subject: str, session: str | None
-) -> tuple[np.ndarray, dict, float, int]:
+) -> tuple[np.ndarray, dict[str, int], float, int]:
     raws_filt = []
     raw_fname = BIDSPath(
         subject=subject,

--- a/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
@@ -23,6 +23,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def _ica_paths(
@@ -30,7 +31,7 @@ def _ica_paths(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict[str, BIDSPath]:
+) -> InFilesT:
     bids_basename = BIDSPath(
         subject=subject,
         session=session,
@@ -55,7 +56,7 @@ def _ica_paths(
 
 
 def _read_ica_and_exclude(
-    in_files: dict,
+    in_files: InFilesT,
 ) -> mne.preprocessing.ICA:
     ica = read_ica(fname=in_files.pop("ica"))
     tsv_data = pd.read_csv(in_files.pop("components"), sep="\t")
@@ -68,7 +69,7 @@ def get_input_fnames_apply_ica_epochs(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     in_files = _ica_paths(cfg=cfg, subject=subject, session=session)
     in_files["epochs"] = (
         in_files["ica"]
@@ -90,7 +91,7 @@ def get_input_fnames_apply_ica_raw(
     session: str | None,
     run: str,
     task: str | None,
-) -> dict:
+) -> InFilesT:
     in_files = _get_run_rest_noise_path(
         cfg=cfg,
         subject=subject,
@@ -114,8 +115,8 @@ def apply_ica_epochs(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     out_files = dict()
     out_files["epochs"] = in_files["epochs"].copy().update(processing="ica", split=None)
 
@@ -199,8 +200,8 @@ def apply_ica_raw(
     session: str | None,
     run: str,
     task: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     ica = _read_ica_and_exclude(in_files)
     in_key = list(in_files)[0]
     assert in_key.startswith("raw"), in_key

--- a/mne_bids_pipeline/steps/preprocessing/_08b_apply_ssp.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08b_apply_ssp.py
@@ -23,6 +23,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_apply_ssp_epochs(
@@ -30,7 +31,7 @@ def get_input_fnames_apply_ssp_epochs(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     in_files = dict()
     in_files["proj"] = _proj_path(cfg=cfg, subject=subject, session=session)
     in_files["epochs"] = in_files["proj"].copy().update(suffix="epo", check=False)
@@ -47,8 +48,8 @@ def apply_ssp_epochs(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     out_files = dict()
     out_files["epochs"] = (
         in_files["epochs"].copy().update(processing="ssp", split=None, check=False)
@@ -84,7 +85,7 @@ def get_input_fnames_apply_ssp_raw(
     session: str | None,
     run: str,
     task: str | None,
-) -> dict:
+) -> InFilesT:
     in_files = _get_run_rest_noise_path(
         cfg=cfg,
         subject=subject,
@@ -110,8 +111,8 @@ def apply_ssp_raw(
     session: str | None,
     run: str,
     task: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     projs = mne.read_proj(in_files.pop("proj"))
     in_key = list(in_files.keys())[0]
     assert in_key.startswith("raw"), in_key

--- a/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
+++ b/mne_bids_pipeline/steps/preprocessing/_09_ptp_reject.py
@@ -26,6 +26,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 from ._07_make_epochs import _add_epochs_image_kwargs
 
@@ -35,7 +36,7 @@ def get_input_fnames_drop_ptp(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     bids_path = BIDSPath(
         subject=subject,
         session=session,
@@ -65,8 +66,8 @@ def drop_ptp(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     import matplotlib.pyplot as plt
 
     out_files = dict()

--- a/mne_bids_pipeline/steps/sensor/_01_make_evoked.py
+++ b/mne_bids_pipeline/steps/sensor/_01_make_evoked.py
@@ -23,6 +23,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_evoked(
@@ -30,7 +31,7 @@ def get_input_fnames_evoked(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     fname_epochs = BIDSPath(
         subject=subject,
         session=session,
@@ -61,8 +62,8 @@ def run_evoked(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     out_files = dict()
     out_files["evoked"] = (
         in_files["epochs"]

--- a/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
+++ b/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
@@ -43,6 +43,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_epochs_decoding(
@@ -52,7 +53,7 @@ def get_input_fnames_epochs_decoding(
     session: str | None,
     condition1: str,
     condition2: str,
-) -> dict:
+) -> InFilesT:
     proc = _get_decoding_proc(config=cfg)
     fname_epochs = BIDSPath(
         subject=subject,
@@ -86,8 +87,8 @@ def run_epochs_decoding(
     session: str | None,
     condition1: str,
     condition2: str,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     import matplotlib.pyplot as plt
 
     msg = f"Contrasting conditions: {condition1} – {condition2}"

--- a/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
+++ b/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
@@ -51,6 +51,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_time_decoding(
@@ -60,7 +61,7 @@ def get_input_fnames_time_decoding(
     session: str | None,
     condition1: str,
     condition2: str,
-) -> dict:
+) -> InFilesT:
     proc = _get_decoding_proc(config=cfg)
     fname_epochs = BIDSPath(
         subject=subject,
@@ -94,8 +95,8 @@ def run_time_decoding(
     session: str | None,
     condition1: str,
     condition2: str,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     import matplotlib.pyplot as plt
 
     if cfg.decoding_time_generalization:

--- a/mne_bids_pipeline/steps/sensor/_04_time_frequency.py
+++ b/mne_bids_pipeline/steps/sensor/_04_time_frequency.py
@@ -26,6 +26,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_time_frequency(
@@ -33,7 +34,7 @@ def get_input_fnames_time_frequency(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     fname_epochs = BIDSPath(
         subject=subject,
         session=session,
@@ -64,8 +65,8 @@ def run_time_frequency(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     import matplotlib.pyplot as plt
 
     epochs_path = in_files.pop("epochs")

--- a/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
+++ b/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
@@ -39,6 +39,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def _prepare_labels(*, epochs: mne.BaseEpochs, contrast: tuple[str, str]) -> np.ndarray:
@@ -116,7 +117,7 @@ def get_input_fnames_csp(
     subject: str,
     session: str | None,
     contrast: tuple[str],
-) -> dict:
+) -> InFilesT:
     proc = _get_decoding_proc(config=cfg)
     fname_epochs = BIDSPath(
         subject=subject,
@@ -147,8 +148,8 @@ def one_subject_decoding(
     subject: str,
     session: str,
     contrast: tuple[str, str],
-    in_files: dict[str, BIDSPath],
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     """Run one subject.
 
     There are two steps in this function:

--- a/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
+++ b/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
@@ -39,10 +39,10 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
-from mne_bids_pipeline.typing import InFilesT, OutFilesT
+from mne_bids_pipeline.typing import InFilesT, IntArrayT, OutFilesT
 
 
-def _prepare_labels(*, epochs: mne.BaseEpochs, contrast: tuple[str, str]) -> np.ndarray:
+def _prepare_labels(*, epochs: mne.BaseEpochs, contrast: tuple[str, str]) -> IntArrayT:
     """Return the projection of the events_id on a boolean vector.
 
     This projection is useful in the case of hierarchical events:
@@ -58,7 +58,7 @@ def _prepare_labels(*, epochs: mne.BaseEpochs, contrast: tuple[str, str]) -> np.
     epochs_cond_1 = epochs[contrast[1]]
     event_codes_condition_1 = set(epochs_cond_1.events[:, 2])
 
-    y = epochs.events[:, 2].copy()
+    y: IntArrayT = epochs.events[:, 2].copy()
     for i in range(len(y)):
         if y[i] in event_codes_condition_0 and y[i] in event_codes_condition_1:
             msg = (
@@ -90,7 +90,7 @@ def prepare_epochs_and_y(
     cfg: SimpleNamespace,
     fmin: float,
     fmax: float,
-) -> tuple[mne.BaseEpochs, np.ndarray]:
+) -> tuple[mne.BaseEpochs, IntArrayT]:
     """Band-pass between, sub-select the desired epochs, and prepare y."""
     # filtering out the conditions we are not interested in, to ensure here we
     # have a valid partition between the condition of the contrast.

--- a/mne_bids_pipeline/steps/sensor/_06_make_cov.py
+++ b/mne_bids_pipeline/steps/sensor/_06_make_cov.py
@@ -26,6 +26,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_cov(
@@ -33,7 +34,7 @@ def get_input_fnames_cov(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     cov_type = _get_cov_type(cfg)
     in_files = dict()
     fname_epochs = BIDSPath(
@@ -97,8 +98,8 @@ def compute_cov_from_epochs(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-    out_files: dict,
+    in_files: InFilesT,
+    out_files: InFilesT,
 ) -> mne.Covariance:
     epo_fname = in_files.pop("epochs")
 
@@ -127,8 +128,8 @@ def compute_cov_from_raw(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-    out_files: dict,
+    in_files: InFilesT,
+    out_files: InFilesT,
 ) -> mne.Covariance:
     fname_raw = in_files.pop("raw")
     run_msg = "resting-state" if fname_raw.task == "rest" else "empty-room"
@@ -154,8 +155,8 @@ def retrieve_custom_cov(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-    out_files: dict,
+    in_files: InFilesT,
+    out_files: InFilesT,
 ) -> mne.Covariance:
     # This should be the only place we use config.noise_cov (rather than cfg.*
     # entries)
@@ -215,8 +216,8 @@ def run_covariance(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None = None,
-    in_files: dict,
-) -> dict[str, BIDSPath]:
+    in_files: InFilesT,
+) -> OutFilesT:
     import matplotlib.pyplot as plt
 
     out_files = dict()

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -44,7 +44,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
-from mne_bids_pipeline.typing import InFilesT, OutFilesT, TypedDict
+from mne_bids_pipeline.typing import FloatArrayT, InFilesT, OutFilesT, TypedDict
 
 
 def get_input_fnames_average_evokeds(
@@ -185,17 +185,17 @@ def average_evokeds(
 
 
 class ClusterAcrossTime(TypedDict):
-    times: np.ndarray
+    times: FloatArrayT
     p_value: float
 
 
 def _decoding_cluster_permutation_test(
-    scores: np.ndarray,
-    times: np.ndarray,
+    scores: FloatArrayT,
+    times: FloatArrayT,
     cluster_forming_t_threshold: float | None,
     n_permutations: int,
     random_seed: int,
-) -> tuple[np.ndarray, list[ClusterAcrossTime], int]:
+) -> tuple[FloatArrayT, list[ClusterAcrossTime], int]:
     """Perform a cluster permutation test on decoding scores.
 
     The clusters are formed across time points.
@@ -361,7 +361,7 @@ def average_time_by_time_decoding(
     }
 
     # Extract mean CV scores from all subjects.
-    mean_scores = np.empty((n_subjects, *time_points_shape))
+    mean_scores: FloatArrayT = np.empty((n_subjects, *time_points_shape))
 
     # Remaining in_files are all decoding data
     assert len(in_files) == n_subjects, list(in_files.keys())
@@ -383,10 +383,9 @@ def average_time_by_time_decoding(
         # performing a 1-sample test (i.e., test against 0)!
         idx = np.where(times >= 0)[0]
 
+        cluster_permutation_scores: FloatArrayT = mean_scores[:, idx] - 0.5
         if cfg.decoding_time_generalization:
-            cluster_permutation_scores = mean_scores[:, idx, idx] - 0.5
-        else:
-            cluster_permutation_scores = mean_scores[:, idx] - 0.5
+            cluster_permutation_scores = mean_scores[:, idx]
 
         cluster_permutation_times = times[idx]
         if cfg.cluster_forming_t_threshold is None:

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -383,9 +383,10 @@ def average_time_by_time_decoding(
         # performing a 1-sample test (i.e., test against 0)!
         idx = np.where(times >= 0)[0]
 
-        cluster_permutation_scores: FloatArrayT = mean_scores[:, idx] - 0.5
         if cfg.decoding_time_generalization:
-            cluster_permutation_scores = mean_scores[:, idx]
+            cluster_permutation_scores = mean_scores[:, idx, idx] - 0.5
+        else:
+            cluster_permutation_scores = mean_scores[:, idx] - 0.5
 
         cluster_permutation_times = times[idx]
         if cfg.cluster_forming_t_threshold is None:

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -44,15 +44,15 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
-from mne_bids_pipeline.typing import TypedDict
+from mne_bids_pipeline.typing import InFilesT, OutFilesT, TypedDict
 
 
 def get_input_fnames_average_evokeds(
     *,
     cfg: SimpleNamespace,
     subject: str,
-    session: dict | None,
-) -> dict:
+    session: str | None,
+) -> InFilesT:
     in_files = dict()
     for this_subject in cfg.subjects:
         in_files[f"evoked-{this_subject}"] = BIDSPath(
@@ -81,8 +81,8 @@ def average_evokeds(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     logger.info(**gen_log_kwargs(message="Creating grand averages"))
     # Container for all conditions:
     conditions = _all_conditions(cfg=cfg)
@@ -228,7 +228,7 @@ def _get_epochs_in_files(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     in_files = dict()
     in_files["epochs"] = BIDSPath(
         subject=cfg.subjects[0],
@@ -295,7 +295,7 @@ def _get_input_fnames_decoding(
     cond_2: str,
     kind: str,
     extension: str = ".mat",
-) -> dict:
+) -> InFilesT:
     in_files = _get_epochs_in_files(cfg=cfg, subject=subject, session=session)
     for this_subject in cfg.subjects:
         in_files[f"scores-{this_subject}"] = _decoding_out_fname(
@@ -324,8 +324,8 @@ def average_time_by_time_decoding(
     session: str | None,
     cond_1: str,
     cond_2: str,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     logger.info(**gen_log_kwargs(message="Averaging time-by-time decoding results"))
     # Get the time points from the very first subject. They are identical
     # across all subjects and conditions, so this should suffice.
@@ -566,8 +566,8 @@ def average_full_epochs_decoding(
     session: str | None,
     cond_1: str,
     cond_2: str,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     n_subjects = len(cfg.subjects)
     in_files.pop("epochs")  # not used but okay to include
 
@@ -640,7 +640,7 @@ def get_input_files_average_full_epochs_report(
     subject: str,
     session: str | None,
     decoding_contrasts: list[list[str]],
-) -> dict:
+) -> InFilesT:
     in_files = dict()
     for contrast in decoding_contrasts:
         in_files[f"decoding-full-epochs-{contrast}"] = _decoding_out_fname(
@@ -664,8 +664,8 @@ def average_full_epochs_report(
     subject: str,
     session: str | None,
     decoding_contrasts: list[list[str]],
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     """Add decoding results to the grand average report."""
     out_files = dict()
     out_files["cluster"] = _decoding_out_fname(
@@ -740,8 +740,8 @@ def average_csp_decoding(
     session: str | None,
     cond_1: str,
     cond_2: str,
-    in_files: dict,
-) -> dict[str, BIDSPath]:
+    in_files: InFilesT,
+) -> OutFilesT:
     msg = f"Summarizing CSP results: {cond_1} - {cond_2}."
     logger.info(**gen_log_kwargs(message=msg))
     in_files.pop("epochs")

--- a/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
+++ b/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
@@ -21,6 +21,7 @@ from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._report import _open_report, _render_bem
 from mne_bids_pipeline._run import _prep_out_files, failsafe_run, save_logs
+from mne_bids_pipeline.typing import InFilesPathT, OutFilesT
 
 
 def _get_bem_params(cfg: SimpleNamespace) -> tuple[str, Path, Path]:
@@ -42,8 +43,8 @@ def get_input_fnames_make_bem_surfaces(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict[str, Path]:
-    in_files: dict[str, Path] = dict()
+) -> InFilesPathT:
+    in_files = dict()
     mri_images, mri_dir, flash_dir = _get_bem_params(cfg)
     in_files["t1"] = mri_dir / "T1.mgz"
     if mri_images == "FLASH":
@@ -59,7 +60,7 @@ def get_output_fnames_make_bem_surfaces(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesPathT:
     out_files = dict()
     conductivity, _ = _get_bem_conductivity(cfg)
     assert conductivity is not None
@@ -80,8 +81,8 @@ def make_bem_surfaces(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesPathT,
+) -> OutFilesT:
     mri_images, _, _ = _get_bem_params(cfg)
     in_files.clear()  # assume we use everything we add
     if mri_images == "FLASH":

--- a/mne_bids_pipeline/steps/source/_02_make_bem_solution.py
+++ b/mne_bids_pipeline/steps/source/_02_make_bem_solution.py
@@ -18,6 +18,7 @@ from mne_bids_pipeline._config_utils import (
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._run import _prep_out_files, failsafe_run, save_logs
+from mne_bids_pipeline.typing import InFilesPathT, OutFilesT
 
 
 def get_input_fnames_make_bem_solution(
@@ -25,7 +26,7 @@ def get_input_fnames_make_bem_solution(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None = None,
-) -> dict:
+) -> InFilesPathT:
     in_files = dict()
     conductivity, _ = _get_bem_conductivity(cfg)
     assert conductivity is not None
@@ -41,7 +42,7 @@ def get_output_fnames_make_bem_solution(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None = None,
-) -> dict:
+) -> InFilesPathT:
     out_files = dict()
     bem_dir = Path(cfg.fs_subjects_dir) / cfg.fs_subject / "bem"
     _, tag = _get_bem_conductivity(cfg)
@@ -59,9 +60,9 @@ def make_bem_solution(
     cfg: SimpleNamespace,
     exec_params: SimpleNamespace,
     subject: str,
-    in_files: dict,
+    in_files: InFilesPathT,
     session: str | None = None,
-) -> dict:
+) -> OutFilesT:
     msg = "Calculating BEM solution"
     logger.info(**gen_log_kwargs(message=msg, subject=subject, session=session))
     conductivity, _ = _get_bem_conductivity(cfg)

--- a/mne_bids_pipeline/steps/source/_03_setup_source_space.py
+++ b/mne_bids_pipeline/steps/source/_03_setup_source_space.py
@@ -3,7 +3,6 @@
 Set up source space for forward and inverse computation.
 """
 
-from pathlib import Path
 from types import SimpleNamespace
 
 import mne
@@ -17,11 +16,12 @@ from mne_bids_pipeline._config_utils import (
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._run import _prep_out_files, failsafe_run, save_logs
+from mne_bids_pipeline.typing import InFilesPathT, OutFilesT
 
 
 def get_input_fnames_setup_source_space(
     *, cfg: SimpleNamespace, subject: str
-) -> dict[str, Path]:
+) -> InFilesPathT:
     in_files = dict()
     surf_path = cfg.fs_subjects_dir / cfg.fs_subject / "surf"
     for hemi in ("lh", "rh"):
@@ -32,7 +32,7 @@ def get_input_fnames_setup_source_space(
 
 def get_output_fnames_setup_source_space(
     *, cfg: SimpleNamespace, subject: str
-) -> dict[str, Path]:
+) -> InFilesPathT:
     out_files = dict()
     out_files["src"] = (
         cfg.fs_subjects_dir
@@ -52,8 +52,8 @@ def run_setup_source_space(
     cfg: SimpleNamespace,
     exec_params: SimpleNamespace,
     subject: str,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesPathT,
+) -> OutFilesT:
     msg = f"Creating source space with spacing {repr(cfg.spacing)}"
     logger.info(**gen_log_kwargs(message=msg, subject=subject))
     src = mne.setup_source_space(

--- a/mne_bids_pipeline/steps/source/_04_make_forward.py
+++ b/mne_bids_pipeline/steps/source/_04_make_forward.py
@@ -28,6 +28,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def _prepare_trans_template(
@@ -98,7 +99,7 @@ def _prepare_trans_subject(
 
 def get_input_fnames_forward(
     *, cfg: SimpleNamespace, subject: str, session: str | None
-) -> dict[str, BIDSPath]:
+) -> InFilesT:
     bids_path = BIDSPath(
         subject=subject,
         session=session,
@@ -141,8 +142,8 @@ def run_forward(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     # Do not use processing=cfg.proc here because the forward could actually be
     # influenced by previous steps (e.g., Maxwell filtering), so just make sure we
     # use cfg.proc when figuring out the head<->MRI transform

--- a/mne_bids_pipeline/steps/source/_05_make_inverse.py
+++ b/mne_bids_pipeline/steps/source/_05_make_inverse.py
@@ -30,6 +30,7 @@ from mne_bids_pipeline._run import (
     failsafe_run,
     save_logs,
 )
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def get_input_fnames_inverse(
@@ -37,7 +38,7 @@ def get_input_fnames_inverse(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict[str, BIDSPath]:
+) -> InFilesT:
     bids_path = BIDSPath(
         subject=subject,
         session=session,
@@ -84,8 +85,8 @@ def run_inverse(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     # TODO: Eventually we should maybe loop over ch_types, e.g., to create
     # MEG, EEG, and MEG+EEG inverses and STCs
     msg = "Computing inverse solutions"

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -22,6 +22,7 @@ from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._report import _all_conditions, _open_report
 from mne_bids_pipeline._run import _prep_out_files, failsafe_run, save_logs
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
 def _stc_path(
@@ -60,7 +61,7 @@ def get_input_fnames_morph_stc(
     subject: str,
     fs_subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     in_files = dict()
     for condition in _all_conditions(cfg=cfg):
         in_files[f"original-{condition}"] = _stc_path(
@@ -83,8 +84,8 @@ def morph_stc(
     subject: str,
     fs_subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict:
+    in_files: InFilesT,
+) -> OutFilesT:
     out_files = dict()
     for condition in _all_conditions(cfg=cfg):
         fname_stc = in_files.pop(f"original-{condition}")
@@ -115,7 +116,7 @@ def get_input_fnames_run_average(
     cfg: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> dict:
+) -> InFilesT:
     in_files = dict()
     assert subject == "average"
     for condition in _all_conditions(cfg=cfg):
@@ -139,8 +140,8 @@ def run_average(
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-    in_files: dict,
-) -> dict[str, BIDSPath]:
+    in_files: InFilesT,
+) -> OutFilesT:
     assert subject == "average"
     out_files = dict()
     conditions = _all_conditions(cfg=cfg)

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -162,7 +162,7 @@ def test_run(
     monkeypatch: pytest.MonkeyPatch,
     dataset_test: Any,
     tmp_path: Path,
-    capsys: pytest.CaptureFixture,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Test running a dataset."""
     test_options = TEST_SUITE[dataset]
@@ -217,7 +217,7 @@ def test_run(
 def test_missing_sessions(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    capsys: pytest.CaptureFixture,
+    capsys: pytest.CaptureFixture[str],
     allow_missing_sessions: bool,
 ) -> None:
     """Test the `allow_missing_sessions` config variable."""

--- a/mne_bids_pipeline/tests/test_validation.py
+++ b/mne_bids_pipeline/tests/test_validation.py
@@ -7,7 +7,7 @@ import pytest
 from mne_bids_pipeline._config_import import _import_config
 
 
-def test_validation(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+def test_validation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """Test that misspellings are caught by our config import validator."""
     config_path = tmp_path / "config.py"
     bad_text = ""

--- a/mne_bids_pipeline/typing.py
+++ b/mne_bids_pipeline/typing.py
@@ -11,6 +11,7 @@ else:
 
 import mne
 import numpy as np
+from mne_bids import BIDSPath
 from numpy.typing import ArrayLike
 from pydantic import PlainValidator
 
@@ -32,6 +33,9 @@ __all__ = [
 
 FloatArrayT: TypeAlias = np.ndarray[Any, np.dtype[np.float64]]
 OutFilesT = dict[str, tuple[str, str | float]]
+InFilesT = dict[str, BIDSPath]  # Only BIDSPath
+InFilesPathT = dict[str, BIDSPath | pathlib.Path]  # allow generic Path as well
+AutoScoresT = dict[str, np.ndarray]
 
 
 class ArbitraryContrast(TypedDict):

--- a/mne_bids_pipeline/typing.py
+++ b/mne_bids_pipeline/typing.py
@@ -31,11 +31,12 @@ __all__ = [
 ]
 
 
-FloatArrayT: TypeAlias = np.ndarray[Any, np.dtype[np.float64]]
-OutFilesT = dict[str, tuple[str, str | float]]
-InFilesT = dict[str, BIDSPath]  # Only BIDSPath
-InFilesPathT = dict[str, BIDSPath | pathlib.Path]  # allow generic Path as well
-AutoScoresT = dict[str, np.ndarray]
+ShapeT: TypeAlias = tuple[int, ...] | tuple[int]
+IntArrayT: TypeAlias = np.ndarray[ShapeT, np.dtype[np.integer[Any]]]
+FloatArrayT: TypeAlias = np.ndarray[ShapeT, np.dtype[np.floating[Any]]]
+OutFilesT: TypeAlias = dict[str, tuple[str, str | float]]
+InFilesT: TypeAlias = dict[str, BIDSPath]  # Only BIDSPath
+InFilesPathT: TypeAlias = dict[str, BIDSPath | pathlib.Path]  # allow generic Path too
 
 
 class ArbitraryContrast(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,11 @@ convention = "numpy"
 [tool.mypy]
 ignore_errors = false
 scripts_are_modules = true
+disable_error_code = [
+  # For libraries like matplotlib that we don't have types for
+  "import-not-found",
+  "import-untyped",
+]
 strict = true
 modules = ["mne_bids_pipeline", "docs.source"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ convention = "numpy"
 ignore_errors = false
 scripts_are_modules = true
 strict = true
-ignore_missing_imports = true
 modules = ["mne_bids_pipeline", "docs.source"]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,20 +137,14 @@ ignore_missing_imports = true
 modules = ["mne_bids_pipeline", "docs.source"]
 
 [[tool.mypy.overrides]]
-module = ["mne_bids_pipeline.steps.*"]
-disable_error_code = [
-  "type-arg",  # TODO: Fix ~100 Missing type parameters for generic type
-]
+module = ["mne_bids_pipeline.steps.freesurfer.contrib.*"]
+ignore_errors = true  # not our code, don't validate
 
 [[tool.mypy.overrides]]
 module = ["mne_bids_pipeline.tests.*"]
 disable_error_code = [
   "misc",  # Untyped decorator makes function "test_all_functions_return" untyped
 ]
-
-[[tool.mypy.overrides]]
-module = ["mne_bids_pipeline.steps.freesurfer.contrib.*"]
-ignore_errors = true  # not our code, don't validate
 
 [[tool.mypy.overrides]]
 module = ['mne_bids_pipeline.tests.configs.*']


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/vX.Y.md.inc`)

Final parts of `mypy` checking. Some stuff is still disabled like:

- full checking of `tests/configs/*` -- I don't think we want to add a bunch of type annotations to these as they're meant to be more human / user-readable
- any checking of `contrib/*`

So I think this is the last set of changes needed for full mypy checking. Note that I created an `InFilesT` which is `dict[str, BIDSPath]` and a `InFilesPathT = dict[str, BIDSPath | Path]`. The latter is used much less often, and typically just with FreeSurfer-facing steps. Not 100% sure I got which-is-which correct in all cases, but probably good enough for now.

I also `git mv docs/source/v1.10.md.inc docs/source/dev.md.inc` because I always have to `tab-tab` to find the correct version number when I need to change this doc. This adds burden to every PR where I have to read the list, figure out which (next) release version we're on, and change the correct doc. With the proposed change, this per-PR burden is gone: you always change `dev.md.inc`. The burden is changed to a one-time-per-release cost instead (as a `git mv` will have to be performed there). Now our PR template can actually point to a specific file to change rather than `vX.Y.md.inc`.