### PR TITLE
Fix outdated docs in steps-ica in CLI

### DIFF
--- a/mne_bids_pipeline/_main.py
+++ b/mne_bids_pipeline/_main.py
@@ -54,7 +54,7 @@ def main() -> None:
         'source', 'report',  or 'all',  or the name of a processing group plus
         the desired step sans the step number and
         filename extension, separated by a '/'. For example, to run ICA, you
-        would pass 'sensor/run_ica`. If unspecified, will run all processing
+        would pass 'preprocessing/ica`. If unspecified, will run all processing
         steps. Can also be a tuple of steps."""
         ),
     )


### PR DESCRIPTION
### Before merging …

- [ ] Changelog has been updated (`docs/source/dev.md.inc`)

in the basic usage .md already the correct syntax is depicted. I assume this changed at some point and was forgotten.

with @jschepers 