### PR TITLE
Test and fix on_error behavior

### DIFF
--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -18,6 +18,7 @@
 - Corrected import order: remove channels before setting template montage as stated in [`eeg_template_montage`][mne_bids_pipeline._config.eeg_template_montage] (#1220 by @dnacombo)
 - Fixed crash when concatenating epochs from runs with different bad channels. The pipeline now uses the union of bad channels across runs. (#1242 by @hoechenberger)
 - Fixed a small CSP labeling glitch in the report. (#1241 by @hoechenberger)
+- Fixed bug where [`on_error`][mne_bids_pipeline._config.on_error] `"continue"` and `"debug"` were not respected by the `init` and `freesurfer/recon_all` steps, which could abort the whole run instead of moving on to (or debugging) the next subject (#1022 by @larsoner)
 
 [//5]: # (### :books: Documentation)
 

--- a/mne_bids_pipeline/_docs.py
+++ b/mne_bids_pipeline/_docs.py
@@ -12,9 +12,6 @@ from . import _config_utils, _decoding, _import_data
 
 _CONFIG_RE = re.compile(r"config\.([a-zA-Z_]+)")
 
-_NO_CONFIG = {
-    "freesurfer/_01_recon_all",
-}
 _IGNORE_OPTIONS = {
     "PIPELINE_NAME",
     "VERSION",
@@ -326,10 +323,7 @@ class _ParseConfigSteps:
                     assert isinstance(keyword.value.value, ast.Name)
                     assert keyword.value.value.id == "config", f"{where} {keyword.value.value.id}"  # noqa: E501  # fmt: skip
                     _add_step_option(step, option)
-            if step in _NO_CONFIG:
-                assert not found, f"Found unexpected get_config* in {step}"
-            else:
-                assert found, f"Could not find get_config* in {step}"
+            assert found, f"Could not find get_config* in {step}"
         for key in self._force_empty:
             steps[key] = list()
         for key, val in steps.items():

--- a/mne_bids_pipeline/steps/freesurfer/_01_recon_all.py
+++ b/mne_bids_pipeline/steps/freesurfer/_01_recon_all.py
@@ -9,7 +9,6 @@ import shutil
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
 
 from mne.utils import run_subprocess
 
@@ -21,32 +20,54 @@ from mne_bids_pipeline._config_utils import (
 )
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
+from mne_bids_pipeline._run import _prep_out_files_path, failsafe_run, save_logs
+from mne_bids_pipeline.typing import InFilesPathT, OutFilesT
 
 fs_bids_app = Path(__file__).parent / "contrib" / "run.py"
 
 
-def run_recon(
-    root_dir: Path,
-    subject: str,
-    fs_bids_app: Any,
-    subjects_dir: Path,
-    session: str | None = None,
-) -> None:
-    subj_dir = subjects_dir / f"sub-{subject}"
-    sub_ses = f"Subject {subject}"
+def get_input_fnames_run_recon(
+    *, cfg: SimpleNamespace, subject: str, session: str | None
+) -> InFilesPathT:
+    """Get input filenames for run_recon."""
+    # The inputs are the (arbitrarily many) raw anatomical MRI files somewhere in
+    # the BIDS dataset, which are impractical to hash individually here; whether to
+    # (re)run is instead governed entirely by whether the output below already
+    # exists (see get_output_fnames_run_recon).
+    return dict()
+
+
+def get_output_fnames_run_recon(
+    *, cfg: SimpleNamespace, subject: str, session: str | None
+) -> InFilesPathT:
+    out_files = dict()
+    subj_dir = cfg.subjects_dir / f"sub-{subject}"
     if session is not None:
         subj_dir = subj_dir.with_name(f"{subj_dir.name}_ses-{session}")
-        sub_ses = f"{sub_ses} session {session}"
+    # aparc+aseg.mgz is one of the last files written by `recon-all -all`, so its
+    # presence is a reasonable proxy for "recon-all has already completed".
+    out_files["aseg"] = subj_dir / "mri" / "aparc+aseg.mgz"
+    return out_files
 
-    if subj_dir.exists():
-        msg = (
-            f"Recon for {sub_ses} is already present. Please delete the "
-            f"directory if you want to recompute."
-        )
-        logger.info(**gen_log_kwargs(message=msg))
-        return
+
+@failsafe_run(
+    get_input_fnames=get_input_fnames_run_recon,
+    get_output_fnames=get_output_fnames_run_recon,
+)
+def run_recon(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    session: str | None,
+    in_files: InFilesPathT,
+) -> OutFilesT:
+    assert not in_files, "run_recon should not receive any input files"
+    sub_ses = f"Subject {subject}"
+    if session is not None:
+        sub_ses = f"{sub_ses} session {session}"
     msg = (
-        "Running recon-all on {sub_ses}. This will take "
+        f"Running recon-all on {sub_ses}. This will take "
         "a LONG time – it's a good idea to let it run over night."
     )
     logger.info(**gen_log_kwargs(message=msg))
@@ -64,8 +85,8 @@ def run_recon(
     cmd = [
         f"{sys.executable}",
         f"{fs_bids_app}",
-        f"{root_dir}",
-        f"{subjects_dir}",
+        f"{cfg.bids_root}",
+        f"{cfg.subjects_dir}",
         "participant",
         "--n_cpus=2",
         "--stages=all",
@@ -77,6 +98,24 @@ def run_recon(
         cmd += [f"--session_label={session}"]
     logger.debug("Running: " + " ".join(cmd))
     run_subprocess(cmd, env=env, verbose=logger.level)
+
+    out_files = get_output_fnames_run_recon(cfg=cfg, subject=subject, session=session)
+    return _prep_out_files_path(
+        exec_params=exec_params,
+        out_files=out_files,
+        check_relative=cfg.subjects_dir,
+    )
+
+
+def get_config(
+    *,
+    config: SimpleNamespace,
+) -> SimpleNamespace:
+    cfg = SimpleNamespace(
+        bids_root=config.bids_root,
+        subjects_dir=get_fs_subjects_dir(config=config),
+    )
+    return cfg
 
 
 def main(*, config: SimpleNamespace) -> None:
@@ -103,9 +142,8 @@ def main(*, config: SimpleNamespace) -> None:
     """  # noqa
     subjects = get_subjects(config)
     sessions = get_sessions(config)
-    root_dir = config.bids_root
-    subjects_dir = Path(get_fs_subjects_dir(config))
-    subjects_dir.mkdir(parents=True, exist_ok=True)
+    cfg = get_config(config=config)
+    cfg.subjects_dir.mkdir(parents=True, exist_ok=True)
 
     # check for session-specific MRIs within subject, and handle accordingly
     subj_sess = list()
@@ -113,7 +151,7 @@ def main(*, config: SimpleNamespace) -> None:
         for _sess in sessions:
             session = (
                 _sess
-                if _has_session_specific_anat(_subj, _sess, subjects_dir)
+                if _has_session_specific_anat(_subj, _sess, cfg.subjects_dir)
                 else None
             )
             subj_sess.append((_subj, session))
@@ -124,13 +162,18 @@ def main(*, config: SimpleNamespace) -> None:
             exec_params=config.exec_params,
             n_iter=len(subj_sess),
         )
-        parallel(
-            run_func(root_dir, subject, fs_bids_app, subjects_dir, session)
+        logs = parallel(
+            run_func(
+                cfg=get_config(config=config),
+                exec_params=config.exec_params,
+                subject=subject,
+                session=session,
+            )
             for subject, session in subj_sess
         )
 
         # Handle fsaverage
-        fsaverage_dir = subjects_dir / "fsaverage"
+        fsaverage_dir = cfg.subjects_dir / "fsaverage"
         if fsaverage_dir.exists():
             if fsaverage_dir.is_symlink():
                 fsaverage_dir.unlink()
@@ -139,5 +182,7 @@ def main(*, config: SimpleNamespace) -> None:
 
         env = os.environ
         shutil.copytree(
-            f"{env['FREESURFER_HOME']}/subjects/fsaverage", subjects_dir / "fsaverage"
+            f"{env['FREESURFER_HOME']}/subjects/fsaverage",
+            cfg.subjects_dir / "fsaverage",
         )
+    save_logs(config=config, logs=logs)

--- a/mne_bids_pipeline/steps/init/_01_init_derivatives_dir.py
+++ b/mne_bids_pipeline/steps/init/_01_init_derivatives_dir.py
@@ -11,7 +11,12 @@ from mne_bids.utils import _write_json
 from mne_bids_pipeline._config_utils import _bids_kwargs, get_subjects_sessions
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._report import _open_report, _report_path
-from mne_bids_pipeline._run import _prep_out_files_path, failsafe_run
+from mne_bids_pipeline._run import (
+    _prep_out_files,
+    _prep_out_files_path,
+    failsafe_run,
+    save_logs,
+)
 from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
 
@@ -49,14 +54,24 @@ def init_dataset(
     return _prep_out_files_path(exec_params=exec_params, out_files=out_files)
 
 
+def get_input_fnames_init_subject_dirs(
+    *, cfg: SimpleNamespace, subject: str, session: str | None
+) -> InFilesT:
+    """Get input filenames for init_subject_dirs."""
+    return dict()
+
+
+@failsafe_run(get_input_fnames=get_input_fnames_init_subject_dirs)
 def init_subject_dirs(
     *,
     cfg: SimpleNamespace,
     exec_params: SimpleNamespace,
     subject: str,
     session: str | None,
-) -> None:
+    in_files: InFilesT,
+) -> OutFilesT:
     """Create processing data output directories for individual participants."""
+    assert not in_files, "init_subject_dirs should not receive any input files"
     out_dir = cfg.deriv_root / f"sub-{subject}"
     if session is not None:
         out_dir /= f"ses-{session}"
@@ -64,7 +79,9 @@ def init_subject_dirs(
 
     out_dir.mkdir(exist_ok=True, parents=True)
 
-    if not _report_path(cfg=cfg, subject=subject, session=session).fpath.is_file():
+    out_files = dict()
+    out_files["report"] = _report_path(cfg=cfg, subject=subject, session=session)
+    if not out_files["report"].fpath.is_file():
         with _open_report(
             cfg=cfg,
             exec_params=exec_params,
@@ -72,9 +89,10 @@ def init_subject_dirs(
             session=session,
         ):
             pass
+    return _prep_out_files(exec_params=exec_params, out_files=out_files)
 
 
-def get_config(
+def get_config_init_dataset(
     *,
     config: SimpleNamespace,
 ) -> SimpleNamespace:
@@ -87,18 +105,33 @@ def get_config(
     return cfg
 
 
+def get_config_init_subject_dirs(
+    *,
+    config: SimpleNamespace,
+) -> SimpleNamespace:
+    # Deliberately excludes PIPELINE_NAME/VERSION/CODE_URL (unlike
+    # get_config_init_dataset): those aren't needed here, and including them would
+    # cause unnecessary cache misses whenever they change (e.g. between releases).
+    return SimpleNamespace(**_bids_kwargs(config=config))
+
+
 def main(*, config: SimpleNamespace) -> None:
     """Initialize the output directories."""
-    init_dataset(cfg=get_config(config=config), exec_params=config.exec_params)
+    logs = [
+        init_dataset(
+            cfg=get_config_init_dataset(config=config), exec_params=config.exec_params
+        )
+    ]
     # Don't bother with parallelization here as I/O operations are generally
     # not well parallelized (and this should be very fast anyway)
     for subject, sessions in get_subjects_sessions(config).items():
         for session in sessions:
-            init_subject_dirs(
-                cfg=get_config(
-                    config=config,
-                ),
-                exec_params=config.exec_params,
-                subject=subject,
-                session=session,
+            logs.append(
+                init_subject_dirs(
+                    cfg=get_config_init_subject_dirs(config=config),
+                    exec_params=config.exec_params,
+                    subject=subject,
+                    session=session,
+                )
             )
+    save_logs(config=config, logs=logs)

--- a/mne_bids_pipeline/tests/test_functions.py
+++ b/mne_bids_pipeline/tests/test_functions.py
@@ -35,10 +35,6 @@ def test_all_functions_return(module_name: str) -> None:
             f"{module_name}.{name} is missing failsafe_run decorator"
         )
         funcs.append(obj)
-    # Some module names we know don't have any
-    if module_name.split(".")[-1] in ("_01_recon_all",):
-        assert len(funcs) == 0
-        return
 
     assert len(funcs) != 0, f"No failsafe_runs functions found in {module_name}"
 

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -10,6 +10,7 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, TypedDict
 
+import pandas as pd
 import pytest
 from h5io import read_hdf5
 from mne_bids import BIDSPath, get_bids_path_from_fname
@@ -18,6 +19,7 @@ from mne_bids_pipeline._config_import import _import_config
 from mne_bids_pipeline._config_utils import _get_ssrt
 from mne_bids_pipeline._download import main as download_main
 from mne_bids_pipeline._main import main
+from mne_bids_pipeline.steps.freesurfer import _01_recon_all
 from mne_bids_pipeline.steps.preprocessing._01_data_quality import (
     get_config as get_config_data_quality,
 )
@@ -281,6 +283,78 @@ def test_run(
         assert dataset not in ("ds000248", "ds004229", "ERP_CORE_P3")
 
 
+def _make_fake_bids_dataset(
+    bids_root: Path,
+    *,
+    subjects: list[str],
+    task: str,
+    sessions: tuple[str | None, ...] = (None,),
+    runs: tuple[str | None, ...] = (None,),
+    suffixes: tuple[str, ...] = (
+        "channels.tsv",
+        "events.tsv",
+        "eeg.vhdr",
+        "eeg.vmrk",
+        "eeg.eeg",
+        "eeg.json",
+    ),
+) -> None:
+    """Create a minimal fake BIDS EEG dataset with empty (invalid) data files.
+
+    The files exist so mne_bids can find them, but their content is empty, so
+    actually reading them fails "for real" if a test goes that far. This matters
+    for on_error tests: the failure needs to reproduce even inside separate
+    (loky) worker processes, which a monkeypatched function would not.
+    """
+    for subject in subjects:
+        sub = f"sub-{subject}"
+        for session in sessions:
+            ses_entity = f"_ses-{session}" if session is not None else ""
+            eeg_dir = (
+                f"{sub}/ses-{session}/eeg" if session is not None else f"{sub}/eeg"
+            )
+            for run in runs:
+                run_entity = f"_run-{run}" if run is not None else ""
+                stem = f"{sub}{ses_entity}_task-{task}{run_entity}"
+                for suffix in suffixes:
+                    file_path = bids_root / eeg_dir / f"{stem}_{suffix}"
+                    file_path.parent.mkdir(parents=True, exist_ok=True)
+                    file_path.touch()
+    for _file in ("dataset_description.json", "participants.tsv", "participants.json"):
+        (bids_root / _file).touch()
+
+
+def _write_pipeline_config(
+    config_path: Path,
+    *,
+    bids_root: Path,
+    deriv_root: Path,
+    ch_types: list[str] | None = None,
+    conditions: list[str] | None = None,
+    **extra: Any,
+) -> None:
+    """Write a minimal pipeline config file from keyword arguments.
+
+    `ch_types`/`conditions` default to the minimal values used across our
+    fake-dataset tests. Any other pipeline config option can be passed via
+    `extra`, e.g. `subjects=[...]`, `task=...`, `on_error=...`,
+    `allow_missing_sessions=...`.
+    """
+    config: dict[str, Any] = dict(
+        bids_root=bids_root,
+        deriv_root=deriv_root,
+        ch_types=["eeg"] if ch_types is None else ch_types,
+        conditions=["zzz"] if conditions is None else conditions,
+        **extra,
+    )
+    lines = []
+    for key, val in config.items():
+        if isinstance(val, Path):
+            val = str(val)
+        lines.append(f"{key} = {val!r}")
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 @pytest.mark.parametrize("allow_missing_sessions", (False, True))
 def test_missing_sessions(
     monkeypatch: pytest.MonkeyPatch,
@@ -291,37 +365,21 @@ def test_missing_sessions(
     """Test the `allow_missing_sessions` config variable."""
     dataset = "fake"
     bids_root = tmp_path / dataset
-    files = (
-        "dataset_description.json",
-        *(f"participants.{x}" for x in ("json", "tsv")),
-        *(f"sub-1/sub-1_sessions.{x}" for x in ("json", "tsv")),
-        *(
-            f"sub-1/ses-a/eeg/sub-1_ses-a_task-foo_{x}.tsv"
-            for x in ("channels", "events")
-        ),
-        *(
-            f"sub-1/ses-a/eeg/sub-1_ses-a_task-foo_eeg.{x}"
-            for x in ("eeg", "json", "vhdr", "vmrk")
-        ),
-    )
-    for _file in files:
-        path = bids_root / _file
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.touch()
+    # Only session "a" gets data on disk; session "b" is deliberately missing.
+    _make_fake_bids_dataset(bids_root, subjects=["1"], task="foo", sessions=("a",))
+    for suffix in ("json", "tsv"):
+        (bids_root / "sub-1" / f"sub-1_sessions.{suffix}").touch()
     # fake a config file (can't use static file because `bids_root` is in `tmp_path`)
-    config = f"""
-bids_root = "{bids_root}"
-deriv_root = "{tmp_path / "derivatives" / "mne-bids-pipeline" / dataset}"
-interactive = False
-subjects = ["1"]
-sessions = ["a", "b"]
-ch_types = ["eeg"]
-conditions = ["zzz"]
-allow_missing_sessions = {allow_missing_sessions}
-"""
     config_path = tmp_path / "fake_config_missing_session.py"
-    with open(config_path, "w") as fid:
-        fid.write(config)
+    _write_pipeline_config(
+        config_path,
+        bids_root=bids_root,
+        deriv_root=tmp_path / "derivatives" / "mne-bids-pipeline" / dataset,
+        interactive=False,
+        subjects=["1"],
+        sessions=["a", "b"],
+        allow_missing_sessions=allow_missing_sessions,
+    )
     # set up the context handler
     context = (
         nullcontext()
@@ -488,40 +546,23 @@ def test_all_runs_picked(tmp_path: Path, runs: list[str]) -> None:
     task = "FCSRT"
     session = "M0"
     bids_root = tmp_path / dataset
-    files = [
-        "dataset_description.json",
-        *(f"participants.{x}" for x in ("json", "tsv")),
-    ]
-    for r in runs:
-        path = (
-            f"sub-{subject}/ses-{session}/eeg/"
-            f"sub-{subject}_ses-{session}_task-{task}_run-{r:02d}"
-        )
-        files.extend(
-            [
-                f"{path}_{x}"
-                for x in (
-                    "channels.tsv",
-                    "events.tsv",
-                    "eeg.vhdr",
-                )
-            ]
-        )
-    for _file in files:
-        path = bids_root / _file
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.touch()
+    _make_fake_bids_dataset(
+        bids_root,
+        subjects=[subject],
+        task=task,
+        sessions=(session,),
+        runs=tuple(f"{r:02d}" for r in runs),
+        suffixes=("channels.tsv", "events.tsv", "eeg.vhdr"),
+    )
     # fake a config file (can't use static file because `bids_root` is in `tmp_path`)
-    config_content = f"""
-bids_root = "{bids_root}"
-deriv_root = "{tmp_path / "derivatives" / "mne-bids-pipeline" / dataset}"
-subjects = ["{subject}"]
-runs = "all"
-ch_types = ["eeg"]
-conditions = ["zzz"]
-"""
     config_path = tmp_path / "fake_config_missing_session.py"
-    config_path.write_text(config_content, encoding="utf-8")
+    _write_pipeline_config(
+        config_path,
+        bids_root=bids_root,
+        deriv_root=tmp_path / "derivatives" / "mne-bids-pipeline" / dataset,
+        subjects=[subject],
+        runs="all",
+    )
     config = _import_config(config_path=config_path)
     cfg = get_config_data_quality(config=config, subject=subject, session=session)
     ssrt = _get_ssrt(config=config, which=("runs",))
@@ -537,3 +578,191 @@ conditions = ["zzz"]
         )
         for key, path in fnames.items():
             assert path.fpath.is_file(), f"File for {key=} not found: {path.fpath}"
+
+
+@pytest.fixture()
+def fake_freesurfer_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Fake a minimal FreeSurfer installation (license + fsaverage dir only)."""
+    fs_home = tmp_path / "freesurfer_home"
+    (fs_home / "license.txt").parent.mkdir(parents=True, exist_ok=True)
+    (fs_home / "license.txt").touch()
+    (fs_home / "subjects" / "fsaverage").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("FREESURFER_HOME", str(fs_home))
+    return fs_home
+
+
+def _run_main(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    config_path: Path,
+    steps: str,
+) -> None:
+    monkeypatch.setenv("_MNE_BIDS_STUDY_TESTING", "true")
+    monkeypatch.setattr(
+        sys, "argv", ["mne_bids_pipeline", str(config_path), f"--steps={steps}"]
+    )
+    with capsys.disabled():
+        print()
+        main()
+
+
+@pytest.mark.parametrize(
+    ("on_error", "n_jobs"),
+    [
+        pytest.param("continue", 1, id="continue-serial"),
+        pytest.param("abort", 1, id="abort-serial"),
+        pytest.param("debug", 1, id="debug-serial"),
+        pytest.param("continue", 2, id="continue-parallel"),
+        pytest.param("abort", 2, id="abort-parallel"),
+    ],
+)
+def test_on_error(
+    on_error: str,
+    n_jobs: int,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that `on_error` controls whether the pipeline aborts or continues.
+
+    The "-parallel" cases (n_jobs=2) matter because with n_jobs>1 subjects are
+    dispatched to separate (loky) worker processes; see _make_fake_bids_dataset.
+    """
+    subjects = ["01", "02", "03", "04"] if n_jobs > 1 else ["01", "02"]
+    task = "task1"
+    bids_root = tmp_path / "on_error"
+    _make_fake_bids_dataset(bids_root, subjects=subjects, task=task)
+
+    deriv_root = tmp_path / "derivatives" / "mne-bids-pipeline" / "on_error"
+    config_path = tmp_path / "config_on_error.py"
+    _write_pipeline_config(
+        config_path,
+        bids_root=bids_root,
+        deriv_root=deriv_root,
+        subjects=subjects,
+        task=task,
+        on_error=on_error,
+        n_jobs=n_jobs,
+    )
+
+    debug_calls: list[None] = []
+    if on_error == "debug":
+        # Don't actually drop into an interactive debugger.
+        monkeypatch.setattr("pdb.post_mortem", lambda tb: debug_calls.append(None))
+
+    steps = "preprocessing/data_quality"
+    if on_error == "debug":
+        with pytest.raises(SystemExit):
+            _run_main(monkeypatch, capsys, config_path, steps)
+        assert debug_calls == [None]
+    elif on_error == "abort":
+        with pytest.raises(Exception):  # noqa: B017
+            _run_main(monkeypatch, capsys, config_path, steps)
+    else:
+        assert on_error == "continue"
+        _run_main(monkeypatch, capsys, config_path, steps)
+        # Every subject should show up in the log, proving that none were
+        # skipped due to an early abort, even under real parallel execution.
+        log_files = list(deriv_root.glob("task-*_log.xlsx"))
+        assert len(log_files) == 1, log_files
+        sheets = pd.read_excel(log_files[0], sheet_name=None)
+        (df,) = [df for name, df in sheets.items() if "data_quality" in name]
+        seen_subjects = sorted(df["subject"].astype(str).str.zfill(2).unique())
+        assert seen_subjects == subjects
+        assert (~df["success"]).all()
+
+
+@pytest.mark.parametrize("on_error", ["continue", "abort"])
+def test_recon_all_on_error(
+    on_error: str,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_freesurfer_home: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that recon-all also honors `on_error` (gh-1022)."""
+    subjects = ["01", "02"]
+    task = "task1"
+    bids_root = tmp_path / "recon_all_on_error"
+    _make_fake_bids_dataset(bids_root, subjects=subjects, task=task)
+
+    deriv_root = tmp_path / "derivatives" / "mne-bids-pipeline" / "recon_all_on_error"
+    subjects_dir = bids_root / "derivatives" / "freesurfer" / "subjects"
+    config_path = tmp_path / "config_recon_all_on_error.py"
+    _write_pipeline_config(
+        config_path,
+        bids_root=bids_root,
+        deriv_root=deriv_root,
+        subjects=subjects,
+        task=task,
+        subjects_dir=subjects_dir,
+        on_error=on_error,
+    )
+
+    # Replace the actual recon-all subprocess call with one that fails
+    # unconditionally, and keep track of how many subjects were attempted (this
+    # step is not tested under n_jobs>1, so the monkeypatch is reliable here).
+    calls: list[None] = []
+
+    def _raise(cmd: list[str], **kwargs: Any) -> None:
+        calls.append(None)
+        raise RuntimeError("Simulated recon-all failure for on_error test")
+
+    monkeypatch.setattr(_01_recon_all, "run_subprocess", _raise)
+
+    steps = "freesurfer/recon_all"
+    if on_error == "abort":
+        with pytest.raises(RuntimeError, match="Simulated recon-all failure"):
+            _run_main(monkeypatch, capsys, config_path, steps)
+    else:
+        assert on_error == "continue"
+        _run_main(monkeypatch, capsys, config_path, steps)
+
+    # "continue" should process every subject; "abort" should stop as soon as
+    # the first subject fails.
+    if on_error == "continue":
+        assert len(calls) == len(subjects)
+    else:
+        assert len(calls) == 1
+
+
+def test_recon_all_skips_existing(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_freesurfer_home: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that recon-all is skipped when its output already exists (gh-1022)."""
+    subject = "01"
+    task = "task1"
+    bids_root = tmp_path / "recon_all_skip"
+    _make_fake_bids_dataset(bids_root, subjects=[subject], task=task)
+
+    deriv_root = tmp_path / "derivatives" / "mne-bids-pipeline" / "recon_all_skip"
+    subjects_dir = bids_root / "derivatives" / "freesurfer" / "subjects"
+    # Pre-create the sentinel output file that marks recon-all as already done.
+    aseg = subjects_dir / f"sub-{subject}" / "mri" / "aparc+aseg.mgz"
+    aseg.parent.mkdir(parents=True, exist_ok=True)
+    aseg.touch()
+
+    config_path = tmp_path / "config_recon_all_skip.py"
+    _write_pipeline_config(
+        config_path,
+        bids_root=bids_root,
+        deriv_root=deriv_root,
+        subjects=[subject],
+        task=task,
+        subjects_dir=subjects_dir,
+    )
+
+    calls: list[None] = []
+
+    def _raise(cmd: list[str], **kwargs: Any) -> None:
+        calls.append(None)
+        raise RuntimeError("recon-all should not have been invoked")
+
+    monkeypatch.setattr(_01_recon_all, "run_subprocess", _raise)
+
+    _run_main(monkeypatch, capsys, config_path, "freesurfer/recon_all")
+
+    assert calls == []


### PR DESCRIPTION
Closes #1022

1. Ensure all steps run with `failsafe_run_wrapper`
2. Improve completion logic in FreeSurfer (gating on a late-`recon-all` stage MRI file)
3. Add tests for `--continue` behavior (#1022)
4. DRY code for creating fake datasets as part of adding new tests

Initial draft made with an assist from Claude Sonnet 5, but I modified and vouch for all code.

This one is a pretty straightforward test + fix, so I'll mark for merge-when-green, but happy to make any changes if anyone wants to look.

### Before merging …

- [x] Changelog has been updated (`docs/source/dev.md.inc`)
