### PR TITLE
BUG: Fix bug with Evoked plots for sub-average

### DIFF
--- a/docs/source/dev.md.inc
+++ b/docs/source/dev.md.inc
@@ -14,7 +14,7 @@
 ### :bug: Bug fixes
 
 - Fixed a bug where the group average step would errantly write its sensor averaged Evoked plots to the last subject's report.
-  To fix this, delete the `derivatives/mne-bids-pipeline/sub-average/` and `derivatives/mne-bids-pipeline/sub-<LAST>` folders and rerun the pipeline.
+  To fix this after-the-fact, delete the `derivatives/mne-bids-pipeline/sub-average/` and `derivatives/mne-bids-pipeline/sub-<LAST>` folders and rerun the pipeline.
   (#1220 by @larsoner)
 
 [//]: # (### :books: Documentation)

--- a/docs/source/dev.md.inc
+++ b/docs/source/dev.md.inc
@@ -11,7 +11,11 @@
 
 [//]: # (### :package: Requirements)
 
-[//]: # (### :bug: Bug fixes)
+### :bug: Bug fixes
+
+- Fixed a bug where the group average step would errantly write its sensor averaged Evoked plots to the last subject's report.
+  To fix this, delete the `derivatives/mne-bids-pipeline/sub-average/` and `derivatives/mne-bids-pipeline/sub-<LAST>` folders and rerun the pipeline.
+  (#1220 by @larsoner)
 
 [//]: # (### :books: Documentation)
 

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -99,12 +99,14 @@ def average_evokeds(
 
     subjects = get_subjects_given_session(cfg, session)
     n_subjects = len(subjects)
-    for subject in subjects:
-        fname_in = in_files.pop(f"evoked-{subject}")
+    for this_subject in subjects:
+        fname_in = in_files.pop(f"evoked-{this_subject}")
         these_evokeds = mne.read_evokeds(fname_in)
         assert isinstance(these_evokeds, list)
         for idx, evoked in enumerate(these_evokeds):
             evokeds_nested[idx].append(evoked)  # Insert into the container
+    del this_subject
+    assert subject == "average", subject  # make sure we didn't bungle it
 
     evokeds: list[mne.Evoked] = list()
     for these_evokeds in evokeds_nested:
@@ -138,6 +140,8 @@ def average_evokeds(
     # given missing run)
     fname_verbose = fname_out.fpath.with_suffix(".fif.IS_INTENTIONALLY_EMPTY.txt")
     if not evokeds:
+        msg = "No evoked data present for any subject, writing empty file."
+        logger.info(**gen_log_kwargs(message=msg))
         fname_out.fpath.write_bytes(b"")
         fname_verbose.write_text("No evoked data present for any subject.\n", "utf-8")
         return _prep_out_files(exec_params=exec_params, out_files=out_files)

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -251,20 +251,22 @@ def test_run(
     with capsys.disabled():
         print()
         main()
-    # post-run checks for correctness
 
-    # sub-average evoked present
+    # post-run checks for correctness
     config_data = config_path.read_text("utf-8")
-    avg_subj_path = (
-        DATA_DIR / "derivatives" / "mne-bids-pipeline" / dataset / "sub-average"
-    )
-    assert avg_subj_path.is_dir()
-    report_html_paths = list(avg_subj_path.rglob("sub-average*_report.html"))
-    assert len(report_html_paths)
-    parser = _ReportTOCFinder()
-    parser.feed(report_html_paths[0].read_text("utf-8"))
-    msg = "\n".join(["Not found in TOC titles:"] + parser.toc_links)
-    if "conditions" in config_data:
+
+    # sub-average evoked present in report
+    if re.search(r"^\s*conditions =", config_data, flags=re.MULTILINE):
+        assert dataset not in ("ds000247", "ds000375")
+        avg_subj_path = (
+            DATA_DIR / "derivatives" / "mne-bids-pipeline" / dataset / "sub-average"
+        )
+        assert avg_subj_path.is_dir()
+        report_html_paths = list(avg_subj_path.rglob("sub-average*_report.html"))
+        assert len(report_html_paths)
+        parser = _ReportTOCFinder()
+        parser.feed(report_html_paths[0].read_text("utf-8"))
+        msg = "\n".join(["Not found in TOC titles:"] + parser.toc_links)
         assert any("Average (sensor)" in name for name in parser.toc_links), msg
     else:
         # Just spot check a few that we know have "conditions" to make sure our

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -261,10 +261,14 @@ def test_run(
     )
     if "sensor" in steps and has_evoked_conditions:
         assert dataset not in ("ds000247", "ds000375")
+        ds_path = test_options.get("dataset", dataset)
         avg_subj_path = (
-            DATA_DIR / "derivatives" / "mne-bids-pipeline" / dataset / "sub-average"
+            DATA_DIR / "derivatives" / "mne-bids-pipeline" / ds_path / "sub-average"
         )
         assert avg_subj_path.is_dir()
+        if ds_path == "ERP_CORE":
+            avg_subj_path = avg_subj_path / f"ses-{test_options['task']}"
+            assert avg_subj_path.is_dir()
         report_html_paths = list(avg_subj_path.rglob("sub-average*_report.html"))
         assert len(report_html_paths)
         parser = _ReportTOCFinder()
@@ -274,7 +278,7 @@ def test_run(
     else:
         # Just spot check a few that we know have "conditions" to make sure our
         # conditional is good
-        assert dataset not in ("ds000248", "ds004229")
+        assert dataset not in ("ds000248", "ds004229", "ERP_CORE_P3")
 
 
 @pytest.mark.parametrize("allow_missing_sessions", (False, True))

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -256,9 +256,9 @@ def test_run(
     config_data = config_path.read_text("utf-8")
 
     # sub-average evoked present in report
-    has_evoked_conditions = re.search(
-        r"^\s*conditions =", config_data, flags=re.MULTILINE
-    ) is not None
+    has_evoked_conditions = (
+        re.search(r"^\s*conditions =", config_data, flags=re.MULTILINE) is not None
+    )
     if "sensor" in steps and has_evoked_conditions:
         assert dataset not in ("ds000247", "ds000375")
         avg_subj_path = (

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -256,7 +256,9 @@ def test_run(
     config_data = config_path.read_text("utf-8")
 
     # sub-average evoked present in report
-    if re.search(r"^\s*conditions =", config_data, flags=re.MULTILINE):
+    if ("sensor" in steps
+        and re.search(r"^\s*conditions =", config_data, flags=re.MULTILINE)
+    ):
         assert dataset not in ("ds000247", "ds000375")
         avg_subj_path = (
             DATA_DIR / "derivatives" / "mne-bids-pipeline" / dataset / "sub-average"

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 from collections.abc import Collection, Generator
 from contextlib import nullcontext
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -170,6 +171,30 @@ def dataset_test(request: pytest.FixtureRequest) -> Generator[None, None, None]:
         yield
 
 
+class _ReportTOCFinder(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.in_a = False
+        self.in_toc = False
+        self.toc_links = list()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "a":
+            self.in_a = True
+        elif tag == "div" and ("id", "toc") in attrs:
+            self.in_toc = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "a":
+            self.in_a = False
+        elif tag == "div" and self.in_toc:
+            self.in_toc = False
+
+    def handle_data(self, data: str) -> None:
+        if self.in_a and self.in_toc:
+            self.toc_links.append(data)
+
+
 @pytest.mark.dataset_test
 @pytest.mark.parametrize("dataset", list(TEST_SUITE))
 def test_run(
@@ -226,6 +251,25 @@ def test_run(
     with capsys.disabled():
         print()
         main()
+    # post-run checks for correctness
+
+    # sub-average evoked present
+    config_data = config_path.read_text("utf-8")
+    avg_subj_path = (
+        DATA_DIR / "derivatives" / "mne-bids-pipeline" / dataset / "sub-average"
+    )
+    assert avg_subj_path.is_dir()
+    report_html_paths = list(avg_subj_path.rglob("sub-average*_report.html"))
+    assert len(report_html_paths)
+    parser = _ReportTOCFinder()
+    parser.feed(report_html_paths[0].read_text("utf-8"))
+    msg = "\n".join(["Not found in TOC titles:"] + parser.toc_links)
+    if "conditions" in config_data:
+        assert any("Average (sensor)" in name for name in parser.toc_links), msg
+    else:
+        # Just spot check a few that we know have "conditions" to make sure our
+        # conditional is good
+        assert dataset not in ("ds000248", "ds004229")
 
 
 @pytest.mark.parametrize("allow_missing_sessions", (False, True))

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -256,9 +256,10 @@ def test_run(
     config_data = config_path.read_text("utf-8")
 
     # sub-average evoked present in report
-    if ("sensor" in steps
-        and re.search(r"^\s*conditions =", config_data, flags=re.MULTILINE)
-    ):
+    has_evoked_conditions = re.search(
+        r"^\s*conditions =", config_data, flags=re.MULTILINE
+    )
+    if "sensor" in steps and has_evoked_conditions:
         assert dataset not in ("ds000247", "ds000375")
         avg_subj_path = (
             DATA_DIR / "derivatives" / "mne-bids-pipeline" / dataset / "sub-average"

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -258,7 +258,7 @@ def test_run(
     # sub-average evoked present in report
     has_evoked_conditions = re.search(
         r"^\s*conditions =", config_data, flags=re.MULTILINE
-    )
+    ) is not None
     if "sensor" in steps and has_evoked_conditions:
         assert dataset not in ("ds000247", "ds000375")
         avg_subj_path = (


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/dev.md.inc`)

Fixes a bug introduced in 1.10.0 where the `sub-average` report didn't contain grand-average Evoked plots because these were written into the report of the last subject instead :facepalm: 

We should probably cut a release after this. @drammock if you agree, should we just make it a 1.10.1 (with the speed enhancements) or a new 1.11.0?