### PR TITLE
fix mf_int_order; add mf_ext_order

### DIFF
--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -686,9 +686,16 @@ account, we are realigning all data to a single position. For this, you can:
 
 mf_int_order: int = 8
 """
-Internal order for the Maxwell basis. Can be set to something lower (e.g., 6
-or higher for datasets where lower or higher spatial complexity, respectively,
-is expected.
+Internal order for the Maxwell basis. Can increase or decrease for datasets where
+neural signals with higher or lower spatial complexity are expected.
+Per MNE, the default values are appropriate for most use cases.
+"""
+
+mf_ext_order: int = 3
+"""
+External order for the Maxwell basis. Can increase or decrease for datasets where
+environmental artifacts with higher or lower spatial complexity are expected.
+Per MNE, the default values are appropriate for most use cases.
 """
 
 mf_reference_run: str | None = None

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -279,6 +279,8 @@ def _check_config(config: SimpleNamespace, config_path: PathLike | None) -> None
         "destination",
         "head_pos",
         "extended_proj",
+        "int_order",
+        "ext_order",
     )
     # check `mf_extra_kws` for things that shouldn't be in there
     if duplicates := (set(config.mf_extra_kws) & set(mf_reserved_kwargs)):

--- a/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
@@ -392,6 +392,8 @@ def run_maxwell_filter(
         destination=destination,
         head_pos=head_pos,
         extended_proj=extended_proj,
+        int_order=cfg.mf_int_order,
+        ext_order=cfg.mf_ext_order,
     )
     # If the mf_kws keys above change, we need to modify our list
     # of illegal keys in _config_import.py
@@ -451,8 +453,14 @@ def run_maxwell_filter(
             t_window=cfg.mf_mc_t_window,
             allow_line_only=(task == "noise"),
         )
+    
+    msg = (
+        "Maxwell Filtering"
+        f" (internal order: {mf_kws['int_order']},"
+        f" external order: {mf_kws['ext_order']}),"
+    )
+    logger.info(**gen_log_kwargs(message=msg))
 
-    logger.info(**gen_log_kwargs(message="Maxwell filtering"))
     raw_sss = mne.preprocessing.maxwell_filter(raw, **mf_kws)
     del raw
     gc.collect()
@@ -613,6 +621,7 @@ def get_config_maxwell_filter(
         mf_filter_chpi=config.mf_filter_chpi,
         mf_destination=config.mf_destination,
         mf_int_order=config.mf_int_order,
+        mf_ext_order=config.mf_ext_order,
         mf_mc_t_window=config.mf_mc_t_window,
         mf_mc_rotation_velocity_limit=config.mf_mc_rotation_velocity_limit,
         mf_mc_translation_velocity_limit=config.mf_mc_translation_velocity_limit,

--- a/mne_bids_pipeline/tests/configs/config_ds000117.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000117.py
@@ -20,6 +20,8 @@ process_empty_room = True
 mf_reference_run = "02"
 mf_cal_fname = bids_root + "/derivatives/meg_derivatives/sss_cal.dat"
 mf_ctc_fname = bids_root + "/derivatives/meg_derivatives/ct_sparse.fif"
+mf_int_order = 7
+mf_ext_order = 4
 
 reject = {"grad": 4000e-13, "mag": 4e-12}
 conditions = ["Famous", "Unfamiliar", "Scrambled"]


### PR DESCRIPTION
### Before merging …

- [ ] Changelog has been updated (`docs/source/dev.md.inc`)

### fix mf_int_order; add mf_ext_order

Fixed bug where `mf_int_order` wasn't being passed to the `maxwell_filter` (wasn't included in `mf_kws`).

Also added a config option to supply `mf_ext_order`. Even though `mf_ext_order` can be supplied through `mf_extra_kws`, seems like an important enough parameter to assign its own config argument.

Included non-standard internal & external orders to the `ds000117` config as a test, though we'd have to check the logs to confirm.

Could can reduce the logging of int/ext order if this is an opinionated default.