### PR TITLE
Drop `Raw.pick_types` and `Epochs.pick_types`

### DIFF
--- a/docs/source/dev.md.inc
+++ b/docs/source/dev.md.inc
@@ -29,10 +29,10 @@
     1. Emptyroom files that lack cHPI channels will now be processed (for line noise only) instead of raising an error.
     2. cHPI filtering is now performed before movement compensation.
 
-- Fix bug where the ``config.proc`` parameter was not used properly during forward model creation (#1014 by @larsoner)
+- Fix bug where the `config.proc` parameter was not used properly during forward model creation (#1014 by @larsoner)
 - Fix bug where emptyroom recordings containing EEG channels would crash the pipeline during maxwell filtering (#1040 by @drammock)
 - Fix bug where only having mag sensors would crash compute_rank in maxwell filtering (#1061 by @harrisonritz)
-- Drop legacy function ``inst.pick_types`` in favor of ``inst.pick`` (#1073 by @PierreGtch)
+- Drop legacy function `inst.pick_types` in favor of `inst.pick` (#1073 by @PierreGtch)
 
 
 ### :books: Documentation

--- a/docs/source/dev.md.inc
+++ b/docs/source/dev.md.inc
@@ -32,6 +32,7 @@
 - Fix bug where the ``config.proc`` parameter was not used properly during forward model creation (#1014 by @larsoner)
 - Fix bug where emptyroom recordings containing EEG channels would crash the pipeline during maxwell filtering (#1040 by @drammock)
 - Fix bug where only having mag sensors would crash compute_rank in maxwell filtering (#1061 by @harrisonritz)
+- Drop legacy function ``inst.pick_types`` in favor of ``inst.pick`` (#1073 by @PierreGtch)
 
 
 ### :books: Documentation

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -466,8 +466,8 @@ def import_er_data(
         )
         raw_ref.info["bads"] = bads
         raw_ref.info._check_consistency()
-    raw_ref.pick_types(meg=True, exclude=[])
-    raw_er.pick_types(meg=True, exclude=[])
+    raw_ref.pick("meg")
+    raw_er.pick("meg")
 
     if prepare_maxwell_filter:
         # We need to include any automatically found bad channels, if relevant.

--- a/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
+++ b/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
@@ -118,7 +118,9 @@ def run_epochs_decoding(
     # around https://github.com/mne-tools/mne-python/issues/12153
     epochs.crop(cfg.decoding_epochs_tmin, cfg.decoding_epochs_tmax)
     # omit bad channels and reference MEG sensors
-    pick_idx = mne.pick_types(epochs.info, meg=True, eeg=True, ref_meg=False, exclude="bads")
+    pick_idx = mne.pick_types(
+        epochs.info, meg=True, eeg=True, ref_meg=False, exclude="bads"
+    )
     epochs.pick(pick_idx)
     pre_steps = _decoding_preproc_steps(
         subject=subject,

--- a/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
+++ b/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
@@ -118,7 +118,7 @@ def run_epochs_decoding(
     # around https://github.com/mne-tools/mne-python/issues/12153
     epochs.crop(cfg.decoding_epochs_tmin, cfg.decoding_epochs_tmax)
     # omit bad channels and reference MEG sensors
-    epochs.pick_types(meg=True, eeg=True, ref_meg=False, exclude="bads")
+    epochs.pick(["meg", "eeg"], exclude=["bads", "ref_meg"])
     pre_steps = _decoding_preproc_steps(
         subject=subject,
         session=session,

--- a/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
+++ b/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
@@ -118,7 +118,8 @@ def run_epochs_decoding(
     # around https://github.com/mne-tools/mne-python/issues/12153
     epochs.crop(cfg.decoding_epochs_tmin, cfg.decoding_epochs_tmax)
     # omit bad channels and reference MEG sensors
-    epochs.pick(["meg", "eeg"], exclude=["bads", "ref_meg"])
+    pick_idx = mne.pick_types(epochs.info, meg=True, eeg=True, ref_meg=False, exclude="bads")
+    epochs.pick(pick_idx)
     pre_steps = _decoding_preproc_steps(
         subject=subject,
         session=session,

--- a/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
+++ b/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
@@ -130,7 +130,9 @@ def run_time_decoding(
     epochs = mne.concatenate_epochs([epochs[epochs_conds[0]], epochs[epochs_conds[1]]])
     n_cond1 = len(epochs[epochs_conds[0]])
     n_cond2 = len(epochs[epochs_conds[1]])
-    pick_idx = mne.pick_types(epochs.info, meg=True, eeg=True, ref_meg=False, exclude="bads")
+    pick_idx = mne.pick_types(
+        epochs.info, meg=True, eeg=True, ref_meg=False, exclude="bads"
+    )
     epochs.pick(pick_idx)
     # We can't use the full rank here because the number of samples can just be the
     # number of epochs (which can be fewer than the number of channels)

--- a/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
+++ b/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
@@ -130,7 +130,7 @@ def run_time_decoding(
     epochs = mne.concatenate_epochs([epochs[epochs_conds[0]], epochs[epochs_conds[1]]])
     n_cond1 = len(epochs[epochs_conds[0]])
     n_cond2 = len(epochs[epochs_conds[1]])
-    epochs.pick_types(meg=True, eeg=True, ref_meg=False, exclude="bads")
+    epochs.pick(["meg", "eeg"], exclude=["bads", "ref_meg"])
     # We can't use the full rank here because the number of samples can just be the
     # number of epochs (which can be fewer than the number of channels)
     pre_steps = _decoding_preproc_steps(

--- a/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
+++ b/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
@@ -130,7 +130,8 @@ def run_time_decoding(
     epochs = mne.concatenate_epochs([epochs[epochs_conds[0]], epochs[epochs_conds[1]]])
     n_cond1 = len(epochs[epochs_conds[0]])
     n_cond2 = len(epochs[epochs_conds[1]])
-    epochs.pick(["meg", "eeg"], exclude=["bads", "ref_meg"])
+    pick_idx = mne.pick_types(epochs.info, meg=True, eeg=True, ref_meg=False, exclude="bads")
+    epochs.pick(pick_idx)
     # We can't use the full rank here because the number of samples can just be the
     # number of epochs (which can be fewer than the number of channels)
     pre_steps = _decoding_preproc_steps(

--- a/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
+++ b/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
@@ -165,7 +165,8 @@ def one_subject_decoding(
     bids_path = in_files["epochs"].copy().update(processing=None, split=None)
     epochs = mne.read_epochs(in_files.pop("epochs"))
     _restrict_analyze_channels(epochs, cfg)
-    epochs.pick(["meg", "eeg"], exclude=["bads", "ref_meg"])
+    pick_idx = mne.pick_types(epochs.info, meg=True, eeg=True, ref_meg=False, exclude="bads")
+    epochs.pick(pick_idx)
 
     if cfg.time_frequency_subtract_evoked:
         epochs.subtract_evoked()

--- a/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
+++ b/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
@@ -165,7 +165,9 @@ def one_subject_decoding(
     bids_path = in_files["epochs"].copy().update(processing=None, split=None)
     epochs = mne.read_epochs(in_files.pop("epochs"))
     _restrict_analyze_channels(epochs, cfg)
-    pick_idx = mne.pick_types(epochs.info, meg=True, eeg=True, ref_meg=False, exclude="bads")
+    pick_idx = mne.pick_types(
+        epochs.info, meg=True, eeg=True, ref_meg=False, exclude="bads"
+    )
     epochs.pick(pick_idx)
 
     if cfg.time_frequency_subtract_evoked:

--- a/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
+++ b/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
@@ -165,7 +165,7 @@ def one_subject_decoding(
     bids_path = in_files["epochs"].copy().update(processing=None, split=None)
     epochs = mne.read_epochs(in_files.pop("epochs"))
     _restrict_analyze_channels(epochs, cfg)
-    epochs.pick_types(meg=True, eeg=True, ref_meg=False, exclude="bads")
+    epochs.pick(["meg", "eeg"], exclude=["bads", "ref_meg"])
 
     if cfg.time_frequency_subtract_evoked:
         epochs.subtract_evoked()


### PR DESCRIPTION
First smal PR :)

This drops the use of legacy `Raw.pick_types` and `Epochs.pick_types` in favor of `.pick(...)`.

See #973 
