### PR TITLE
Fix a small naming glitch for CSP in the report

### DIFF
--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -16,6 +16,7 @@
 
 - Fixed bug where [`log_level`][mne_bids_pipeline._config.log_level] was not being applied to the MBPlogger (#1224 by @larsoner)
 - Corrected import order: remove channels before setting template montage as stated in [`eeg_template_montage`][mne_bids_pipeline._config.eeg_template_montage] (#1220 by @dnacombo)
+- Fixed a small CSP labeling glitch in the report. (#1241 by @hoechenberger)
 
 [//5]: # (### :books: Documentation)
 

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -745,7 +745,7 @@ def add_csp_grand_average(
         "csp",
         f"{_sanitize_cond_tag(cond_1)}–{_sanitize_cond_tag(cond_2)}",
     ) + extra_tags
-    title = f"CSP decoding{prefix}{cond_1} vs. {cond_2}"
+    title = f"CSP decoding: {prefix}{cond_1} vs. {cond_2}"
     report.add_figure(
         fig=fig,
         title=title,

--- a/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
+++ b/mne_bids_pipeline/steps/sensor/_05_decoding_csp.py
@@ -425,7 +425,7 @@ def one_subject_decoding(
                 scores=all_decoding_scores,
                 metric=cfg.decoding_metric,
             )
-            title = f"CSP decoding{prefix}"
+            title = f"CSP decoding: {prefix}"
             report.add_figure(
                 fig=fig,
                 title=title,


### PR DESCRIPTION
E.g. in `main` we would produce:

```
CSP decodingresponse/incorrect vs. response/correct
```

With this PR, we produce:

```
CSP decoding: response/incorrect vs. response/correct
```

### Before merging …

- [x] Changelog has been updated (`docs/source/dev.md.inc`)
