### PR TITLE
Switch to mne-tools scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: Check Qt
           command: |
-            wget -q https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/check_qt_import.sh
+            wget -q https://raw.githubusercontent.com/mne-tools/mne-tools/main/tools/check_qt_import.sh
             bash check_qt_import.sh PySide6
       # Look at what we have and fail early if there is some library conflict
       - run:

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -36,7 +36,7 @@ echo "export RUN_TESTS=\".circleci/run_dataset_and_copy_files.sh\"" | tee -a "$B
 echo "export DOWNLOAD_DATA=\"coverage run -m mne_bids_pipeline._download\"" | tee -a "$BASH_ENV"
 
 # Similar CircleCI setup to mne-python (Xvfb, minimal commands, env vars)
-wget -q https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/setup_xvfb.sh
+wget -q https://raw.githubusercontent.com/mne-tools/mne-tools/main/tools/setup_xvfb.sh
 bash setup_xvfb.sh
 sudo apt install -qq tcsh libxft2
 wget -q https://raw.githubusercontent.com/mne-tools/mne-python/main/tools/get_minimal_commands.sh


### PR DESCRIPTION
`setup_xvfb.sh` and `check_qt_import.sh` tools are being moved from MNE-Python (https://github.com/mne-tools/mne-python/pull/13971) to MNE-Tools (https://github.com/mne-tools/mne-tools).

This PR makes it so the scripts are accessed in the CIs from their new home.