### PR TITLE
Validate and document rest_epochs_duration

### DIFF
--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -15,6 +15,7 @@
 
 ### :bug: Bug fixes
 
+- Raise an informative error if [`rest_epochs_duration`][mne_bids_pipeline._config.rest_epochs_duration] is not set for resting-state data and document the parameter (#1272 by @viranovskaya)
 - Fixed bug where [`log_level`][mne_bids_pipeline._config.log_level] was not being applied to the MBPlogger (#1224 by @larsoner)
 - Corrected import order: remove channels before setting template montage as stated in [`eeg_template_montage`][mne_bids_pipeline._config.eeg_template_montage] (#1220 by @dnacombo)
 - Fixed crash when concatenating epochs from runs with different bad channels. The pipeline now uses the union of bad channels across runs. (#1242 by @hoechenberger)

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -1197,7 +1197,10 @@ Can be a dict mapping task names to tmax values.
 
 rest_epochs_duration: float | None = None
 """
-Duration of epochs in seconds.
+Duration of fixed-length epochs, in seconds. This parameter must be set when
+[`task_is_rest`][mne_bids_pipeline._config.task_is_rest] is `True`. Use
+[`rest_epochs_overlap`][mne_bids_pipeline._config.rest_epochs_overlap] to control
+the overlap between consecutive epochs.
 """
 
 rest_epochs_overlap: float | None = None

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -503,6 +503,12 @@ def _check_config(config: SimpleNamespace, config_path: PathLike | None) -> None
         )
 
     # Another check that depends on some of the functions defined above
+    if config.task_is_rest and config.rest_epochs_duration is None:
+        raise ValueError(
+            "Please set `rest_epochs_duration` in your configuration when "
+            "`task_is_rest` is True."
+        )
+
     if not config.task_is_rest and config.conditions is None:
         raise ValueError(
             "Please indicate the name of your conditions in your "

--- a/mne_bids_pipeline/tests/test_validation.py
+++ b/mne_bids_pipeline/tests/test_validation.py
@@ -11,11 +11,7 @@ from mne_bids_pipeline._config_import import ConfigError, _import_config
 def test_rest_epochs_duration_validation(tmp_path: Path) -> None:
     """Test that resting-state epoch duration is required."""
     config_path = tmp_path / "config.py"
-    config_text = (
-        f"bids_root = '{tmp_path}'\n"
-        "ch_types = ['eeg']\n"
-        "task_is_rest = True\n"
-    )
+    config_text = f"bids_root = '{tmp_path}'\nch_types = ['eeg']\ntask_is_rest = True\n"
     config_path.write_text(config_text)
 
     with pytest.raises(ValueError, match="Please set `rest_epochs_duration`"):

--- a/mne_bids_pipeline/tests/test_validation.py
+++ b/mne_bids_pipeline/tests/test_validation.py
@@ -8,6 +8,25 @@ import pytest
 from mne_bids_pipeline._config_import import ConfigError, _import_config
 
 
+def test_rest_epochs_duration_validation(tmp_path: Path) -> None:
+    """Test that resting-state epoch duration is required."""
+    config_path = tmp_path / "config.py"
+    config_text = (
+        f"bids_root = '{tmp_path}'\n"
+        "ch_types = ['eeg']\n"
+        "task_is_rest = True\n"
+    )
+    config_path.write_text(config_text)
+
+    with pytest.raises(ValueError, match="Please set `rest_epochs_duration`"):
+        _import_config(config_path=config_path)
+
+    config_path.write_text(
+        config_text + "rest_epochs_duration = 30\nrest_epochs_overlap = 0\n"
+    )
+    _import_config(config_path=config_path)
+
+
 def test_validation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """Test that misspellings are caught by our config import validator."""
     config_path = tmp_path / "config.py"


### PR DESCRIPTION
Fixes #1020.

When `task_is_rest=True` and `rest_epochs_duration` is not set, configuration
validation now raises a clear error before epoch creation.

The parameter documentation now explains that it sets the length of
fixed-duration resting-state epochs and how `rest_epochs_overlap` is used.

The regression test covers both a missing duration and a valid resting-state
configuration.

### Before merging …

- [x] Changelog has been updated (`docs/source/dev.md`)
