### PR TITLE
MAINT: Verify sizes on download

### DIFF
--- a/mne_bids_pipeline/_download.py
+++ b/mne_bids_pipeline/_download.py
@@ -32,13 +32,14 @@ def _download_via_openneuro(*, ds_name: str, ds_path: Path) -> None:
     options = DATASET_OPTIONS[ds_name]
     assert "hash" not in options
 
-    openneuro.download(
+    kwargs = dict(
         dataset=options["openneuro"],
         target_dir=ds_path,
         include=options.get("include", []),
         exclude=options.get("exclude", []),
-        verify_size=False,
     )
+    print(f"Downloading with openneuro.download(**{kwargs})")
+    openneuro.download(**kwargs)
 
 
 def _download_from_web(*, ds_name: str, ds_path: Path) -> None:


### PR DESCRIPTION
All PRs are failing due to https://github.com/OpenNeuroOrg/openneuro/issues/3765, but it would probably be better if the failure mode was clearer. Not sure why we had `verify_sizes=False`, but let's get rid of it so we get failures earlier like:
```
E   RuntimeError: Server claimed size of /home/larsoner/mne_data/ds003392/sub-01/meg/sub-01_acq-calibration_meg.dat would be 40121 bytes, but downloaded 0 bytes.
```
Also, print the download command in case it's helpful to replicate it locally.