### PR TITLE
ENH: Report bad channel statuses

### DIFF
--- a/docs/source/dev.md.inc
+++ b/docs/source/dev.md.inc
@@ -8,6 +8,7 @@
 - New value `"twa"` for config option [`mf_destination`][mne_bids_pipeline._config.mf_destination], to use the time-weighted average head position across runs as the destination position. (#1043 and #1055 by @drammock)
 - New config options [`mf_cal_missing`][mne_bids_pipeline._config.mf_cal_missing] and [`mf_ctc_missing`][mne_bids_pipeline._config.mf_ctc_missing] for handling missing calibration and cross-talk files (#1057 by @harrisonritz)
 - New config options [`find_bad_channels_extra_kws`][mne_bids_pipeline._config.find_bad_channels_extra_kws], [`notch_extra_kws`][mne_bids_pipeline._config.notch_extra_kws], and [`bandpass_extra_kws`][mne_bids_pipeline._config.bandpass_extra_kws] to pass additional keyword arguments to `mne.preprocessing.find_bad_channels_maxwell`, `mne.filter.notch_filter`, and `mne.filter.filter_data` respectively (#1061 by @harrisonritz)
+- Bad channel reports now say which channels were marked as bad in the original data and which were detected automatically by the pipeline. (#1138 by @larsoner)
 - Config option [`ssp_ecg_channel`][mne_bids_pipeline._config.ssp_ecg_channel] now allows dict values, for setting a different channel name for each subject/session (#1062 by @drammock)
 - New config option [`epochs_custom_metadata`][mne_bids_pipeline._config.epochs_custom_metadata] allows for custom metadata when creating epochs. (#1088 by @harrisonritz)
 


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/dev.md.inc`)

Closes #932

Running `pytest mne_bids_pipeline/ -k ds004229` I now see this new section (HTML modified by me to make it print two channel names so you can see the spacing):

<img width="1296" height="999" alt="image" src="https://github.com/user-attachments/assets/77d1d75c-f22f-41ce-b0ad-2fa01ba5fdc5" />
