### PR TITLE
fix ignoring sessions that have no data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           command: |
             pip install --upgrade --progress-bar off pip
             # TODO: Restore https://api.github.com/repos/mne-tools/mne-bids/zipball/main pending https://github.com/mne-tools/mne-bids/pull/1349/files#r1885104885
-            pip install --upgrade --progress-bar off "autoreject @ https://api.github.com/repos/autoreject/autoreject/zipball/master" "mne[hdf5] @ git+https://github.com/mne-tools/mne-python@main" "mne-bids[full]" numba
+            pip install --upgrade --progress-bar off "autoreject @ https://api.github.com/repos/autoreject/autoreject/zipball/master" "mne[hdf5] @ git+https://github.com/mne-tools/mne-python@main" "mne-bids[full] @ git+https://github.com/mne-tools/mne-bids@main" numba
             pip install -ve .[tests]
             pip install "PyQt6!=6.6.1" "PyQt6-Qt6!=6.6.1,!=6.6.2,!=6.6.3,!=6.7.0"
       - run:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         python-version: "3.12"
     - run: pip install --upgrade pip
-    - run: pip install -ve .[tests] codespell tomli --only-binary="numpy,scipy,pandas,matplotlib,pyarrow,numexpr"
+    - run: pip install -ve .[tests] "mne-bids[full] @ git+https://github.com/mne-tools/mne-bids@main" codespell tomli --only-binary="numpy,scipy,pandas,matplotlib,pyarrow,numexpr"
     - run: make codespell-error
     - run: pytest mne_bids_pipeline -m "not dataset_test"
     - uses: codecov/codecov-action@v5

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -6,12 +6,14 @@ import os
 import pathlib
 from dataclasses import field
 from functools import partial
+from inspect import signature
 from types import SimpleNamespace
 from typing import Any
 
 import matplotlib
 import mne
 import numpy as np
+from mne_bids import get_entity_vals
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from ._logging import gen_log_kwargs, logger
@@ -322,6 +324,16 @@ def _check_config(config: SimpleNamespace, config_path: PathLike | None) -> None
             'recordings by setting noise_cov = "emptyroom", but you did not '
             "enable empty-room data processing. "
             "Please set process_empty_room = True"
+        )
+
+    if (
+        config.allow_missing_sessions
+        and "ignore_suffixes" not in signature(get_entity_vals).parameters
+    ):
+        raise ConfigError(
+            "You've requested to `allow_missing_sessions`, but this functionality "
+            "requires a newer version of `mne_bids` than you have available. Please "
+            "update MNE-BIDS (or if on the latest version, install the dev version)."
         )
 
     bl = config.baseline

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -146,7 +146,7 @@ def get_subjects_sessions(config: SimpleNamespace) -> dict[str, list[str]]:
     subj_sessions: dict[str, list[str]] = dict()
     cfg_sessions = _get_sessions(config)
     # find which tasks to ignore when deciding if a subj has data for a session
-    if config.task is None:
+    if config.task == "":
         ignore_tasks = None
     else:
         all_tasks = _get_entity_vals_cached(

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -4,6 +4,7 @@ import copy
 import functools
 import pathlib
 from collections.abc import Iterable, Sized
+from inspect import signature
 from types import ModuleType, SimpleNamespace
 from typing import Any, Literal, TypeVar
 
@@ -165,14 +166,19 @@ def get_subjects_sessions(
 
     # loop over subjs and check for available sessions
     subj_sessions: dict[str, tuple[None] | tuple[str, ...]] = dict()
+    kwargs = (
+        dict(ignore_suffixes=("scans", "coordsystem"))
+        if "ignore_suffixes" in signature(mne_bids.get_entity_vals).parameters
+        else dict()
+    )
     for subject in subjects:
         valid_sessions_subj = _get_entity_vals_cached(
             config.bids_root / f"sub-{subject}",
             entity_key="session",
             ignore_tasks=ignore_tasks,
             ignore_acquisitions=("calibration", "crosstalk"),
-            ignore_suffixes=("scans", "coordsystem"),
             ignore_datatypes=ignore_datatypes,
+            **kwargs,
         )
         missing_sessions = sorted(set(cfg_sessions) - set(valid_sessions_subj))
         if missing_sessions and not config.allow_missing_sessions:

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -258,7 +258,7 @@ allow_missing_sessions = {allow_missing_sessions}
     context = (
         nullcontext()
         if allow_missing_sessions
-        else pytest.raises(RuntimeError, match=r"Subject 1 is missing session \('b',\)")
+        else pytest.raises(RuntimeError, match=r"Subject 1 is missing session \['b'\]")
     )
     # run
     command = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "openpyxl",
   "autoreject",
   "mne[hdf5] >=1.7",
-  "mne-bids[full] @ git+https://github.com/mne-tools/mne-bids@41ce36a4dc938e85a2f6a32ed3eeb88c732bfbae",
+  "mne-bids[full]",
   "filelock",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,9 @@ exclude = [
   "ignore_words.txt",
 ]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.codespell]
 skip = "docs/site/*,*.html,steps/freesurfer/contrib/*"
 ignore-words = "ignore_words.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,6 @@ exclude = [
   "ignore_words.txt",
 ]
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
 [tool.codespell]
 skip = "docs/site/*,*.html,steps/freesurfer/contrib/*"
 ignore-words = "ignore_words.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "openpyxl",
   "autoreject",
   "mne[hdf5] >=1.7",
-  "mne-bids[full]",
+  "mne-bids[full] @ git+https://github.com/mne-tools/mne-bids@41ce36a4dc938e85a2f6a32ed3eeb88c732bfbae",
   "filelock",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
The addition of `allow_missing_sessions` in #1000 had some problems:

1. it was storing `[None]` in the `subjs_sessions` dict in cases where a subject had no valid sessions; this was not behaving as expected
2. the use of `mne_bids.get_entity_vals` was not working as expected, because even if a subject had no *data* for a session for a given task, the presence of `coordsystem.json` or `scans.tsv` sidecars was causing it to report that the subject had *some files* for that session.

Item (2) was fixed in https://github.com/mne-tools/mne-bids/pull/1362; item (1) is fixed here. Works on my data, but will self-review to add some questions about implementation/testing.


### Before merging …

- [ ] Changelog has been updated (`docs/source/dev.md.inc`)
