### PR TITLE
Improve (and test) support for session-specific MRIs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -ve .[tests] --only-binary="numpy,scipy,pandas,matplotlib,pyarrow,numexpr"
+      - run: pip install -ve .[tests] pyvistaqt --only-binary="numpy,scipy,pandas,matplotlib,pyarrow,numexpr"
       - uses: actions/cache@v4
         with:
           key: MNE-funloc-data

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -ve .[tests] pyvistaqt --only-binary="numpy,scipy,pandas,matplotlib,pyarrow,numexpr"
+      - run: pip install -ve .[tests] pyvistaqt PySide6 --only-binary="numpy,scipy,pandas,matplotlib,pyarrow,numexpr,PySide6"
       - uses: actions/cache@v4
         with:
           key: MNE-funloc-data

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -77,3 +77,30 @@ jobs:
         timeout-minutes: 1
       - uses: codecov/codecov-action@v5
         if: success() || failure()
+  non-doc-dataset-tests:
+    name: 'Non-doc dataset tests'
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -e {0}
+    strategy:
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pyvista/setup-headless-display-action@main
+        with:
+          qt: true
+          pyvista: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -ve .[tests] --only-binary="numpy,scipy,pandas,matplotlib,pyarrow,numexpr"
+      - uses: actions/cache@v4
+        with:
+          key: MNE-funloc-data
+          path: ~/mne_data/MNE-funloc-data
+        id: MNE-funloc-data-cache
+      - run: python -m mne_bids_pipeline._download MNE-funloc-data
+        if: steps.MNE-funloc-data-cache.outputs.cache-hit != 'true'
+      - run: pytest --cov-append -k test_session_specific_mri mne_bids_pipeline/

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: pyvista/setup-headless-display-action@main
         with:
           qt: true
-          pyvista: false
+          pyvista: true
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: pyvista/setup-headless-display-action@main
         with:
           qt: true
-          pyvista: true
+          pyvista: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -136,8 +136,6 @@ plugins:
     - search
     - macros
     - privacy # https://squidfunk.github.io/mkdocs-material/plugins/privacy/
-    - tags:
-        tags_file: tags.md
     - include-markdown
     - exclude:
         glob:

--- a/docs/source/dev.md.inc
+++ b/docs/source/dev.md.inc
@@ -39,3 +39,4 @@
 - Improve logging messages in maxwell filtering steps. (#893 by @drammock)
 - Validate extra config params passed in during testing. (#1044 by @drammock)
 - New testing/example dataset "funloc" added. (#1045 by @drammock)
+- Better testing of session-specific MRIs. (#1039 by @drammock)

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -64,7 +64,9 @@ def _import_config(
             config=config, config_path=extra_config, include_private=True
         )
         # Update valid_extra_names as needed if test configs in tests/test_run.py change
-        valid_extra_names = set(("_n_jobs", "_raw_split_size", "_epochs_split_size"))
+        valid_extra_names = set(
+            ("_n_jobs", "_raw_split_size", "_epochs_split_size", "subjects_dir")
+        )
         assert set(extra_names) - valid_extra_names == set(), extra_names
         extra_exec_params_keys = tuple(set(["_n_jobs"]) & set(extra_names))
     keep_names.extend(extra_exec_params_keys)

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -65,7 +65,13 @@ def _import_config(
         )
         # Update valid_extra_names as needed if test configs in tests/test_run.py change
         valid_extra_names = set(
-            ("_n_jobs", "_raw_split_size", "_epochs_split_size", "subjects_dir")
+            (
+                "_n_jobs",
+                "_raw_split_size",
+                "_epochs_split_size",
+                "subjects_dir",  # test_session_specific_mri
+                "deriv_root",  # test_session_specific_mri
+            )
         )
         assert set(extra_names) - valid_extra_names == set(), extra_names
         extra_exec_params_keys = tuple(set(["_n_jobs"]) & set(extra_names))

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -71,6 +71,7 @@ def _import_config(
                 "_epochs_split_size",
                 "subjects_dir",  # test_session_specific_mri
                 "deriv_root",  # test_session_specific_mri
+                "Path",  # test_session_specific_mri
             )
         )
         assert set(extra_names) - valid_extra_names == set(), extra_names

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -55,6 +55,12 @@ def get_fs_subject(
         return f"sub-{subject}"
 
 
+def _has_session_specific_anat(
+    subject: str, session: str | None, subjects_dir: pathlib.Path
+) -> bool:
+    return (subjects_dir / f"sub-{subject}_ses-{session}").exists()
+
+
 @functools.cache
 def _get_entity_vals_cached(
     *args: list[Any],

--- a/mne_bids_pipeline/steps/freesurfer/_01_recon_all.py
+++ b/mne_bids_pipeline/steps/freesurfer/_01_recon_all.py
@@ -14,6 +14,7 @@ from typing import Any
 from mne.utils import run_subprocess
 
 from mne_bids_pipeline._config_utils import (
+    _has_session_specific_anat,
     get_fs_subjects_dir,
     get_sessions,
     get_subjects,
@@ -76,12 +77,6 @@ def run_recon(
         cmd += [f"--session_label={session}"]
     logger.debug("Running: " + " ".join(cmd))
     run_subprocess(cmd, env=env, verbose=logger.level)
-
-
-def _has_session_specific_anat(
-    subject: str, session: str | None, subjects_dir: Path
-) -> bool:
-    return (subjects_dir / f"sub-{subject}_ses-{session}").exists()
 
 
 def main(*, config: SimpleNamespace) -> None:

--- a/mne_bids_pipeline/tests/datasets.py
+++ b/mne_bids_pipeline/tests/datasets.py
@@ -16,6 +16,7 @@ class DATASET_OPTIONS_T(TypedDict, total=False):
     exclude: list[str]  # []
     hash: str  # ""
     processor: str  # ""
+    processor: str  # ""
 
 
 DATASET_OPTIONS: dict[str, DATASET_OPTIONS_T] = {

--- a/mne_bids_pipeline/tests/datasets.py
+++ b/mne_bids_pipeline/tests/datasets.py
@@ -16,7 +16,6 @@ class DATASET_OPTIONS_T(TypedDict, total=False):
     exclude: list[str]  # []
     hash: str  # ""
     processor: str  # ""
-    processor: str  # ""
 
 
 DATASET_OPTIONS: dict[str, DATASET_OPTIONS_T] = {

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -363,7 +363,6 @@ def test_session_specific_mri(
                     dst_file = dst_file.replace(subj, freesurfer_subject_mapping[subj])
                     break
             shutil.copyfile(src=walk_root / _file, dst=dst_dir / offset / dst_file)
-    # print_dir_tree(new_bids_path.root)  # for debugging
     # update config so that `subjects_dir` and `deriv_root` also point to the tempdir
     extra_config = f"""
 from pathlib import Path
@@ -408,6 +407,6 @@ deriv_root = Path("{new_bids_path.root}") / "derivatives" / "mne-bids-pipeline" 
         )
         result = pattern.search(coregs["html"])
         assert result is not None
-        assert float(result.group("dist")) < 3
+        assert float(result.group("dist")) < 3  # fit between pts and outer_skin < 3 mm
         results.append(result.groups())
     assert results[0] != results[1]  # different npts and/or different mean distance

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -358,8 +358,9 @@ def test_session_specific_mri(
     # print_dir_tree(new_bids_path.root)  # for debugging
     # update config so that `subjects_dir` and `deriv_root` also point to the tempdir
     extra_config = f"""
+from pathlib import Path
 subjects_dir = "{new_bids_path.root / "derivatives" / "freesurfer" / "subjects"}"
-deriv_root = "{new_bids_path.root / "derivatives" / "mne-bids-pipeline" / "MNE-funloc-data"}"
+deriv_root = Path("{new_bids_path.root}") / "derivatives" / "mne-bids-pipeline" / "MNE-funloc-data"
 """  # noqa E501
     extra_path = tmp_path / "extra_config.py"
     extra_path.write_text(extra_config)

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -356,10 +356,11 @@ def test_session_specific_mri(
                 dst_file = dst_file.replace(fs_sub, freesurfer_subject_mapping[fs_sub])
             shutil.copyfile(src=walk_root / _file, dst=dst_dir / offset / dst_file)
     # print_dir_tree(new_bids_path.root)  # for debugging
-    # update config so that `subjects_dir` also points to the tempdir
+    # update config so that `subjects_dir` and `deriv_root` also point to the tempdir
     extra_config = f"""
 subjects_dir = "{new_bids_path.root / "derivatives" / "freesurfer" / "subjects"}"
-"""
+deriv_root = "{new_bids_path.root / "derivatives" / "mne-bids-pipeline" / "MNE-funloc-data"}"
+"""  # noqa E501
     extra_path = tmp_path / "extra_config.py"
     extra_path.write_text(extra_config)
     monkeypatch.setenv("_MNE_BIDS_STUDY_TESTING_EXTRA_CONFIG", str(extra_path))

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -293,7 +293,7 @@ def test_session_specific_mri(
     config = test_options.get("config", f"config_{dataset}.py")
     config_path = BIDS_PIPELINE_DIR / "tests" / "configs" / config
     config_obj = _import_config(config_path=config_path)
-    # copy the dataset to a tmpdir, and in the destination location (a tmpdir) make it
+    # copy the dataset to a tmpdir, and in the destination location make it
     # seem like there's only one subj with different MRIs for different sessions
     new_bids_path = BIDSPath(root=tmp_path / dataset, subject="01", session="a")
     # sub-01/* → sub-01/ses-a/* ;  sub-02/* → sub-01/ses-b/*
@@ -333,7 +333,7 @@ def test_session_specific_mri(
         # in theory we should rewrite `participants.tsv` to remove the `sub-02` line,
         # but in practice it will just get ignored so we won't bother.
         shutil.copyfile(src=_file, dst=dst_dir / _file.name)
-    # now move derivatives (freesurfer files)
+    # derivatives (freesurfer files)
     src_dir = config_obj.bids_root / "derivatives" / "freesurfer" / "subjects"
     dst_dir = new_bids_path.root / "derivatives" / "freesurfer" / "subjects"
     dst_dir.mkdir(parents=True)

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -347,13 +347,14 @@ def test_session_specific_mri(
         for _dir in dirs:
             _dir = freesurfer_subject_mapping.get(_dir, _dir)
             (dst_dir / offset / _dir).mkdir()
-        # for filenames that contain the subject identifier (e.g. BEM files), we need to
-        # change the filename too, not just parent folder name
+        # for filenames that contain the subject identifier (BEM files, morph maps),
+        # we need to change the filename too, not just parent folder name
         for _file in files:
             dst_file = _file
-            fs_sub = dst_file[:5]
-            if fs_sub in freesurfer_subject_mapping:
-                dst_file = dst_file.replace(fs_sub, freesurfer_subject_mapping[fs_sub])
+            for subj in freesurfer_subject_mapping:
+                if subj in dst_file:
+                    dst_file = dst_file.replace(subj, freesurfer_subject_mapping[subj])
+                    break
             shutil.copyfile(src=walk_root / _file, dst=dst_dir / offset / dst_file)
     # print_dir_tree(new_bids_path.root)  # for debugging
     # update config so that `subjects_dir` and `deriv_root` also point to the tempdir

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -300,18 +300,18 @@ def test_session_specific_mri(
     for src_subj, dst_sess in (("01", "a"), ("02", "b")):
         src_dir = config_obj.bids_root / f"sub-{src_subj}"
         dst_dir = new_bids_path.root / "sub-01" / f"ses-{dst_sess}"
-        for root, dirs, files in src_dir.walk():
-            offset = root.relative_to(src_dir)
+        for walk_root, dirs, files in src_dir.walk():
+            offset = walk_root.relative_to(src_dir)
             for _dir in dirs:
                 (dst_dir / offset / _dir).mkdir(parents=True)
             for _file in files:
-                bp = get_bids_path_from_fname(root / _file)
+                bp = get_bids_path_from_fname(walk_root / _file)
                 bp.update(root=new_bids_path.root, subject="01", session=dst_sess)
                 # rewrite scans.tsv files to have correct filenames in it
                 if _file.endswith("scans.tsv"):
                     lines = [
                         line.replace(f"sub-{src_subj}", f"sub-01_ses-{dst_sess}")
-                        for line in (root / _file).read_text().split("\n")
+                        for line in (walk_root / _file).read_text().split("\n")
                     ]
                     (dst_dir / offset / bp.basename).write_text("\n".join(lines))
                 # For all other files, a simple copy suffices; rewriting
@@ -319,7 +319,7 @@ def test_session_specific_mri(
                 # overwrites it with the value in `participants.tsv` anyway.
                 else:
                     shutil.copyfile(
-                        src=root / _file, dst=dst_dir / offset / bp.basename
+                        src=walk_root / _file, dst=dst_dir / offset / bp.basename
                     )
     # emptyroom
     src_dir = config_obj.bids_root / "sub-emptyroom"

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -284,6 +284,7 @@ allow_missing_sessions = {allow_missing_sessions}
             main()
 
 
+@pytest.mark.dataset_test
 def test_session_specific_mri(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -314,7 +314,9 @@ def test_session_specific_mri(
                         for line in (root / _file).read_text().split("\n")
                     ]
                     (dst_dir / offset / bp.basename).write_text("\n".join(lines))
-                # for all other files, a simple copy suffices
+                # For all other files, a simple copy suffices; rewriting
+                # `raw.info["subject_info"]["his_id"]` is not necessary because MNE-BIDS
+                # overwrites it with the value in `participants.tsv` anyway.
                 else:
                     shutil.copyfile(
                         src=root / _file, dst=dst_dir / offset / bp.basename
@@ -328,6 +330,8 @@ def test_session_specific_mri(
     dst_dir = new_bids_path.root
     files = [f for f in src_dir.iterdir() if f.is_file()]
     for _file in files:
+        # in theory we should rewrite `participants.tsv` to remove the `sub-02` line,
+        # but in practice it will just get ignored so we won't bother.
         shutil.copyfile(src=_file, dst=dst_dir / _file.name)
     # now move derivatives (freesurfer files)
     src_dir = config_obj.bids_root / "derivatives" / "freesurfer" / "subjects"

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -333,12 +333,12 @@ def test_session_specific_mri(
     src_dir = config_obj.bids_root / "derivatives" / "freesurfer" / "subjects"
     dst_dir = new_bids_path.root / "derivatives" / "freesurfer" / "subjects"
     dst_dir.mkdir(parents=True)
-    freesurfer_subject_mapping = dict(sub01="sub-01_ses-a", sub02="sub-01_ses-b")
+    freesurfer_subject_mapping = {"sub-01": "sub-01_ses-a", "sub-02": "sub-01_ses-b"}
     for walk_root, dirs, files in src_dir.walk():
         # change "root" so that in later steps of the walk when we're inside a subject's
         # dir, the "offset" (folders between dst_dir and filename) will be correct
         new_root = walk_root
-        if "sub01" in walk_root.parts or "sub02" in walk_root.parts:
+        if "sub-01" in walk_root.parts or "sub-02" in walk_root.parts:
             new_root = Path(
                 *[freesurfer_subject_mapping.get(p, p) for p in new_root.parts]
             )


### PR DESCRIPTION
~~Per conversation with @larsoner I'm splitting out the work of adding the funloc dataset (and fixing the bugs it reveals) to make the diff cleaner on #1035 (which is actually dealing with a different problem than what funloc addresses --- #1035 is about skipping missing sessions, not handling session-specific anat).~~

This PR has been rebased after #1045 was merged, so now all it does is monkeypatch the funloc dataset to test support for session-specific MRIs.

### Before merging …

- [x] Changelog has been updated (`docs/source/dev.md.inc`)
