### PR TITLE
fixup generation of template config files

### DIFF
--- a/docs/source/dev.md.inc
+++ b/docs/source/dev.md.inc
@@ -32,6 +32,7 @@
 - Fix bug where the ``config.proc`` parameter was not used properly during forward model creation (#1014 by @larsoner)
 - Fix bug where emptyroom recordings containing EEG channels would crash the pipeline during maxwell filtering (#1040 by @drammock)
 - Fix bug where only having mag sensors would crash compute_rank in maxwell filtering (#1061 by @harrisonritz)
+- Improvements to template config file generation (#1074 by @drammock)
 
 
 ### :books: Documentation

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -313,7 +313,7 @@ Can also be `None` if you do not want to create bipolar channels.
     ```
 """
 
-eeg_reference: Literal["average"] | str | Sequence["str"] = "average"
+eeg_reference: Literal["average"] | str | Sequence[str] = "average"
 """
 The EEG reference to use. If `average`, will use the average reference,
 i.e. the average across all channels. If a string, must be the name of a single
@@ -385,7 +385,7 @@ doesn't contain coordinates for some channels.
     ```
 """
 
-analyze_channels: Literal["all", "ch_types"] | Annotated[Sequence["str"], MinLen(1)] = (
+analyze_channels: Literal["all", "ch_types"] | Annotated[Sequence[str], MinLen(1)] = (
     "ch_types"
 )
 """

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -715,7 +715,7 @@ location is used.
     ```python
     mf_cal_fname = '/path/to/your/file/calibration_cal.dat'
     ```
-"""  # noqa : E501
+"""
 
 mf_cal_missing: Literal["ignore", "warn", "raise"] = "raise"
 """
@@ -737,7 +737,7 @@ location is used.
     ```python
     mf_ctc_fname = '/path/to/your/file/crosstalk_ct.fif'
     ```
-"""  # noqa : E501
+"""
 
 mf_ctc_missing: Literal["ignore", "warn", "raise"] = "raise"
 """
@@ -1069,7 +1069,7 @@ unknown metadata column, a warning will be emitted and all epochs will be kept.
     ```python
     epochs_metadata_query = ['response_missing.isna()']
     ```
-"""  # noqa: E501
+"""
 
 conditions: Sequence[str] | dict[str, str] | None = None
 """
@@ -1085,7 +1085,8 @@ Passing a dictionary allows to assign a name to map a complex condition name
 
 This is a **required** parameter in the configuration file, unless you are
 processing resting-state data. If left as `None` and
-[`task_is_rest`][mne_bids_pipeline._config.task_is_rest] is not `True`, we will raise an error.
+[`task_is_rest`][mne_bids_pipeline._config.task_is_rest] is not `True`, we will raise an
+error.
 
 ???+ example "Example"
     Specifying conditions as lists of strings:
@@ -1102,7 +1103,7 @@ processing resting-state data. If left as `None` and
     conditions = {'simple_name': 'complex/condition/with_subconditions'}
     conditions = {'correct': 'response/correct',
                   'incorrect': 'response/incorrect'}
-"""  # noqa : E501
+"""
 
 epochs_tmin: float = -0.2
 """
@@ -1200,9 +1201,12 @@ Artifact regression is applied before SSP or ICA.
     miscellaneous channels, you could do:
 
     ```python
-    regress_artifact = {"picks": "meg", "picks_artifact": ["MISC 001", "MISC 002", "MISC 003"]}
+    regress_artifact = {
+        "picks": "meg",
+        "picks_artifact": ["MISC 001", "MISC 002", "MISC 003"]
+    }
     ```
-"""  # noqa: E501
+"""
 
 spatial_filter: Literal["ssp", "ica"] | None = None
 """
@@ -1492,7 +1496,8 @@ will generate a dictionary with (hopefully!) optimal thresholds for each
 channel type.
 
 If `"autoreject_local"`, use "local" `autoreject` to detect (and potentially repair) bad
-channels in each epoch. Use [`autoreject_n_interpolate`][mne_bids_pipeline._config.autoreject_n_interpolate]
+channels in each epoch.
+Use [`autoreject_n_interpolate`][mne_bids_pipeline._config.autoreject_n_interpolate]
 to control how many channels are allowed to be bad before an epoch gets dropped.
 
 ???+ example "Example"
@@ -1503,7 +1508,7 @@ to control how many channels are allowed to be bad before an epoch gets dropped.
     reject = "autoreject_global"  # find global (per channel type) PTP thresholds
     reject = "autoreject_local"  # find local (per channel) thresholds and repair epochs
     ```
-"""  # noqa: E501
+"""
 
 reject_tmin: float | None = None
 """
@@ -1694,7 +1699,7 @@ on **all** time points.
 
 Because each classifier is trained and tested on **all** time points, this
 procedure may take a significant amount of time.
-"""  # noqa: E501
+"""
 
 decoding_time_generalization_decim: int = 1
 """

--- a/mne_bids_pipeline/_config_template.py
+++ b/mne_bids_pipeline/_config_template.py
@@ -1,3 +1,4 @@
+import ast
 from pathlib import Path
 
 from ._logging import gen_log_kwargs, logger
@@ -15,15 +16,37 @@ def create_template_config(
         raise FileExistsError(f"The specified path already exists: {target_path}")
 
     # Create a template by commenting out most of the lines in _config.py
-    config: list[str] = []
-    with open(CONFIG_SOURCE_PATH, encoding="utf-8") as f:
-        for line in f:
-            line = (
-                line if line.startswith(("#", "\n", "import", "from")) else f"# {line}"
-            )
-            config.append(line)
+    config: list[str] = ["# Template config file for mne_bids_pipeline.", ""]
+    text = CONFIG_SOURCE_PATH.read_text(encoding="utf-8")
+    # skip file header
+    to_strip = "# Default settings for data processing and analysis.\n\n"
+    if text.startswith(to_strip):
+        text = text[len(to_strip) :]
+    lines = text.split("\n")
+    # make sure we catch all imports and assignments
+    tree = ast.parse(text, type_comments=True)
+    for ix, line in enumerate(lines, start=1):  # ast.parse assigns 1-indexed `lineno`!
+        nodes = [_node for _node in tree.body if _node.lineno <= ix <= _node.end_lineno]  # type:ignore[operator]
+        if not nodes:
+            # blank lines and comments aren't parsed by `ast.parse`:
+            assert line == "" or line.startswith("#"), line
+        else:
+            assert len(nodes) == 1, nodes
+            node = nodes[0]
+            # config value assignments should become commented out:
+            if isinstance(node, ast.AnnAssign):
+                line = f"# {line}"
+            # imports get written as-is (not commented out):
+            elif isinstance(node, ast.Import | ast.ImportFrom):
+                pass
+            # everything else should be (multiline) string literals:
+            else:
+                assert isinstance(node, ast.Expr), node
+                assert isinstance(node.value, ast.Constant), node.value
+                assert isinstance(node.value.value, str), node.value.value
+        config.append(line)
 
-    target_path.write_text("".join(config), encoding="utf-8")
+    target_path.write_text("\n".join(config), encoding="utf-8")
     message = f"Successfully created template configuration file at: {target_path}"
     logger.info(**gen_log_kwargs(message=message, emoji="✅"))
 

--- a/mne_bids_pipeline/tests/test_documented.py
+++ b/mne_bids_pipeline/tests/test_documented.py
@@ -213,13 +213,37 @@ def test_datasets_in_doc() -> None:
     assert tests == test_names, "CircleCI tests != tests/test_run.py"
 
 
+def _replace_config_value_in_file(fpath: Path, config_key: str, new_value: str) -> None:
+    """Assign a value to a config key in a file, and uncomment the line if needed."""
+    lines = fpath.read_text().split("\n")
+    pattern = re.compile(rf"(?:# )?({config_key}: .* = )(?:.*)")
+    for ix, line in enumerate(lines):
+        if pattern.match(line):
+            lines[ix] = pattern.sub(
+                rf"\1{new_value}",
+                line,  # omit comment marker, change default value to `new_value`
+            )
+            break
+    fpath.write_text("\n".join(lines))
+
+
 def test_config_template_valid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure our config template is syntactically valid (importable)."""
+    monkeypatch.setenv("BIDS_ROOT", str(tmp_path))
     fpath = tmp_path / "foo.py"
     create_template_config(fpath)
-    monkeypatch.setenv("BIDS_ROOT", str(tmp_path))
-    # we need check=False because (at least):
-    #   - `ch_types` fails pydantic validation (its default is `[]` but its annotation
-    #     requires length > 0)
-    #   - `conditions` cannot be None unless `task_is_rest = True` (defaults to False)
-    _import_config(config_path=fpath, check=False, log=False)
+    # `ch_types` fails pydantic validation (its default is `[]` but its annotation
+    # requires length > 0)
+    with pytest.raises(
+        ValueError, match="ch_types\n  Value should have at least 1 item"
+    ):
+        _import_config(config_path=fpath, log=False)
+    # Give `ch_types` a value so pydantic will succeed...
+    _replace_config_value_in_file(fpath, "ch_types", '["meg"]')
+    # ...but now `_check_config` will raise an error that `conditions` cannot be None
+    # unless `task_is_rest = True` (which defaults to False)
+    with pytest.raises(ValueError, match="the `conditions` parameter is empty"):
+        _import_config(config_path=fpath, log=False)
+    # give a non-None value for `conditions`, now importing the config should work
+    _replace_config_value_in_file(fpath, "conditions", '["foo"]')
+    _import_config(config_path=fpath, log=False)


### PR DESCRIPTION
on `main`, template config files have a couple of bad features:

these lines get commented out, making the file syntactically invalid (unclosed parens):

https://github.com/mne-tools/mne-bids-pipeline/blob/6005b52381203ed3993dc1cc4943e8fd507f993b/mne_bids_pipeline/_config.py#L11-L15

this line does not get commented out, because it starts with "from":

https://github.com/mne-tools/mne-bids-pipeline/blob/6005b52381203ed3993dc1cc4943e8fd507f993b/mne_bids_pipeline/_config.py#L348

This PR:

- [x] fixes commented-out import lines (item 1 above)
- [x] fixes missed commented-out line starting with "from" (item 2 above)
- [x] writes multiline string literals (AKA, the docstrings for each config value) as-is, so that in the template config file, the IDE will (potentially) highlight them a different color, making it much easier to see which lines are changable config values and which are supporting documentation.
- [x] removes a few unnecessary `# noqa E501` comments
- [x] changes a couple cases of `Sequence["str"]` to `Sequence[str]`
- [x] Updates the changelog (`docs/source/dev.md.inc`)
