### PR TITLE
MAINT: Dont cache website docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1097,14 +1097,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "3b:da:0c:a3:e7:e8:31:08:ff:db:c3:42:c9:b5:bf:77"
-      - restore_cache:
-          keys:
-            - source-cache
       - checkout
-      - save_cache:
-          key: source-cache
-          paths:
-            - ".git"
       - attach_workspace:
           at: ~/
       - bash_env
@@ -1128,6 +1121,7 @@ jobs:
             ARGS="--config-file docs/mkdocs.yml"
             # First we need to actually check out our current version of
             # gh-pages so we don't remove it!
+            set -x
             git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
             git fetch origin
             # If it's tagged as v*, deploy as "v*" and "stable" as well

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1141,6 +1141,9 @@ jobs:
               mike deploy dev $ARGS
             fi
             git checkout gh-pages
+            # TODO: On release, consider doing something like:
+            # $ rm 1.9/examples/*/sub-*_report.html
+            # To save ~500MB-1TB! Left as a manual step for now.
             git reset $(git commit-tree HEAD^{tree} -m "Deploy and squash docs [ci skip]")
             git log -n3  # should just be one, but let's be sure
             git push origin --force gh-pages


### PR DESCRIPTION
No reason to cache the source docs since `mike deploy` overwrites history every time. This should fix a really annoying error that has cropped up that I'm trying to fix via SSH :crossed_fingers:  (see https://app.circleci.com/pipelines/gh/mne-tools/mne-bids-pipeline/5523/details)