### PR TITLE
make late pipeline steps robust to missing sessions

### DIFF
--- a/docs/source/dev.md.inc
+++ b/docs/source/dev.md.inc
@@ -47,4 +47,4 @@
 - Improve logging messages in maxwell filtering steps. (#893 by @drammock)
 - Validate extra config params passed in during testing. (#1044 by @drammock)
 - New testing/example dataset "funloc" added. (#1045 by @drammock)
-- Better testing of session-specific MRIs. (#1039 by @drammock)
+- Bugfixes and better testing of session-specific MRIs. (#1039 and #1067 by @drammock)

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -213,6 +213,7 @@ def get_subjects_given_session(
         if config.allow_missing_sessions
         else config.subjects
     )
+    assert not isinstance(subjects, str), subjects  # make sure it's not "all"
     return subjects
 
 

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -187,16 +187,15 @@ def get_subjects_sessions(
             ignore_datatypes=ignore_datatypes,
             **kwargs,
         )
+        keep_sessions: tuple[str, ...]
         # if valid_sessions_subj is empty, it might be because the dataset just doesn't
         # have `session` subfolders, or it might be that none of the sessions in config
         # are available for this subject.
         if not valid_sessions_subj:
-            if has_session_folders := any(
-                [x.name.startswith("ses") for x in subj_folder.iterdir()]
-            ):
-                keep_sessions = ()
+            if any([x.name.startswith("ses") for x in subj_folder.iterdir()]):
+                keep_sessions = ()  # has `ses-*` folders, just not the ones we want
             else:
-                keep_sessions = cfg_sessions  # AKA (None,)
+                keep_sessions = cfg_sessions  # doesn't have `ses-*` folders
         else:
             missing_sessions = sorted(set(cfg_sessions) - set(valid_sessions_subj))
             if missing_sessions and not config.allow_missing_sessions:

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -203,6 +203,19 @@ def get_subjects_sessions(
     return subj_sessions
 
 
+def get_subjects_given_session(
+    config: SimpleNamespace, session: str | None
+) -> tuple[str, ...]:
+    """Get the subjects who actually have data for a given session."""
+    sub_ses = get_subjects_sessions(config)
+    subjects = (
+        tuple(sub for sub, ses in sub_ses.items() if session in ses)
+        if config.allow_missing_sessions
+        else config.subjects
+    )
+    return subjects
+
+
 def get_runs_all_subjects(
     config: SimpleNamespace,
 ) -> dict[str, tuple[None] | tuple[str, ...]]:

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -186,13 +186,18 @@ def get_subjects_sessions(
             ignore_datatypes=ignore_datatypes,
             **kwargs,
         )
-        missing_sessions = sorted(set(cfg_sessions) - set(valid_sessions_subj))
-        if missing_sessions and not config.allow_missing_sessions:
-            raise RuntimeError(
-                f"Subject {subject} is missing session{_pl(missing_sessions)} "
-                f"{missing_sessions}, and `config.allow_missing_sessions` is False"
-            )
-        keep_sessions = tuple(sorted(set(cfg_sessions) & set(valid_sessions_subj)))
+        # if valid_sessions_subj is empty, assume the dataset just doesn't have
+        # `session` subfolders
+        if not valid_sessions_subj:
+            keep_sessions = cfg_sessions  # AKA (None,)
+        else:
+            missing_sessions = sorted(set(cfg_sessions) - set(valid_sessions_subj))
+            if missing_sessions and not config.allow_missing_sessions:
+                raise RuntimeError(
+                    f"Subject {subject} is missing session{_pl(missing_sessions)} "
+                    f"{missing_sessions}, and `config.allow_missing_sessions` is False"
+                )
+            keep_sessions = tuple(sorted(set(cfg_sessions) & set(valid_sessions_subj)))
         if len(keep_sessions):
             subj_sessions[subject] = keep_sessions
     return subj_sessions

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -232,9 +232,10 @@ def _get_epochs_in_files(
     session: str | None,
 ) -> InFilesT:
     in_files = dict()
+    # here we just need one subject's worth of Epochs, to get the time domain. But we
+    # still must be careful that the subject actually has data for the requested session
     in_files["epochs"] = BIDSPath(
-        # TODO subject ignored here & cfg.subjects[0] might not have data for `session`
-        subject=cfg.subjects[0],
+        subject=get_subjects_given_session(cfg, session)[0],
         session=session,
         task=cfg.task,
         acquisition=cfg.acq,
@@ -299,8 +300,7 @@ def _get_input_fnames_decoding(
     kind: str,
     extension: str = ".mat",
 ) -> InFilesT:
-    # TODO subject will get ignored here is that ok? ↓↓↓↓↓↓↓
-    in_files = _get_epochs_in_files(cfg=cfg, subject=subject, session=session)
+    in_files = _get_epochs_in_files(cfg=cfg, subject="ignored", session=session)
     for this_subject in cfg.subjects:
         in_files[f"scores-{this_subject}"] = _decoding_out_fname(
             cfg=cfg,

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -89,7 +89,7 @@ def average_evokeds(
     logger.info(**gen_log_kwargs(message="Creating grand averages"))
     # Container for all conditions:
     conditions = _all_conditions(cfg=cfg)
-    evokeds_nested: list[list[mne.Evked]] = [list() for _ in range(len(conditions))]
+    evokeds_nested: list[list[mne.Evoked]] = [list() for _ in range(len(conditions))]
 
     keys = list(in_files)
     for key in keys:

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -22,6 +22,7 @@ from mne_bids_pipeline._config_utils import (
     get_eeg_reference,
     get_sessions,
     get_subjects,
+    get_subjects_sessions,
 )
 from mne_bids_pipeline._decoding import _handle_csp_args
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
@@ -54,7 +55,13 @@ def get_input_fnames_average_evokeds(
     session: str | None,
 ) -> InFilesT:
     in_files = dict()
-    for this_subject in cfg.subjects:
+    sub_ses = get_subjects_sessions(cfg)
+    subjects = (
+        tuple(sub for sub, ses in sub_ses.items() if session in ses)
+        if cfg.allow_missing_sessions
+        else cfg.subjects
+    )
+    for this_subject in subjects:
         in_files[f"evoked-{this_subject}"] = BIDSPath(
             subject=this_subject,
             session=session,
@@ -976,6 +983,7 @@ def get_config(
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
         subjects=get_subjects(config),
+        allow_missing_sessions=config.allow_missing_sessions,
         task_is_rest=config.task_is_rest,
         conditions=config.conditions,
         contrasts=config.contrasts,

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -233,6 +233,7 @@ def _get_epochs_in_files(
 ) -> InFilesT:
     in_files = dict()
     in_files["epochs"] = BIDSPath(
+        # TODO subject ignored here & cfg.subjects[0] might not have data for `session`
         subject=cfg.subjects[0],
         session=session,
         task=cfg.task,
@@ -298,6 +299,7 @@ def _get_input_fnames_decoding(
     kind: str,
     extension: str = ".mat",
 ) -> InFilesT:
+    # TODO subject will get ignored here is that ok? ↓↓↓↓↓↓↓
     in_files = _get_epochs_in_files(cfg=cfg, subject=subject, session=session)
     for this_subject in cfg.subjects:
         in_files[f"scores-{this_subject}"] = _decoding_out_fname(

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -22,7 +22,7 @@ from mne_bids_pipeline._config_utils import (
     get_eeg_reference,
     get_sessions,
     get_subjects,
-    get_subjects_sessions,
+    get_subjects_given_session,
 )
 from mne_bids_pipeline._decoding import _handle_csp_args
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
@@ -55,12 +55,8 @@ def get_input_fnames_average_evokeds(
     session: str | None,
 ) -> InFilesT:
     in_files = dict()
-    sub_ses = get_subjects_sessions(cfg)
-    subjects = (
-        tuple(sub for sub, ses in sub_ses.items() if session in ses)
-        if cfg.allow_missing_sessions
-        else cfg.subjects
-    )
+    # for each session, only use subjects who actually have data for that session
+    subjects = get_subjects_given_session(cfg, session)
     for this_subject in subjects:
         in_files[f"evoked-{this_subject}"] = BIDSPath(
             subject=this_subject,

--- a/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
+++ b/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
@@ -154,16 +154,16 @@ def main(*, config: SimpleNamespace) -> None:
             mne.datasets.fetch_fsaverage(get_fs_subjects_dir(config))
         return
 
-    # check for session-specific MRIs within subject, and handle accordingly
+    # check for session-specific MRIs within subject, and add entries to `subj_sess` for
+    # each combination of subject+session that has its own MRI
     subjects_dir = Path(get_fs_subjects_dir(config))
-    # TODO this block looks awkward / possibly creates redundant entries?
-    subj_sess = list()
+    subj_sess = set()
     for _subj, sessions in get_subjects_sessions(config).items():
         for sess in sessions:
             _sess = (
                 sess if _has_session_specific_anat(_subj, sess, subjects_dir) else None
             )
-            subj_sess.append((_subj, _sess))
+            subj_sess.add((_subj, _sess))
 
     with get_parallel_backend(config.exec_params):
         parallel, run_func = parallel_func(
@@ -181,6 +181,6 @@ def main(*, config: SimpleNamespace) -> None:
                 session=session,
                 force_run=config.recreate_bem,
             )
-            for subject, session in subj_sess
+            for subject, session in sorted(subj_sess)
         )
     save_logs(config=config, logs=logs)

--- a/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
+++ b/mne_bids_pipeline/steps/source/_01_make_bem_surfaces.py
@@ -156,6 +156,7 @@ def main(*, config: SimpleNamespace) -> None:
 
     # check for session-specific MRIs within subject, and handle accordingly
     subjects_dir = Path(get_fs_subjects_dir(config))
+    # TODO this block looks awkward / possibly creates redundant entries?
     subj_sess = list()
     for _subj, sessions in get_subjects_sessions(config).items():
         for sess in sessions:

--- a/mne_bids_pipeline/steps/source/_02_make_bem_solution.py
+++ b/mne_bids_pipeline/steps/source/_02_make_bem_solution.py
@@ -12,8 +12,7 @@ from mne_bids_pipeline._config_utils import (
     _get_bem_conductivity,
     get_fs_subject,
     get_fs_subjects_dir,
-    get_sessions,
-    get_subjects,
+    get_subjects_sessions,
 )
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
@@ -125,7 +124,7 @@ def main(*, config: SimpleNamespace) -> None:
                 session=session,
                 force_run=config.recreate_bem,
             )
-            for subject in get_subjects(config)
-            for session in get_sessions(config)
+            for subject, sessions in get_subjects_sessions(config).items()
+            for session in sessions
         )
     save_logs(config=config, logs=logs)

--- a/mne_bids_pipeline/steps/source/_03_setup_source_space.py
+++ b/mne_bids_pipeline/steps/source/_03_setup_source_space.py
@@ -11,7 +11,7 @@ from mne_bids_pipeline._config_utils import (
     get_fs_subject,
     get_fs_subjects_dir,
     get_sessions,
-    get_subjects,
+    get_subjects_sessions,
 )
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
@@ -96,10 +96,9 @@ def main(*, config: SimpleNamespace) -> None:
         return
 
     if config.use_template_mri is not None:
-        subjects = [config.use_template_mri]
+        sub_ses = {config.use_template_mri: get_sessions(config=config)}
     else:
-        subjects = get_subjects(config=config)
-    sessions = get_sessions(config=config)
+        sub_ses = get_subjects_sessions(config=config)
 
     with get_parallel_backend(config.exec_params):
         parallel, run_func = parallel_func(
@@ -115,7 +114,7 @@ def main(*, config: SimpleNamespace) -> None:
                 exec_params=config.exec_params,
                 subject=subject,
             )
-            for subject in subjects
+            for subject, sessions in sub_ses
             for session in sessions
         )
     save_logs(config=config, logs=logs)

--- a/mne_bids_pipeline/steps/source/_03_setup_source_space.py
+++ b/mne_bids_pipeline/steps/source/_03_setup_source_space.py
@@ -114,7 +114,7 @@ def main(*, config: SimpleNamespace) -> None:
                 exec_params=config.exec_params,
                 subject=subject,
             )
-            for subject, sessions in sub_ses
+            for subject, sessions in sub_ses.items()
             for session in sessions
         )
     save_logs(config=config, logs=logs)

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -119,8 +119,14 @@ def get_input_fnames_run_average(
 ) -> InFilesT:
     in_files = dict()
     assert subject == "average"
+    sub_ses = get_subjects_sessions(cfg)
+    subjects = (
+        tuple(sub for sub, ses in sub_ses.items() if session in ses)
+        if cfg.allow_missing_sessions
+        else cfg.subjects
+    )
     for condition in _all_conditions(cfg=cfg):
-        for this_subject in cfg.subjects:
+        for this_subject in subjects:
             in_files[f"{this_subject}-{condition}"] = _stc_path(
                 cfg=cfg,
                 subject=this_subject,

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -231,7 +231,6 @@ def main(*, config: SimpleNamespace) -> None:
     cfg = get_config(config=config)
     exec_params = config.exec_params
     all_sessions = get_sessions(config)
-    subjects_sessions = get_subjects_sessions(config)
 
     logs = list()
     with get_parallel_backend(exec_params):
@@ -244,7 +243,7 @@ def main(*, config: SimpleNamespace) -> None:
                 fs_subject=get_fs_subject(config=cfg, subject=subject, session=session),
                 session=session,
             )
-            for subject, sessions in subjects_sessions.items()
+            for subject, sessions in get_subjects_sessions(config).items()
             for session in sessions
         )
     logs += [

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -151,11 +151,17 @@ def run_average(
     assert subject == "average"
     out_files = dict()
     conditions = _all_conditions(cfg=cfg)
+    sub_ses = get_subjects_sessions(cfg)
+    subjects = (
+        tuple(sub for sub, ses in sub_ses.items() if session in ses)
+        if cfg.allow_missing_sessions
+        else cfg.subjects
+    )
     for condition in conditions:
         stc = np.array(
             [
                 mne.read_source_estimate(in_files.pop(f"{this_subject}-{condition}"))
-                for this_subject in cfg.subjects
+                for this_subject in subjects
             ]
         ).mean(axis=0)
         out_files[condition] = _stc_path(

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -211,6 +211,7 @@ def get_config(
         subjects=get_subjects(config=config),
         exclude_subjects=config.exclude_subjects,
         sessions=get_sessions(config),
+        allow_missing_sessions=config.allow_missing_sessions,
         use_template_mri=config.use_template_mri,
         contrasts=config.contrasts,
         report_stc_n_time_points=config.report_stc_n_time_points,

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -15,6 +15,7 @@ from mne_bids_pipeline._config_utils import (
     get_fs_subjects_dir,
     get_sessions,
     get_subjects,
+    get_subjects_given_session,
     get_subjects_sessions,
     sanitize_cond_name,
 )
@@ -119,12 +120,8 @@ def get_input_fnames_run_average(
 ) -> InFilesT:
     in_files = dict()
     assert subject == "average"
-    sub_ses = get_subjects_sessions(cfg)
-    subjects = (
-        tuple(sub for sub, ses in sub_ses.items() if session in ses)
-        if cfg.allow_missing_sessions
-        else cfg.subjects
-    )
+    # for each session, only use subjects who actually have data for that session
+    subjects = get_subjects_given_session(cfg, session)
     for condition in _all_conditions(cfg=cfg):
         for this_subject in subjects:
             in_files[f"{this_subject}-{condition}"] = _stc_path(
@@ -151,12 +148,8 @@ def run_average(
     assert subject == "average"
     out_files = dict()
     conditions = _all_conditions(cfg=cfg)
-    sub_ses = get_subjects_sessions(cfg)
-    subjects = (
-        tuple(sub for sub, ses in sub_ses.items() if session in ses)
-        if cfg.allow_missing_sessions
-        else cfg.subjects
-    )
+    # for each session, only use subjects who actually have data for that session
+    subjects = get_subjects_given_session(cfg, session)
     for condition in conditions:
         stc = np.array(
             [


### PR DESCRIPTION
a couple of late pipeline steps are still not robust to the `allow_missing_sessions` kwarg. ~~So far~~ this PR fixes:

- [x] sensor/_99_group_average
- [x] source/_02_make_bem_solution
- [x] source/_03_setup_source_space
- [x] source/_99_group_average

~~probably I'll hit more as I churn through this dataset, so marking as draft for now; I'm facing the dreaded BEM error "The source surface has a matching number of triangles but ordering is wrong" so I need to get that unblocked before I can find out if later steps are also failing due to missing sessions.~~


### Before merging …

- [x] Changelog has been updated (`docs/source/dev.md.inc`)
- [x] probably should add to the reporting for _99_group_average the list of subjects included (or excluded?) from each grand average, since it could be potentially different lists of subjects for each session.
