### PR TITLE
Add the code from PR "Add support for MNE-ICALabel #812"

### DIFF
--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1415,7 +1415,7 @@ EEG data.
     ```
 """
 
-icalabel_include: Annotated[Sequence[Literal["brain", "muscle artifact", "eye blink", "heart beat", "line noise", "channel noise", "other"]], Len(1, 7)] = [] # TODO: Find out how to use ["brain", "other"] as default
+icalabel_include: Annotated[Sequence[Literal["brain", "muscle artifact", "eye blink", "heart beat", "line noise", "channel noise", "other"]], Len(1, 7)] = ["brain","other"]
 """
 Which independent components (ICs) to keep based on the labels given by ICLabel.
 Possible labels are "brain", "muscle artifact", "eye blink", "heart beat", "line noise", "channel noise", "other".

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1376,10 +1376,20 @@ it is to run but the less data you have to compute a good ICA. Set to
 `1` or `None` to not perform any decimation.
 """
 
+ica_use_ecg_detection: bool = True
+"""
+Whether to use the MNE ECG detection on the ICA components.
+"""
+
 ica_ecg_threshold: float = 0.1
 """
 The cross-trial phase statistics (CTPS) threshold parameter used for detecting
 ECG-related ICs.
+"""
+
+ica_use_eog_detection: bool = True
+"""
+Whether to use the MNE EOG detection on the ICA components.
 """
 
 ica_eog_threshold: float = 3.0
@@ -1387,6 +1397,28 @@ ica_eog_threshold: float = 3.0
 The threshold to use during automated EOG classification. Lower values mean
 that more ICs will be identified as EOG-related. If too low, the
 false-alarm rate increases dramatically.
+"""
+
+
+
+# From: https://github.com/mne-tools/mne-bids-pipeline/pull/812
+ica_use_icalabel: bool = False
+"""
+Whether to use MNE-ICALabel to automatically label ICA components. Only available for
+EEG data.
+!!! info
+    Using MNE-ICALabel mandates that you also set:
+    ```python
+    eeg_reference = "average"
+    ica_l_freq = 1
+    h_freq = 100
+    ```
+"""
+
+icalabel_include: Annotated[Sequence[Literal["brain", "muscle artifact", "eye blink", "heart beat", "line noise", "channel noise", "other"]], Len(1, 7)] = [] # TODO: Find out how to use ["brain", "other"] as default
+"""
+Which independent components (ICs) to keep based on the labels given by ICLabel.
+Possible labels are "brain", "muscle artifact", "eye blink", "heart beat", "line noise", "channel noise", "other".
 """
 
 # ### Amplitude-based artifact rejection

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -341,6 +341,20 @@ def _check_config(config: SimpleNamespace, config_path: PathLike | None) -> None
                 f"but got shape {destination.shape}"
             )
 
+# From: https://github.com/mne-tools/mne-bids-pipeline/pull/812
+    # MNE-ICALabel
+    if config.ica_use_icalabel:
+        if config.ica_l_freq != 1.0 or config.h_freq != 100.0:
+            raise ValueError(
+                f"When using MNE-ICALabel, you must set ica_l_freq=1 and h_freq=100, "
+                f"but got: ica_l_freq={config.ica_l_freq} and h_freq={config.h_freq}"
+            )
+
+        if config.eeg_reference != "average":
+            raise ValueError(
+                f'When using MNE-ICALabel, you must set eeg_reference="average", but '
+                f"got: eeg_reference={config.eeg_reference}"
+            )
 
 def _default_factory(key: str, val: Any) -> Any:
     # convert a default to a default factory if needed, having an explicit
@@ -350,6 +364,7 @@ def _default_factory(key: str, val: Any) -> Any:
         {"custom": (8, 24.0, 40)},  # decoding_csp_freqs
         ["evoked"],  # inverse_targets
         [4, 8, 16],  # autoreject_n_interpolate
+        #["brain", "muscle artifact", "eye blink", "heart beat", "line noise", "channel noise", "other"], # icalabel_include
     ]
 
     def default_factory() -> Any:

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -365,6 +365,7 @@ def _default_factory(key: str, val: Any) -> Any:
         ["evoked"],  # inverse_targets
         [4, 8, 16],  # autoreject_n_interpolate
         #["brain", "muscle artifact", "eye blink", "heart beat", "line noise", "channel noise", "other"], # icalabel_include
+        ["brain","other"]
     ]
 
     def default_factory() -> Any:

--- a/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
@@ -14,9 +14,11 @@ import mne
 import numpy as np
 import pandas as pd
 from mne.preprocessing import create_ecg_epochs, create_eog_epochs
+from mne.viz import plot_ica_components
 from mne_bids import BIDSPath
 from mne_icalabel import label_components
 import mne_icalabel
+import matplotlib.pyplot as plt
 
 from mne_bids_pipeline._config_utils import (
     _bids_kwargs,
@@ -375,6 +377,22 @@ def find_ica_artifacts(
             n_jobs=1,  # avoid automatic parallelization
             tags=("ica",),  # the default but be explicit
         )
+
+        # Add a plot for each excluded IC together with the given label and the probability
+        # TODO: Improve this plot e.g. combine all figures in one plot
+        for ic, label, prob in zip(icalabel_ics, icalabel_labels, icalabel_prob):
+            excluded_IC_figure = plot_ica_components(
+                ica=ica,
+                picks=ic,
+            )
+            excluded_IC_figure.axes[0].text(0, -0.15, f"Label: {label} \n Probability: {prob:.3f}", ha="center", fontsize=8, bbox={"facecolor":"orange", "alpha":0.5, "pad":5})
+
+            report.add_figure(
+                fig=excluded_IC_figure,
+                title = f'ICA{ic:03}',
+                replace=True,
+            )
+            plt.close(excluded_IC_figure)
 
     msg = 'Carefully review the extracted ICs and mark components "bad" in:'
     logger.info(**gen_log_kwargs(message=msg, emoji="🛑"))

--- a/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
+++ b/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
@@ -75,11 +75,15 @@ if task == "N400":  # test autoreject local without ICA
     spatial_filter = None
     reject = "autoreject_local"
     autoreject_n_interpolate = [2, 4]
-elif task == "N170":  # test autoreject local before ICA
+elif task == "N170":  # test autoreject local before ICA, and MNE-ICALabel
     spatial_filter = "ica"
+    ica_algorithm = "picard-extended_infomax"
+    ica_use_icalabel = True
+    ica_l_freq = 1
+    h_freq = 100
     ica_reject = "autoreject_local"
     reject = "autoreject_global"
-    autoreject_n_interpolate = [2, 4]
+    autoreject_n_interpolate = [12] # only for testing!
 else:
     spatial_filter = "ica"
     ica_reject = dict(eeg=350e-6, eog=500e-6)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
   "autoreject",
   "mne[hdf5] >=1.7",
   "mne-bids[full]",
+  "mne-icalabel",
+  "onnxruntime",  # for mne-icalabel
   "filelock",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
### Changes
- Added the code from [this PR](https://github.com/mne-tools/mne-bids-pipeline/pull/812) by @hoechenberger 
  - Comment:  In the newer version of mne-bids-pipeline the ICA is divided into two scripts, therefore I had to divide the code into these scripts.
 - @behinger added two config variables `ica_use_ecg_detection` and `ica_use_eog_detection` to control whether MNE eog/ecg detection should be used on the ICs
 - We implemented that the user can specify in the config file (using the variable `icalabel_include`) which labels/ICs to include. Default is `["brain","other"]`. 
   - Comment: We should add tests for this e.g. No value given -> Default should be used, Empty list or wrong labels -> Error
 - Added plots of the excluded ICs to the report together with their labels and the probability of the labels. 
   - Comment: The plotting needs improvement e.g. combine all single plots in one plot

### Before merging …

- [ ] Changelog has been updated (`docs/source/dev.md.inc`)
