### PR TITLE
ENH: Speed up sidecar searches

### DIFF
--- a/mne_bids_pipeline/_logging.py
+++ b/mne_bids_pipeline/_logging.py
@@ -157,27 +157,33 @@ def gen_log_kwargs(
         emoji = default_emoji
     if emoji == "skip":
         default_subject = "*"
-    stack = inspect.stack()
-    up_locals = stack[1].frame.f_locals
-    if subject is None:
-        subject = up_locals.get("subject", default_subject)
-    if session is None:
-        session = up_locals.get("session", None)
-    if run is None:
-        run = up_locals.get("run", None)
-    if task is None:
-        task = up_locals.get("task", None)
-        if task not in ("noise", "rest"):
-            # If task is set but there's only one task, don't show it
-            n_tasks = 2
-            cfg = up_locals.get("cfg", None)
-            if cfg is None:
-                config = up_locals.get("config", None)
-                n_tasks = len(getattr(config, "all_tasks", []))
-            else:
-                n_tasks = len(getattr(cfg, "all_tasks", []))
-            if n_tasks == 1:
-                task = None
+    frame = inspect.currentframe()
+    try:
+        up_locals = frame.f_back.f_locals
+    except Exception:
+        pass
+    else:
+        if subject is None:
+            subject = up_locals.get("subject", default_subject)
+        if session is None:
+            session = up_locals.get("session", None)
+        if run is None:
+            run = up_locals.get("run", None)
+        if task is None:
+            task = up_locals.get("task", None)
+            if task not in ("noise", "rest"):
+                # If task is set but there's only one task, don't show it
+                n_tasks = 2
+                cfg = up_locals.get("cfg", None)
+                if cfg is None:
+                    config = up_locals.get("config", None)
+                    n_tasks = len(getattr(config, "all_tasks", []))
+                else:
+                    n_tasks = len(getattr(cfg, "all_tasks", []))
+                if n_tasks == 1:
+                    task = None
+    finally:
+        del frame
 
     # Do some nice formatting
     if subject is not None:

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -189,7 +189,7 @@ class ConditionalStepMemory:
                 hashes.append(hash_(k, v))
                 # also hash the sidecar files if this is a BIDSPath and
                 # MNE-BIDS is new enough
-                if not (self.sidecars and hasattr(v, "find_matching_sidecar")):
+                if not (self.sidecars and isinstance(v, BIDSPath)):
                     continue
                 # from mne_bids/read.py
                 # The v.datatype is maybe not right, might need to use
@@ -201,8 +201,8 @@ class ConditionalStepMemory:
                     ("coordsystem", ".json"),
                     (v.datatype, ".json"),
                 ):
-                    sidecar = v.find_matching_sidecar(
-                        suffix=suffix, extension=extension, on_error="ignore"
+                    sidecar = _find_matching_sidecar_cached(
+                        v, suffix=suffix, extension=extension
                     )
                     if sidecar is None:
                         continue
@@ -502,6 +502,34 @@ def _prep_out_files_path(
             kind="out",
         )
     return out_files
+
+
+def _find_matching_sidecar_cached(
+    bids_path: BIDSPath, suffix: str | None, extension: str
+) -> pathlib.Path | None:
+    state = bids_path.entities
+    for key in ("root", "suffix", "extension", "datatype", "check"):
+        val = getattr(bids_path, key)
+        state[key] = val
+    return _find_matching_sidecar_cached_impl(
+        **state, pass_suffix=suffix, pass_extension=extension
+    )
+
+
+@functools.cache
+def _find_matching_sidecar_cached_impl(
+    *, pass_suffix: str | None, pass_extension: str, **state: dict[str, Any]
+) -> pathlib.Path | None:
+    # We have to do this dance because BIDSPath objects are not hashable, but we
+    # want to cache the sidecar finding (which can be expensive when there are
+    # many files in a directory). So we cache based on the BIDSPath's state, which
+    # is hashable (as it's just a dict of strings and bools).
+    bids_path = BIDSPath(**state)
+    return bids_path.find_matching_sidecar(
+        suffix=pass_suffix,
+        extension=pass_extension,
+        on_error="ignore",
+    )
 
 
 def _path_to_str_hash(

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -189,7 +189,7 @@ class ConditionalStepMemory:
             hashes = []
             for k, v in in_files.items():
                 hashes.append(hash_(k, v))
-# also hash the sidecar files if this is a BIDSPath
+                # also hash the sidecar files if this is a BIDSPath
                 if not (self.sidecars and isinstance(v, BIDSPath)):
                     continue
                 # from mne_bids/read.py

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -161,7 +161,9 @@ class ConditionalStepMemory:
         self.sidecars = sidecars
 
     def cache(self, func: Callable[..., Any]) -> Callable[..., Any]:
-        def wrapper(*args: list[Any], **kwargs: dict[str, Any]) -> bool:
+        def __mbp_cached_func_wrapper__(
+            *args: list[Any], **kwargs: dict[str, Any]
+        ) -> bool:
             in_files = out_files = None
             force_run = kwargs.pop("force_run", False)
             these_kwargs = kwargs.copy()
@@ -257,9 +259,7 @@ class ConditionalStepMemory:
                     emoji = "🔂"
                 else:
                     # Check our output file hashes
-                    # Need to make a copy of kwargs["in_files"] in particular
-                    use_kwargs = copy.deepcopy(kwargs)
-                    out_files_hashes = memorized_func(*args, **use_kwargs)
+                    out_files_hashes = memorized_func(*args, **kwargs)
                     for key, (fname, this_hash) in out_files_hashes.items():
                         fname = pathlib.Path(fname)
                         if not fname.exists():
@@ -334,7 +334,7 @@ class ConditionalStepMemory:
                 )
             return not done
 
-        return wrapper
+        return __mbp_cached_func_wrapper__
 
     def clear(self) -> None:
         self.memory.clear()

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -189,8 +189,7 @@ class ConditionalStepMemory:
             hashes = []
             for k, v in in_files.items():
                 hashes.append(hash_(k, v))
-                # also hash the sidecar files if this is a BIDSPath and
-                # MNE-BIDS is new enough
+# also hash the sidecar files if this is a BIDSPath
                 if not (self.sidecars and isinstance(v, BIDSPath)):
                     continue
                 # from mne_bids/read.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "jupyter-server-proxy",
   "matplotlib",
   "meegkit",
-  "mne-bids[full]",
+  "mne-bids[full] >=0.12",  # BIDSPath.find_matching_sidecar
   "mne-icalabel",
   "mne[hdf5] >=1.7",
   "nibabel",

--- a/uv.lock
+++ b/uv.lock
@@ -2443,7 +2443,7 @@ requires-dist = [
     { name = "matplotlib" },
     { name = "meegkit" },
     { name = "mne", extras = ["hdf5"], specifier = ">=1.7" },
-    { name = "mne-bids", extras = ["full"] },
+    { name = "mne-bids", extras = ["full"], specifier = ">=0.12" },
     { name = "mne-icalabel" },
     { name = "nibabel" },
     { name = "numpy" },


### PR DESCRIPTION
Just a few more speed tweaks

1. Avoid `inspect.stack()`, it's expensive. Use `currentframe().f_back` instead
2. Pin to MNE-BIDS version that has `find_matching_sidecar` (3+ years old, should be fine)
3. Cache `find_matching_sidecar`
4. We don't need to `deepcopy` our `kwargs`, that's from old code (we only modify if we actually call the underlying func, which we won't do at this level of code as we know it's in the call cache)

With this PR we're down to < 30s, which is nice since we were ~90s last week before optimizations!

After this PR, the vast majority of time is now spent in `joblib` caching of function code etc. There is perhaps some way to speed this up, too, since we know that in a given `mne_bids_pipeline` invocation this code will not change... but that's probably for another day :smile: 

| main | PR |
| -- | -- |
| <img width="963" height="1029" alt="image" src="https://github.com/user-attachments/assets/f91faf3e-f1c7-4f18-a079-5424826ce7b0" /> | <img width="963" height="1029" alt="image" src="https://github.com/user-attachments/assets/150392ab-600f-4a90-b547-ace08ada143f" /> |