### PR TITLE
FIX: sanitize tags

### DIFF
--- a/docs/source/dev.md.inc
+++ b/docs/source/dev.md.inc
@@ -35,6 +35,7 @@
 - Fix bug where only having mag sensors would crash compute_rank during maxwell filtering or epoching (#1061 and #1069 by @harrisonritz)
 - Improvements to template config file generation (#1074 by @drammock)
 - Fix bug where `mf_int_order` wasn't passed to `maxwell_filter`. Added config option for `mf_ext_order`. (#1092 by @harrisonritz)
+- Sanitize report tags that contain `"` or `'`, e.g., for certain metadata contrasts (#1097 by @harrisonritz)
 
 ### :books: Documentation
 

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -568,7 +568,7 @@ def _all_conditions(*, cfg: SimpleNamespace) -> list[str]:
 
 
 def _sanitize_cond_tag(cond: str) -> str:
-    return str(cond).lower().replace(" ", "-")
+    return str(cond).lower().replace("'", "").replace('"', "").replace(" ", "-")
 
 
 def _imshow_tf(

--- a/mne_bids_pipeline/tests/configs/config_ds001810.py
+++ b/mne_bids_pipeline/tests/configs/config_ds001810.py
@@ -13,7 +13,7 @@ eeg_template_montage = "biosemi64"
 reject = dict(eeg=100e-6)
 baseline = (None, 0)
 conditions = ["61450", "61511"]
-contrasts = [("61450", "61511")]
+contrasts = [("61450", "61511"), ("letter=='a'", "letter=='b'")]
 decode = True
 decoding_n_splits = 3  # only for testing, use 5 otherwise
 
@@ -26,10 +26,40 @@ interpolate_bads_grand_average = False
 n_jobs = 4
 
 epochs_custom_metadata = {
-    "ses-anodalpost": pd.DataFrame({"ones": np.ones(253)}),
-    "ses-anodalpre": pd.DataFrame({"ones": np.ones(268)}),
-    "ses-anodaltDCS": pd.DataFrame({"ones": np.ones(269)}),
-    "ses-cathodalpost": pd.DataFrame({"ones": np.ones(290)}),
-    "ses-cathodalpre": pd.DataFrame({"ones": np.ones(267)}),
-    "ses-cathodaltDCS": pd.DataFrame({"ones": np.ones(297)}),
+    "ses-anodalpost": pd.DataFrame(
+        {
+            "ones": np.ones(253),
+            "letter": ["a" for x in range(150)] + ["b" for x in range(103)],
+        }
+    ),
+    "ses-anodalpre": pd.DataFrame(
+        {
+            "ones": np.ones(268),
+            "letter": ["a" for x in range(150)] + ["b" for x in range(118)],
+        }
+    ),
+    "ses-anodaltDCS": pd.DataFrame(
+        {
+            "ones": np.ones(269),
+            "letter": ["a" for x in range(150)] + ["b" for x in range(119)],
+        }
+    ),
+    "ses-cathodalpost": pd.DataFrame(
+        {
+            "ones": np.ones(290),
+            "letter": ["a" for x in range(150)] + ["b" for x in range(140)],
+        }
+    ),
+    "ses-cathodalpre": pd.DataFrame(
+        {
+            "ones": np.ones(267),
+            "letter": ["a" for x in range(150)] + ["b" for x in range(117)],
+        }
+    ),
+    "ses-cathodaltDCS": pd.DataFrame(
+        {
+            "ones": np.ones(297),
+            "letter": ["a" for x in range(150)] + ["b" for x in range(147)],
+        }
+    ),
 }  # number of rows are hand-set


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/dev.md.inc`)


### Description
Currently, contrasts from metadata (e.g., `cond == "A"`) won't create valid report tags due to illegal characters (`"`, `'`).
PR properly sanitizes these tags. Added metadata-based decoding to test suite in `ds001810`.


edit: Wondered if this should be fixed at `mne-python` level, but really only an issue if you auto-generate tags.