### PR TITLE
Clean up documented options code and options passing

### DIFF
--- a/.circleci/run_dataset_and_copy_files.sh
+++ b/.circleci/run_dataset_and_copy_files.sh
@@ -47,6 +47,13 @@ else
 fi
 test $RUN_TIME -le $RERUN_LIMIT
 
+# Most of the pipeline runs in loky/dask worker processes, which write their own
+# coverage data files (see [tool.coverage.run] in pyproject.toml). Merge them into
+# the main one before the upload, or everything executed in a worker looks
+# uncovered. --append is required so the parent process's data is kept too.
+coverage combine --append || true
+coverage xml || true
+
 if [[ "$COPY_FILES" == "false" ]]; then
   echo -e "${EMPH}Not copying files${RESET}"
   exit 0

--- a/.circleci/run_dataset_and_copy_files.sh
+++ b/.circleci/run_dataset_and_copy_files.sh
@@ -47,10 +47,7 @@ else
 fi
 test $RUN_TIME -le $RERUN_LIMIT
 
-# Most of the pipeline runs in loky/dask worker processes, which write their own
-# coverage data files (see [tool.coverage.run] in pyproject.toml). Merge them into
-# the main one before the upload, or everything executed in a worker looks
-# uncovered. --append is required so the parent process's data is kept too.
+# Merge in coverage from loky/dask workers; --append keeps the parent's data.
 coverage combine --append || true
 coverage xml || true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,10 @@ jobs:
     - run: pip install -ve . --group dev "mne-bids[full] @ git+https://github.com/mne-tools/mne-bids@main" "openneuro-py @ https://api.github.com/repos/openneuro-py/openneuro-py/zipball/main" codespell tomli --only-binary="numpy,scipy,pandas,matplotlib,pyarrow,numexpr"
     - run: lefthook run pre-commit --all-files  # fail early if code style issues!
     - run: pytest mne_bids_pipeline -m "not dataset_test"
+    # merge coverage written by loky/dask worker processes; see
+    # [tool.coverage.run] in pyproject.toml
+    - run: coverage combine --append || true
+    - run: coverage xml || true
     - uses: codecov/codecov-action@v7
       if: success()
       name: 'Upload coverage to CodeCov'
@@ -79,6 +83,8 @@ jobs:
       - run: pytest --cov-append -k ${{ matrix.dataset }} mne_bids_pipeline/
         timeout-minutes: 1
         name: Rerun ${{ matrix.dataset }} test to check all steps cached
+      - run: coverage combine --append || true
+      - run: coverage xml || true
       - uses: codecov/codecov-action@v7
         if: success() || failure()
   non-doc-dataset-tests:
@@ -108,3 +114,8 @@ jobs:
       - run: python -m mne_bids_pipeline._download MNE-funloc-data
         if: steps.MNE-funloc-data-cache.outputs.cache-hit != 'true'
       - run: pytest --cov-append -k test_session_specific_mri mne_bids_pipeline/
+      - run: coverage combine --append || true
+      - run: coverage xml || true
+      - uses: codecov/codecov-action@v7
+        if: success()
+        name: 'Upload coverage to CodeCov'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,7 @@ jobs:
     - run: pip install -ve . --group dev "mne-bids[full] @ git+https://github.com/mne-tools/mne-bids@main" "openneuro-py @ https://api.github.com/repos/openneuro-py/openneuro-py/zipball/main" codespell tomli --only-binary="numpy,scipy,pandas,matplotlib,pyarrow,numexpr"
     - run: lefthook run pre-commit --all-files  # fail early if code style issues!
     - run: pytest mne_bids_pipeline -m "not dataset_test"
-    # merge coverage written by loky/dask worker processes; see
-    # [tool.coverage.run] in pyproject.toml
+    # merge in coverage from loky/dask workers; see [tool.coverage.run]
     - run: coverage combine --append || true
     - run: coverage xml || true
     - uses: codecov/codecov-action@v7

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,7 @@ mne_bids_pipeline.egg-info/
 build/
 .hypothesis/
 .coverage*
+coverage.xml
+/.claude/
 junit-results.xml
 .cache/

--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -28,3 +28,4 @@
 ### :medical_symbol: Code health and infrastructure
 
 - Pinned Python version for development to 3.13. (#1243 by @hoechenberger)
+- Improved the accounting of options used in each step (#1268 by @larsoner)

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -962,6 +962,17 @@ def _bids_kwargs(*, config: SimpleNamespace) -> dict[str, str | None]:
     )
 
 
+def _mf_cal_kwargs(
+    *, config: SimpleNamespace, subject: str, session: str | None
+) -> dict[str, Any]:
+    """Get the Maxwell filter calibration / cross-talk params."""
+    return dict(
+        mf_cal_fname=get_mf_cal_fname(config=config, subject=subject, session=session),
+        mf_ctc_fname=get_mf_ctc_fname(config=config, subject=subject, session=session),
+        mf_head_origin=config.mf_head_origin,
+    )
+
+
 def _do_mf_autobad(*, cfg: SimpleNamespace) -> bool:
     return bool(cfg.find_noisy_channels_meg or cfg.find_flat_channels_meg)
 

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -281,10 +281,14 @@ def get_subjects_sessions(
 def get_subjects_given_session(
     config: SimpleNamespace, session: str | None
 ) -> tuple[str, ...]:
-    """Get the subjects who actually have data for a given session."""
-    sub_ses = get_subjects_sessions(config)
+    """Get the subjects who actually have data for a given session.
+
+    Steps call this at run time with their ``cfg``, so it reads the mapping that
+    ``get_config()`` already resolved instead of re-scanning the dataset (which
+    it used to do on every call, and then discard unless sessions were missing).
+    """
     subjects = (
-        tuple(sub for sub, ses in sub_ses.items() if session in ses)
+        tuple(sub for sub, ses in config.subjects_sessions.items() if session in ses)
         if config.allow_missing_sessions
         else config.subjects
     )

--- a/mne_bids_pipeline/_docs.py
+++ b/mne_bids_pipeline/_docs.py
@@ -1,6 +1,6 @@
 import ast
 import inspect
-import re
+import textwrap
 from collections import defaultdict
 from pathlib import Path
 from types import FunctionType
@@ -8,29 +8,14 @@ from typing import Any
 
 from tqdm import tqdm
 
-from . import _config_utils, _decoding, _import_data
-
-_CONFIG_RE = re.compile(r"config\.([a-zA-Z_]+)")
+from . import _config_utils
 
 _IGNORE_OPTIONS = {
     "PIPELINE_NAME",
     "VERSION",
     "CODE_URL",
     "all_tasks",
-}
-# We don't need to parse the config itself, just the steps
-_MANUAL_KWS = {
-    "preprocessing/_01_data_quality:get_config:extra_kwargs": (
-        "mf_cal_fname",
-        "mf_ctc_fname",
-        "mf_head_origin",
-        "find_flat_channels_meg",
-        "find_noisy_channels_meg",
-    ),
-    "preprocessing/_06a1_fit_ica:get_config:epochs_tmin": ("epochs_tmin",),
-    "preprocessing/_06a1_fit_ica:get_config:epochs_tmax": ("epochs_tmax",),
-    "source/_04_make_forward:get_config:t1_bids_path": ("mri_t1_path_generator",),
-    "source/_04_make_forward:get_config:landmarks_kind": ("mri_landmarks_kind",),
+    "exec_params",
 }
 # Some don't show up so force them to be empty
 _EXECUTION_OPTIONS = (
@@ -98,236 +83,80 @@ _FORCE_EMPTY = _EXECUTION_OPTIONS + (
     "data_type",
     "allow_missing_sessions",
 )
-# Eventually we could parse AST to get these, but this is simple enough
-_EXTRA_FUNCS = {
-    "_import_data_kwargs": ("get_mf_reference_run_task",),
-    "get_sessions": ("_get_sessions",),
-    "_decoding_preproc_steps": ("_get_rank",),
-}
+
+
+def _collect_options(
+    node: ast.AST,
+    namespace: dict[str, Any],
+    options: list[str],
+    seen: set[tuple[str, str]],
+) -> None:
+    """Collect config.* attribute accesses in node, recursing into called functions."""
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Attribute):
+            if (
+                isinstance(sub.value, ast.Name)
+                and sub.value.id == "config"
+                and not sub.attr.startswith("__")
+                and sub.attr not in _IGNORE_OPTIONS
+                and sub.attr not in options
+            ):
+                options.append(sub.attr)
+        elif isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name):
+            func = namespace.get(sub.func.id)
+            if func is not None:
+                func = inspect.unwrap(func)
+            if not isinstance(func, FunctionType):
+                continue
+            # Only follow functions defined in this package
+            if not (func.__module__ or "").startswith(__package__):
+                continue
+            key = (func.__module__, func.__qualname__)
+            if key in seen:
+                continue
+            seen.add(key)
+            source = textwrap.dedent(inspect.getsource(func))
+            _collect_options(ast.parse(source), func.__globals__, options, seen)
 
 
 class _ParseConfigSteps:
     def __init__(self, force_empty: tuple[str, ...] | None = None) -> None:
         """Build a mapping from config options to tuples of steps that use each option.
 
+        Each step module's ``get_config*`` and ``main`` functions are statically
+        analyzed: every ``config.<option>`` attribute access counts as a use, and
+        calls to functions defined in this package are followed recursively so
+        that options used indirectly via helpers are attributed to the step, too.
+
         The mapping is stored in `self.steps`.
         """
         self._force_empty = _FORCE_EMPTY if force_empty is None else force_empty
-        steps: dict[str, Any] = defaultdict(list)
-
-        def _add_step_option(step: str, option: str) -> None:
-            if option not in _IGNORE_OPTIONS and step not in steps[option]:
-                steps[option].append(step)
-
-        # Add a few helper functions
-        for func_extra in (
-            _config_utils._get_task_conditions_dict,
-            _config_utils._get_task_contrasts,
-            _config_utils._get_task_decoding_contrasts,
-            _config_utils._limit_which_clean,
-            _config_utils.get_eeg_reference,
-            _config_utils.get_fs_subject,
-            _config_utils.get_fs_subjects_dir,
-            _config_utils.get_mf_cal_fname,
-            _config_utils.get_mf_ctc_fname,
-            _config_utils.get_subjects_sessions,
-            _import_data._get_mf_reference_path,
-        ):
-            this_list: list[str] = []
-            assert isinstance(func_extra, FunctionType)
-            for attr in ast.walk(ast.parse(inspect.getsource(func_extra))):
-                if not isinstance(attr, ast.Attribute):
-                    continue
-                if not (isinstance(attr.value, ast.Name) and attr.value.id == "config"):
-                    continue
-                if attr.attr not in this_list:
-                    this_list.append(attr.attr)
-            _MANUAL_KWS[func_extra.__name__] = tuple(this_list)
-
-        for module in tqdm(
-            sum(_config_utils._get_step_modules().values(), tuple()),
-            desc="Generating option->step mapping",
-        ):
+        steps: dict[str, list[str]] = defaultdict(list)
+        modules = dict.fromkeys(  # deduplicate ("all" repeats the other groups)
+            sum(_config_utils._get_step_modules().values(), tuple())
+        )
+        for module in tqdm(modules, desc="Generating option->step mapping"):
             step = "/".join(module.__name__.split(".")[-2:])
-            found = False  # found at least one?
-            # Walk the module file for "get_config*" functions (can be multiple!)
             assert module.__file__ is not None
-            source = Path(module.__file__).read_text("utf-8")
-            for func in ast.walk(ast.parse(source)):
-                if not isinstance(func, ast.FunctionDef):
-                    continue
-                where = f"{step}:{func.name}"
-                # Also look at config.* args in main(), e.g. config.recreate_bem
-                # and config.recreate_scalp_surface
-                if func.name == "main":
-                    # Look at all function calls in main()
-                    for call in ast.walk(func):
-                        if not isinstance(call, ast.Call):
-                            continue
-                        if not isinstance(call.func, ast.Name):
-                            continue
-                        key = call.func.id
-                        for keyword in call.keywords:
-                            if not isinstance(keyword.value, ast.Attribute):
-                                continue
-                            assert isinstance(keyword.value.value, ast.Name)
-                            if keyword.value.value.id != "config":
-                                continue
-                            if keyword.value.attr in ("exec_params",):
-                                continue
-                            _add_step_option(step, keyword.value.attr)
-                        if key in _MANUAL_KWS:
-                            for option in _MANUAL_KWS[key]:
-                                _add_step_option(step, option)
-
-                    # Also look for root-level conditionals like use_maxwell_filter,
-                    # spatial_filter, or inverse_targets
-                    for cond in ast.walk(func):
-                        # is a conditional in main()
-                        if not isinstance(cond, ast.If):
-                            continue
-                        # missing a return statement inside it
-                        if not any(isinstance(c, ast.Return) for c in ast.walk(cond)):
-                            if isinstance(cond.test, ast.Compare) and isinstance(
-                                cond.test.comparators[0], ast.Attribute
-                            ):
-                                attr = cond.test.comparators[0]
-                                if (
-                                    isinstance(attr.value, ast.Name)
-                                    and attr.value.id == "config"
-                                ):
-                                    _add_step_option(step, attr.attr)
-                            # This sort of debugging can help next time something
-                            # isn't added in a main() conditional:
-                            #
-                            # this_source = ast.get_source_segment(source, cond.test)
-                            # if (
-                            #     this_source is not None
-                            #     and "inverse_targets" in this_source
-                            # ):
-                            #     1/0
-                            #
-                            continue
-                        # Okay, we know it has a return statement inside somewhere
-                        for attr in ast.walk(cond.test):
-                            if not isinstance(attr, ast.Attribute):
-                                continue
-                            assert isinstance(attr.value, ast.Name)
-                            if attr.value.id != "config":
-                                continue
-                            _add_step_option(step, attr.attr)
-
-                # Now look at get_config* functions anywhere in the file
-                if not func.name.startswith("get_config"):
-                    continue
-                found = True
-                for call in ast.walk(func):
-                    if not isinstance(call, ast.Call):
-                        continue
-                    # We want named functions, not things like class attributes
-                    # (i.e., my_func() not my_dict.items())
-                    assert isinstance(call.func, ast.Name)
-                    if call.func.id != "SimpleNamespace":
-                        continue
-                    break
-                else:
-                    raise RuntimeError(f"Could not find SimpleNamespace in {func}")
-                assert call.args == []
-                for keyword in call.keywords:
-                    if isinstance(keyword.value, ast.Call):
-                        assert isinstance(keyword.value.func, ast.Name)
-                        key = keyword.value.func.id
-                        if key in _MANUAL_KWS:
-                            for option in _MANUAL_KWS[key]:
-                                _add_step_option(step, option)
-                            continue
-                        func_id = keyword.value.func.id
-                        if func_id in (
-                            "_sanitize_callable",
-                            "_get_task_float",
-                        ):
-                            assert len(keyword.value.args) == 1
-                            assert isinstance(keyword.value.args[0], ast.Attribute)
-                            assert isinstance(keyword.value.args[0].value, ast.Name)
-                            assert keyword.value.args[0].value.id == "config"
-                            option = keyword.value.args[0].attr
-                            _add_step_option(step, option)
-                            continue
-                        # Allowlist of function names that we ignore when deciding
-                        # which config options are used. Things like `_bids_kwargs`
-                        # for example are used in every func and use lots of config
-                        # values, so they would just add unnecessary noise (people
-                        # will understand that changing something like "runs" will
-                        # affect many steps).
-                        if key not in (
-                            "_bids_kwargs",
-                            "_import_data_kwargs",
-                            "_get_runs_sst",
-                            "get_datatype",
-                            "get_runs_tasks",
-                            "get_subjects",
-                            "get_sessions",
-                        ):
-                            raise RuntimeError(
-                                f"{where} cannot handle call {keyword.value.func.id=} "
-                                f"for {key}"
-                            )
-                        # Get the source and regex for config values
-                        if key == "_import_data_kwargs":
-                            funcs = [getattr(_import_data, key)]
-                        elif key == "_decoding_preproc_steps":
-                            funcs = [getattr(_decoding, key)]
-                        else:
-                            funcs = [getattr(_config_utils, key)]
-                        for func_name in _EXTRA_FUNCS.get(key, ()):
-                            funcs.append(getattr(_config_utils, func_name))
-                        for fi, func in enumerate(funcs):
-                            assert isinstance(func, FunctionType), func
-                            func_source = inspect.getsource(func)
-                            assert "config: SimpleNamespace" in func_source, key
-                            if fi == 0:
-                                for func_name in _EXTRA_FUNCS.get(key, ()):
-                                    assert f"{func_name}(" in func_source, (
-                                        key,
-                                        func_name,
-                                    )
-                            attrs = _CONFIG_RE.findall(func_source)
-                            # pure wrappers
-                            if key not in (
-                                "get_sessions",
-                                "get_runs_tasks",
-                            ):
-                                assert len(attrs), (
-                                    f"No config.* found in source of {key}"
-                                )
-                            for attr in attrs:
-                                _add_step_option(step, attr)
-                        continue
-                    if isinstance(keyword.value, ast.Name):
-                        key = f"{where}:{keyword.value.id}"
-                        if key in _MANUAL_KWS:
-                            for option in _MANUAL_KWS[key]:
-                                _add_step_option(step, option)
-                            continue
-                        raise RuntimeError(f"{where} cannot handle Name {key=}")
-                    if isinstance(keyword.value, ast.IfExp):  # conditional
-                        if keyword.arg == "processing":  # inline conditional for proc
-                            continue
-                    if not isinstance(keyword.value, ast.Attribute):
-                        raise RuntimeError(
-                            f"{where} cannot handle type {keyword.value=}"
-                        )
-                    option = keyword.value.attr
-                    if option in _IGNORE_OPTIONS:
-                        continue
-                    assert isinstance(keyword.value.value, ast.Name)
-                    assert keyword.value.value.id == "config", f"{where} {keyword.value.value.id}"  # noqa: E501  # fmt: skip
-                    _add_step_option(step, option)
-            assert found, f"Could not find get_config* in {step}"
+            tree = ast.parse(Path(module.__file__).read_text("utf-8"))
+            # Walk get_config* (can be multiple!) and main
+            funcs = [
+                node
+                for node in tree.body
+                if isinstance(node, ast.FunctionDef)
+                and (node.name == "main" or node.name.startswith("get_config"))
+            ]
+            assert any(node.name.startswith("get_config") for node in funcs), (
+                f"Could not find get_config* in {step}"
+            )
+            options: list[str] = []
+            seen: set[tuple[str, str]] = set()
+            for func in funcs:
+                _collect_options(func, vars(module), options, seen)
+            for option in options:
+                steps[option].append(step)
         for key in self._force_empty:
             steps[key] = list()
-        for key, val in steps.items():
-            assert len(val) == len(set(val)), f"{key} {val}"
         self.steps: dict[str, tuple[str, ...]] = {k: tuple(v) for k, v in steps.items()}
 
     def __call__(self, option: str) -> tuple[str, ...]:

--- a/mne_bids_pipeline/_docs.py
+++ b/mne_bids_pipeline/_docs.py
@@ -201,6 +201,28 @@ def _dict_keys_assigned(scope: ast.AST, name: str) -> set[str]:
     return keys
 
 
+def _fields_from_value(
+    value: ast.expr, namespace: dict[str, Any], fields: set[str], scope: ast.AST
+) -> None:
+    """Collect the field names an expression assigned to a kwargs dict contributes."""
+    if not (isinstance(value, ast.Call) and isinstance(value.func, ast.Name)):
+        return
+    if value.func.id in ("dict", "SimpleNamespace"):
+        _fields_from_call(value, namespace, fields, scope)
+        return
+    func = _resolve_func(value.func.id, namespace)
+    if func is None:
+        return
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in ("dict", "SimpleNamespace")
+        ):
+            _fields_from_call(node, func.__globals__, fields, tree)
+
+
 def _fields_from_call(
     call: ast.Call, namespace: dict[str, Any], fields: set[str], scope: ast.AST
 ) -> None:
@@ -209,9 +231,16 @@ def _fields_from_call(
         if keyword.arg is not None:
             fields.add(keyword.arg)
             continue
-        # ``**extra_kwargs`` where a local dict was filled in conditionally
+        # ``**extra_kwargs`` where a local dict was built up conditionally, either
+        # by subscript assignment or by assigning a helper's return value
         if isinstance(keyword.value, ast.Name):
-            fields |= _dict_keys_assigned(scope, keyword.value.id)
+            name = keyword.value.id
+            fields |= _dict_keys_assigned(scope, name)
+            for node in ast.walk(scope):
+                if isinstance(node, ast.Assign) and any(
+                    isinstance(t, ast.Name) and t.id == name for t in node.targets
+                ):
+                    _fields_from_value(node.value, namespace, fields, scope)
             continue
         # ``**_helper(...)`` expansion: recurse into the dict the helper returns
         if not (

--- a/mne_bids_pipeline/_docs.py
+++ b/mne_bids_pipeline/_docs.py
@@ -3,7 +3,7 @@ import inspect
 import textwrap
 from collections import defaultdict
 from pathlib import Path
-from types import FunctionType
+from types import FunctionType, ModuleType
 from typing import Any
 
 from tqdm import tqdm
@@ -38,15 +38,12 @@ _EXECUTION_OPTIONS = (
     "interactive",
 )
 _FORCE_EMPTY = _EXECUTION_OPTIONS + (
-    # Plus some BIDS one we don't detect because _bids_kwargs etc. above,
-    # which we could cross-check against the general.md list. A notable
-    # exception is random_state, since this does have more localized effects.
-    # These are used a lot at the very beginning, so adding them will lead
-    # to long lists. Instead, let's just mention at the top of General that
-    # messing with basic BIDS params will affect almost every step.
+    # Plus the basic BIDS params, which come in via _bids_kwargs and friends and
+    # so land on nearly every step. Listing them all would be noise, so instead we
+    # mention at the top of General that changing them affects almost every step.
+    # A notable exception is random_state, which does have more localized effects.
     "bids_root",
     "deriv_root",
-    "subjects_dir",
     "sessions",
     "acq",
     "proc",
@@ -56,25 +53,7 @@ _FORCE_EMPTY = _EXECUTION_OPTIONS + (
     "runs",
     "exclude_runs",
     "subjects",
-    "crop_runs",
-    "process_empty_room",
-    "process_rest",
-    "eeg_bipolar_channels",
     "eeg_reference",
-    "eeg_template_montage",
-    "drop_channels",
-    "reader_extra_params",
-    "plot_psd_for_runs",
-    "shortest_event",
-    "find_breaks",
-    "min_break_duration",
-    "t_break_annot_start_after_previous_event",
-    "t_break_annot_stop_before_next_event",
-    "rename_events",
-    "on_rename_missing_events",
-    "fix_stim_artifact",
-    "stim_artifact_tmin",
-    "stim_artifact_tmax",
     # And some that we force to be empty because they affect too many things
     # and what they affect is an incomplete list anyway
     "exclude_subjects",
@@ -85,38 +64,246 @@ _FORCE_EMPTY = _EXECUTION_OPTIONS + (
 )
 
 
-def _collect_options(
+def _bound_names(call: ast.Call, func: FunctionType, names: frozenset[str]) -> set[str]:
+    """Get the parameters of `func` that receive one of `names` at this call site.
+
+    This is what keeps the traversal honest: a helper's ``config`` parameter only
+    holds our object if the call site actually handed it over. Steps call helpers
+    both as ``f(cfg=cfg)`` and ``f(config=cfg)``, while unrelated functions (e.g.
+    ``_import_config``) have a ``config`` of their own that must not be followed.
+    """
+    try:
+        params = list(inspect.signature(func).parameters)
+    except (TypeError, ValueError):  # pragma: no cover
+        params = []
+    bound = set()
+    for pos, arg in enumerate(call.args):
+        if isinstance(arg, ast.Name) and arg.id in names and pos < len(params):
+            bound.add(params[pos])
+    for keyword in call.keywords:
+        if (
+            keyword.arg is not None
+            and isinstance(keyword.value, ast.Name)
+            and keyword.value.id in names
+        ):
+            bound.add(keyword.arg)
+    return bound
+
+
+def _collect_attrs(
     node: ast.AST,
     namespace: dict[str, Any],
-    options: list[str],
-    seen: set[tuple[str, str]],
+    names: frozenset[str],
+    attrs: set[str],
+    seen: set[tuple[str, str, frozenset[str]]],
+    *,
+    follow_get_config: bool,
 ) -> None:
-    """Collect config.* attribute accesses in node, recursing into called functions."""
+    """Collect ``<name>.<attr>`` accesses, recursing into functions that are called.
+
+    `names` are the local names currently bound to the object of interest (the
+    config for the "write" side, the cfg namespace for the "read" side). Only
+    functions defined in this package are followed, and only when the call site
+    passes the object to them. Each (function, binding) pair is visited at most
+    once, so recursive and mutually recursive helpers terminate.
+    """
     for sub in ast.walk(node):
         if isinstance(sub, ast.Attribute):
             if (
                 isinstance(sub.value, ast.Name)
-                and sub.value.id == "config"
+                and sub.value.id in names
                 and not sub.attr.startswith("__")
                 and sub.attr not in _IGNORE_OPTIONS
-                and sub.attr not in options
             ):
-                options.append(sub.attr)
+                attrs.add(sub.attr)
         elif isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name):
-            func = namespace.get(sub.func.id)
-            if func is not None:
-                func = inspect.unwrap(func)
-            if not isinstance(func, FunctionType):
+            func = _resolve_func(sub.func.id, namespace)
+            if func is None:
                 continue
-            # Only follow functions defined in this package
-            if not (func.__module__ or "").startswith(__package__):
+            # get_config* builds cfg; it is the "write" side, never a cfg reader
+            if not follow_get_config and func.__name__.startswith("get_config"):
                 continue
-            key = (func.__module__, func.__qualname__)
+            bound = _bound_names(sub, func, names)
+            if not bound:
+                continue
+            key = (func.__module__, func.__qualname__, frozenset(bound))
             if key in seen:
                 continue
             seen.add(key)
             source = textwrap.dedent(inspect.getsource(func))
-            _collect_options(ast.parse(source), func.__globals__, options, seen)
+            _collect_attrs(
+                ast.parse(source),
+                func.__globals__,
+                frozenset(bound),
+                attrs,
+                seen,
+                follow_get_config=follow_get_config,
+            )
+
+
+def _step_module_funcs(module: ModuleType) -> list[ast.FunctionDef]:
+    assert module.__file__ is not None
+    tree = ast.parse(Path(module.__file__).read_text("utf-8"))
+    return [node for node in tree.body if isinstance(node, ast.FunctionDef)]
+
+
+def get_step_options(module: ModuleType) -> set[str]:
+    """Get the config options a step writes into its ``cfg`` (or uses in ``main``).
+
+    This is the "write" side: ``get_config*`` and ``main`` are walked for
+    ``config.<option>`` accesses, following calls into package helpers.
+    """
+    funcs = _step_module_funcs(module)
+    assert any(func.name.startswith("get_config") for func in funcs), (
+        f"Could not find get_config* in {module.__name__}"
+    )
+    options: set[str] = set()
+    seen: set[tuple[str, str, frozenset[str]]] = set()
+    for func in funcs:
+        if func.name == "main" or func.name.startswith("get_config"):
+            _collect_attrs(
+                func,
+                vars(module),
+                frozenset({"config"}),
+                options,
+                seen,
+                follow_get_config=True,
+            )
+    return options
+
+
+def _resolve_func(name: str, namespace: dict[str, Any]) -> FunctionType | None:
+    func = namespace.get(name)
+    if func is not None:
+        func = inspect.unwrap(func)
+    if isinstance(func, FunctionType) and (func.__module__ or "").startswith(
+        __package__
+    ):
+        return func
+    return None
+
+
+def _dict_keys_assigned(scope: ast.AST, name: str) -> set[str]:
+    """Get the literal string keys assigned into a local dict, e.g. ``d["k"] = v``."""
+    keys = set()
+    for node in ast.walk(scope):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Subscript)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == name
+                and isinstance(target.slice, ast.Constant)
+                and isinstance(target.slice.value, str)
+            ):
+                keys.add(target.slice.value)
+    return keys
+
+
+def _fields_from_call(
+    call: ast.Call, namespace: dict[str, Any], fields: set[str], scope: ast.AST
+) -> None:
+    """Collect the field names a ``SimpleNamespace(...)``/``dict(...)`` call builds."""
+    for keyword in call.keywords:
+        if keyword.arg is not None:
+            fields.add(keyword.arg)
+            continue
+        # ``**extra_kwargs`` where a local dict was filled in conditionally
+        if isinstance(keyword.value, ast.Name):
+            fields |= _dict_keys_assigned(scope, keyword.value.id)
+            continue
+        # ``**_helper(...)`` expansion: recurse into the dict the helper returns
+        if not (
+            isinstance(keyword.value, ast.Call)
+            and isinstance(keyword.value.func, ast.Name)
+        ):
+            continue
+        func = _resolve_func(keyword.value.func.id, namespace)
+        if func is None:
+            continue
+        tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in ("dict", "SimpleNamespace")
+            ):
+                _fields_from_call(node, func.__globals__, fields, tree)
+
+
+def get_kwargs_helper_fields(func: FunctionType) -> set[str]:
+    """Get the cfg field names a ``*_kwargs`` helper contributes to a step."""
+    fields: set[str] = set()
+    tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in ("dict", "SimpleNamespace")
+        ):
+            _fields_from_call(node, func.__globals__, fields, tree)
+    return fields - _IGNORE_OPTIONS
+
+
+def get_step_cfg_fields(module: ModuleType) -> set[str]:
+    """Get the ``cfg`` fields a step's ``get_config*`` builds.
+
+    Unlike :func:`get_step_options` (which reports *config options* consulted,
+    including ones read to compute a derived value), this reports the names that
+    end up on the ``cfg`` namespace, so it can be compared against
+    :func:`get_step_reads` to find fields that are passed but never read.
+    """
+    fields: set[str] = set()
+    for func in _step_module_funcs(module):
+        if not func.name.startswith("get_config"):
+            continue
+        for node in ast.walk(func):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "SimpleNamespace"
+            ):
+                _fields_from_call(node, vars(module), fields, func)
+    # symmetry with the read side, which also ignores these
+    return fields - _IGNORE_OPTIONS
+
+
+def get_step_reads(module: ModuleType) -> set[str]:
+    """Get the ``cfg`` fields a step actually reads at run time.
+
+    This is the "read" side, and the counterpart of :func:`get_step_options`.
+    Every function in the step module except ``get_config*`` is walked, and calls
+    into package helpers are followed. Helpers receive ``cfg`` under both names
+    (``f(cfg=cfg)`` and ``f(config=cfg)``), so accesses on either name count.
+
+    ``main`` is special: there ``config`` is the real config rather than ``cfg``,
+    so only direct ``cfg.<field>`` accesses count and calls are not followed
+    (the functions ``main`` hands ``cfg`` to are module-level, and walked anyway).
+    """
+    reads: set[str] = set()
+    seen: set[tuple[str, str, frozenset[str]]] = set()
+    for func in _step_module_funcs(module):
+        if func.name.startswith("get_config"):
+            continue
+        if func.name == "main":
+            for sub in ast.walk(func):
+                if (
+                    isinstance(sub, ast.Attribute)
+                    and isinstance(sub.value, ast.Name)
+                    and sub.value.id == "cfg"
+                ):
+                    reads.add(sub.attr)
+            continue
+        _collect_attrs(
+            func,
+            vars(module),
+            frozenset({"cfg"}),
+            reads,
+            seen,
+            follow_get_config=False,
+        )
+    return reads
 
 
 class _ParseConfigSteps:
@@ -137,23 +324,7 @@ class _ParseConfigSteps:
         )
         for module in tqdm(modules, desc="Generating option->step mapping"):
             step = "/".join(module.__name__.split(".")[-2:])
-            assert module.__file__ is not None
-            tree = ast.parse(Path(module.__file__).read_text("utf-8"))
-            # Walk get_config* (can be multiple!) and main
-            funcs = [
-                node
-                for node in tree.body
-                if isinstance(node, ast.FunctionDef)
-                and (node.name == "main" or node.name.startswith("get_config"))
-            ]
-            assert any(node.name.startswith("get_config") for node in funcs), (
-                f"Could not find get_config* in {step}"
-            )
-            options: list[str] = []
-            seen: set[tuple[str, str]] = set()
-            for func in funcs:
-                _collect_options(func, vars(module), options, seen)
-            for option in options:
+            for option in sorted(get_step_options(module)):
                 steps[option].append(step)
         for key in self._force_empty:
             steps[key] = list()

--- a/mne_bids_pipeline/_docs.py
+++ b/mne_bids_pipeline/_docs.py
@@ -274,26 +274,17 @@ def get_step_reads(module: ModuleType) -> set[str]:
 
     This is the "read" side, and the counterpart of :func:`get_step_options`.
     Every function in the step module except ``get_config*`` is walked, and calls
-    into package helpers are followed. Helpers receive ``cfg`` under both names
-    (``f(cfg=cfg)`` and ``f(config=cfg)``), so accesses on either name count.
+    into package helpers are followed.
 
-    ``main`` is special: there ``config`` is the real config rather than ``cfg``,
-    so only direct ``cfg.<field>`` accesses count and calls are not followed
-    (the functions ``main`` hands ``cfg`` to are module-level, and walked anyway).
+    Only the name ``cfg`` seeds the traversal, which is what makes ``main`` safe
+    to walk like any other function: its ``config`` is the real config, so
+    ``config.<option>`` there is not a cfg read and ``f(config=config)`` is not
+    followed, while ``f(config=cfg)`` -- which ``main`` does do -- is.
     """
     reads: set[str] = set()
     seen: set[tuple[str, str, frozenset[str]]] = set()
     for func in _step_module_funcs(module):
         if func.name.startswith("get_config"):
-            continue
-        if func.name == "main":
-            for sub in ast.walk(func):
-                if (
-                    isinstance(sub, ast.Attribute)
-                    and isinstance(sub.value, ast.Name)
-                    and sub.value.id == "cfg"
-                ):
-                    reads.add(sub.attr)
             continue
         _collect_attrs(
             func,

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -867,28 +867,43 @@ def _read_bads_tsv(
     return out
 
 
-def _import_data_kwargs(
+def _raw_path_kwargs(
     *, config: SimpleNamespace, subject: str, session: str | None
 ) -> dict[str, Any]:
-    """Get config params needed for any raw data loading."""
+    """Get config params needed to work out *which* raw files a step deals with.
+
+    This is the subset of :func:`_import_data_kwargs` needed by steps that read
+    already-derived data and so never re-run the raw import itself. Steps that do
+    import raw data want :func:`_import_data_kwargs`, which builds on this.
+    """
     mf_reference_run, mf_reference_task = get_mf_reference_run_task(
         config=config, subject=subject, session=session
     )
     return dict(
-        # import_experimental_data / general
-        task=config.task,
         process_empty_room=config.process_empty_room,
         process_rest=config.process_rest,
         task_is_rest=config.task_is_rest,
-        # _get_raw_paths, _get_noise_path
-        use_maxwell_filter=config.use_maxwell_filter,
         mf_reference_run=mf_reference_run,
         mf_reference_task=mf_reference_task,
         data_type=config.data_type,
-        # automatic add_bads
-        find_noisy_channels_meg=config.find_noisy_channels_meg,
-        find_flat_channels_meg=config.find_flat_channels_meg,
-        find_bad_channels_extra_kws=config.find_bad_channels_extra_kws,
+        ch_types=config.ch_types,
+        **_bids_kwargs(config=config),
+    )
+
+
+def _import_data_kwargs(
+    *, config: SimpleNamespace, subject: str, session: str | None
+) -> dict[str, Any]:
+    """Get config params needed for any raw data loading.
+
+    Automatic bad-channel detection params are *not* included; only
+    ``preprocessing/_01_data_quality`` does that, and it adds them itself.
+    """
+    return dict(
+        # import_experimental_data / general
+        task=config.task,
+        # _get_raw_paths, _get_noise_path
+        use_maxwell_filter=config.use_maxwell_filter,
         # 1. _load_data
         reader_extra_params=config.reader_extra_params,
         crop_runs=config.crop_runs,
@@ -896,7 +911,6 @@ def _import_data_kwargs(
         eeg_template_montage=config.eeg_template_montage,
         # 3. _create_bipolar_channels
         eeg_bipolar_channels=config.eeg_bipolar_channels,
-        ch_types=config.ch_types,
         eog_channels=config.eog_channels,
         # 4. _drop_channels_func
         drop_channels=config.drop_channels,
@@ -912,10 +926,7 @@ def _import_data_kwargs(
         fix_stim_artifact=config.fix_stim_artifact,
         stim_artifact_tmin=config.stim_artifact_tmin,
         stim_artifact_tmax=config.stim_artifact_tmax,
-        # args used for all runs that process raw (reporting / writing)
-        plot_psd_for_runs=config.plot_psd_for_runs,
-        _raw_split_size=config._raw_split_size,
-        **_bids_kwargs(config=config),
+        **_raw_path_kwargs(config=config, subject=subject, session=session),
     )
 
 

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -867,6 +867,21 @@ def _read_bads_tsv(
     return out
 
 
+def _epochs_kwargs(*, config: SimpleNamespace) -> dict[str, Any]:
+    """Get the config params that :func:`make_epochs` consumes."""
+    return dict(
+        epochs_custom_metadata=config.epochs_custom_metadata,
+        epochs_metadata_tmin=config.epochs_metadata_tmin,
+        epochs_metadata_tmax=config.epochs_metadata_tmax,
+        epochs_metadata_keep_first=config.epochs_metadata_keep_first,
+        epochs_metadata_keep_last=config.epochs_metadata_keep_last,
+        epochs_metadata_query=config.epochs_metadata_query,
+        event_repeated=config.event_repeated,
+        rest_epochs_duration=config.rest_epochs_duration,
+        rest_epochs_overlap=config.rest_epochs_overlap,
+    )
+
+
 def _raw_path_kwargs(
     *, config: SimpleNamespace, subject: str, session: str | None
 ) -> dict[str, Any]:

--- a/mne_bids_pipeline/steps/init/_02_find_empty_room.py
+++ b/mne_bids_pipeline/steps/init/_02_find_empty_room.py
@@ -122,7 +122,6 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        data_type=get_datatype(config),
         **_bids_kwargs(config=config),
     )
     return cfg

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -370,11 +370,11 @@ def get_config(
         )
         extra_kwargs["mf_head_origin"] = config.mf_head_origin
     cfg = SimpleNamespace(
-        # These are included in _import_data_kwargs for automatic add_bads
-        # detection
-        # find_flat_channels_meg=config.find_flat_channels_meg,
-        # find_noisy_channels_meg=config.find_noisy_channels_meg,
-        # find_bad_channels_extra_kws=config.find_bad_channels_extra_kws,
+        # automatic add_bads detection; this is the only step that does it
+        find_flat_channels_meg=config.find_flat_channels_meg,
+        find_noisy_channels_meg=config.find_noisy_channels_meg,
+        find_bad_channels_extra_kws=config.find_bad_channels_extra_kws,
+        plot_psd_for_runs=config.plot_psd_for_runs,
         **_import_data_kwargs(config=config, subject=subject, session=session),
         **extra_kwargs,
     )

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -8,9 +8,8 @@ import pandas as pd
 from mne_bids_pipeline._config_utils import (
     _do_mf_autobad,
     _get_ssrt,
+    _mf_cal_kwargs,
     _pl,
-    get_mf_cal_fname,
-    get_mf_ctc_fname,
 )
 from mne_bids_pipeline._import_data import (
     _bads_path,
@@ -355,20 +354,11 @@ def get_config(
     subject: str,
     session: str | None,
 ) -> SimpleNamespace:
+    # only needed when we actually run automatic bad-channel detection
+    # If these change, need to update hooks.py in doc build
     extra_kwargs = dict()
     if config.find_noisy_channels_meg or config.find_flat_channels_meg:
-        # If these change, need to update hooks.py in doc build
-        extra_kwargs["mf_cal_fname"] = get_mf_cal_fname(
-            config=config,
-            subject=subject,
-            session=session,
-        )
-        extra_kwargs["mf_ctc_fname"] = get_mf_ctc_fname(
-            config=config,
-            subject=subject,
-            session=session,
-        )
-        extra_kwargs["mf_head_origin"] = config.mf_head_origin
+        extra_kwargs = _mf_cal_kwargs(config=config, subject=subject, session=session)
     cfg = SimpleNamespace(
         # automatic add_bads detection; this is the only step that does it
         find_flat_channels_meg=config.find_flat_channels_meg,

--- a/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
@@ -28,9 +28,8 @@ from mne_bids import BIDSPath, read_raw_bids
 from mne_bids_pipeline._config_utils import (
     _get_ss,
     _get_ssrt,
+    _mf_cal_kwargs,
     _pl,
-    get_mf_cal_fname,
-    get_mf_ctc_fname,
     get_runs_tasks,
 )
 from mne_bids_pipeline._import_data import (
@@ -721,19 +720,9 @@ def get_config_maxwell_filter(
     session: str | None,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        mf_cal_fname=get_mf_cal_fname(
-            config=config,
-            subject=subject,
-            session=session,
-        ),
-        mf_ctc_fname=get_mf_ctc_fname(
-            config=config,
-            subject=subject,
-            session=session,
-        ),
+        **_mf_cal_kwargs(config=config, subject=subject, session=session),
         mf_st_duration=config.mf_st_duration,
         mf_st_correlation=config.mf_st_correlation,
-        mf_head_origin=config.mf_head_origin,
         mf_mc=config.mf_mc,
         mf_filter_chpi=config.mf_filter_chpi,
         mf_destination=config.mf_destination,

--- a/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
@@ -744,6 +744,8 @@ def get_config_maxwell_filter(
         mf_mc_translation_velocity_limit=config.mf_mc_translation_velocity_limit,
         mf_esss=config.mf_esss,
         mf_extra_kws=config.mf_extra_kws,
+        plot_psd_for_runs=config.plot_psd_for_runs,
+        _raw_split_size=config._raw_split_size,
         **_import_data_kwargs(config=config, subject=subject, session=session),
     )
     return cfg

--- a/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_03_maxfilter.py
@@ -720,7 +720,6 @@ def get_config_maxwell_filter(
     session: str | None,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        **_mf_cal_kwargs(config=config, subject=subject, session=session),
         mf_st_duration=config.mf_st_duration,
         mf_st_correlation=config.mf_st_correlation,
         mf_mc=config.mf_mc,
@@ -735,6 +734,7 @@ def get_config_maxwell_filter(
         mf_extra_kws=config.mf_extra_kws,
         plot_psd_for_runs=config.plot_psd_for_runs,
         _raw_split_size=config._raw_split_size,
+        **_mf_cal_kwargs(config=config, subject=subject, session=session),
         **_import_data_kwargs(config=config, subject=subject, session=session),
     )
     return cfg

--- a/mne_bids_pipeline/steps/preprocessing/_04_frequency_filter.py
+++ b/mne_bids_pipeline/steps/preprocessing/_04_frequency_filter.py
@@ -378,6 +378,8 @@ def get_config(
         regress_artifact=config.regress_artifact,
         notch_extra_kws=config.notch_extra_kws,
         bandpass_extra_kws=config.bandpass_extra_kws,
+        plot_psd_for_runs=config.plot_psd_for_runs,
+        _raw_split_size=config._raw_split_size,
         **_import_data_kwargs(config=config, subject=subject, session=session),
     )
     return cfg

--- a/mne_bids_pipeline/steps/preprocessing/_05_regress_artifact.py
+++ b/mne_bids_pipeline/steps/preprocessing/_05_regress_artifact.py
@@ -9,7 +9,7 @@ from mne.preprocessing import EOGRegression
 from mne_bids_pipeline._config_utils import _get_ssrt
 from mne_bids_pipeline._import_data import (
     _get_run_rest_noise_path,
-    _import_data_kwargs,
+    _raw_path_kwargs,
     _read_raw_msg,
 )
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
@@ -133,7 +133,9 @@ def get_config(
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
         regress_artifact=config.regress_artifact,
-        **_import_data_kwargs(config=config, subject=subject, session=session),
+        plot_psd_for_runs=config.plot_psd_for_runs,
+        _raw_split_size=config._raw_split_size,
+        **_raw_path_kwargs(config=config, subject=subject, session=session),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -24,7 +24,11 @@ from mne_bids_pipeline._config_utils import (
     get_eeg_reference,
     get_runs_tasks,
 )
-from mne_bids_pipeline._import_data import annotations_to_events, make_epochs
+from mne_bids_pipeline._import_data import (
+    _epochs_kwargs,
+    annotations_to_events,
+    make_epochs,
+)
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._reject import _get_reject
@@ -377,6 +381,7 @@ def get_config(
     # different lengths, let's use the average tmin/tmax across tasks
     epochs_tmin, epochs_tmax = _get_task_average_epochs_tlims(config=config)
     cfg = SimpleNamespace(
+        **_epochs_kwargs(config=config),
         conditions=config.conditions,
         runs_tasks=get_runs_tasks(
             config=config, subject=subject, session=session, which=("runs", "rest")
@@ -395,18 +400,9 @@ def get_config(
         ch_types=config.ch_types,
         epochs_decim=config.epochs_decim,
         raw_resample_sfreq=config.raw_resample_sfreq,
-        event_repeated=config.event_repeated,
         epochs_tmin=epochs_tmin,
         epochs_tmax=epochs_tmax,
-        epochs_custom_metadata=config.epochs_custom_metadata,
-        epochs_metadata_tmin=config.epochs_metadata_tmin,
-        epochs_metadata_tmax=config.epochs_metadata_tmax,
-        epochs_metadata_keep_first=config.epochs_metadata_keep_first,
-        epochs_metadata_keep_last=config.epochs_metadata_keep_last,
-        epochs_metadata_query=config.epochs_metadata_query,
         eeg_reference=get_eeg_reference(config),
-        rest_epochs_duration=config.rest_epochs_duration,
-        rest_epochs_overlap=config.rest_epochs_overlap,
         processing="filt" if config.regress_artifact is None else "regress",
         _epochs_split_size=config._epochs_split_size,
         **_bids_kwargs(config=config),

--- a/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a1_fit_ica.py
@@ -381,7 +381,6 @@ def get_config(
     # different lengths, let's use the average tmin/tmax across tasks
     epochs_tmin, epochs_tmax = _get_task_average_epochs_tlims(config=config)
     cfg = SimpleNamespace(
-        **_epochs_kwargs(config=config),
         conditions=config.conditions,
         runs_tasks=get_runs_tasks(
             config=config, subject=subject, session=session, which=("runs", "rest")
@@ -405,6 +404,7 @@ def get_config(
         eeg_reference=get_eeg_reference(config),
         processing="filt" if config.regress_artifact is None else "regress",
         _epochs_split_size=config._epochs_split_size,
+        **_epochs_kwargs(config=config),
         **_bids_kwargs(config=config),
     )
     return cfg

--- a/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
+++ b/mne_bids_pipeline/steps/preprocessing/_06a2_find_ica_artifacts.py
@@ -20,7 +20,6 @@ from mne_bids import BIDSPath
 from mne_bids_pipeline._config_utils import (
     _bids_kwargs,
     _get_ss,
-    get_eeg_reference,
     get_eog_channels,
     get_runs_tasks,
 )
@@ -593,7 +592,6 @@ def get_config(
         ica_exclusion_thresholds=config.ica_exclusion_thresholds,
         ica_class_thresholds=config.ica_class_thresholds,
         ch_types=config.ch_types,
-        eeg_reference=get_eeg_reference(config),
         eog_channels=config.eog_channels,
         processing="filt" if config.regress_artifact is None else "regress",
         **_bids_kwargs(config=config),

--- a/mne_bids_pipeline/steps/preprocessing/_07_make_epochs.py
+++ b/mne_bids_pipeline/steps/preprocessing/_07_make_epochs.py
@@ -358,7 +358,6 @@ def get_config(
     task: str | None = None,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        **_epochs_kwargs(config=config),
         use_maxwell_filter=config.use_maxwell_filter,
         task_is_rest=config.task_is_rest,
         conditions=config.conditions,
@@ -374,6 +373,7 @@ def get_config(
             config=config, subject=subject, session=session, task=task
         ),
         processing="filt" if config.regress_artifact is None else "regress",
+        **_epochs_kwargs(config=config),
         **_bids_kwargs(config=config),
     )
     return cfg

--- a/mne_bids_pipeline/steps/preprocessing/_07_make_epochs.py
+++ b/mne_bids_pipeline/steps/preprocessing/_07_make_epochs.py
@@ -21,7 +21,11 @@ from mne_bids_pipeline._config_utils import (
     _get_task_float,
     get_eeg_reference,
 )
-from mne_bids_pipeline._import_data import annotations_to_events, make_epochs
+from mne_bids_pipeline._import_data import (
+    _epochs_kwargs,
+    annotations_to_events,
+    make_epochs,
+)
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._report import _get_prefix_tags, _open_report
@@ -354,25 +358,17 @@ def get_config(
     task: str | None = None,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
+        **_epochs_kwargs(config=config),
         use_maxwell_filter=config.use_maxwell_filter,
         task_is_rest=config.task_is_rest,
         conditions=config.conditions,
         epochs_tmin=_get_task_float(config.epochs_tmin, task=task),
         epochs_tmax=_get_task_float(config.epochs_tmax, task=task),
-        epochs_custom_metadata=config.epochs_custom_metadata,
-        epochs_metadata_tmin=config.epochs_metadata_tmin,
-        epochs_metadata_tmax=config.epochs_metadata_tmax,
-        epochs_metadata_keep_first=config.epochs_metadata_keep_first,
-        epochs_metadata_keep_last=config.epochs_metadata_keep_last,
-        epochs_metadata_query=config.epochs_metadata_query,
-        event_repeated=config.event_repeated,
         epochs_decim=config.epochs_decim,
         report_add_epochs_image_kwargs=config.report_add_epochs_image_kwargs,
         ch_types=config.ch_types,
         noise_cov=_sanitize_callable(config.noise_cov),
         eeg_reference=get_eeg_reference(config),
-        rest_epochs_duration=config.rest_epochs_duration,
-        rest_epochs_overlap=config.rest_epochs_overlap,
         _epochs_split_size=config._epochs_split_size,
         runs_for_task=_get_runs_sst(
             config=config, subject=subject, session=session, task=task

--- a/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08a_apply_ica.py
@@ -13,7 +13,7 @@ from mne.preprocessing import read_ica
 from mne_bids import BIDSPath
 
 from mne_bids_pipeline._config_utils import _get_ssrt, _get_sst, _limit_which_clean
-from mne_bids_pipeline._import_data import _get_run_rest_noise_path, _import_data_kwargs
+from mne_bids_pipeline._import_data import _get_run_rest_noise_path, _raw_path_kwargs
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._report import _add_raw, _open_report
@@ -253,9 +253,10 @@ def get_config(
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
         ica_use_icalabel=config.ica_use_icalabel,
-        processing="filt" if config.regress_artifact is None else "regress",
         _epochs_split_size=config._epochs_split_size,
-        **_import_data_kwargs(config=config, subject=subject, session=session),
+        plot_psd_for_runs=config.plot_psd_for_runs,
+        _raw_split_size=config._raw_split_size,
+        **_raw_path_kwargs(config=config, subject=subject, session=session),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/preprocessing/_08b_apply_ssp.py
+++ b/mne_bids_pipeline/steps/preprocessing/_08b_apply_ssp.py
@@ -14,7 +14,7 @@ from mne_bids_pipeline._config_utils import (
     _limit_which_clean,
     _proj_path,
 )
-from mne_bids_pipeline._import_data import _get_run_rest_noise_path, _import_data_kwargs
+from mne_bids_pipeline._import_data import _get_run_rest_noise_path, _raw_path_kwargs
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
 from mne_bids_pipeline._parallel import get_parallel_backend, parallel_func
 from mne_bids_pipeline._report import _add_raw, _open_report
@@ -161,9 +161,10 @@ def get_config(
     session: str | None,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        processing="filt" if config.regress_artifact is None else "regress",
         _epochs_split_size=config._epochs_split_size,
-        **_import_data_kwargs(config=config, subject=subject, session=session),
+        plot_psd_for_runs=config.plot_psd_for_runs,
+        _raw_split_size=config._raw_split_size,
+        **_raw_path_kwargs(config=config, subject=subject, session=session),
     )
     return cfg
 

--- a/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
+++ b/mne_bids_pipeline/steps/sensor/_02_decoding_full_epochs.py
@@ -249,7 +249,6 @@ def get_config(
         conditions=_get_task_conditions_dict(conditions=config.conditions, task=task),
         contrasts=_get_task_decoding_contrasts(config, task=task),
         cov_rank=config.cov_rank,
-        decode=config.decode,
         decoding_which_epochs=config.decoding_which_epochs,
         decoding_metric=config.decoding_metric,
         decoding_epochs_tmin=config.decoding_epochs_tmin,

--- a/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
+++ b/mne_bids_pipeline/steps/sensor/_03_decoding_time_by_time.py
@@ -336,7 +336,6 @@ def get_config(
         conditions=_get_task_conditions_dict(conditions=config.conditions, task=task),
         contrasts=_get_task_decoding_contrasts(config, task=task),
         cov_rank=config.cov_rank,
-        decode=config.decode,
         decoding_which_epochs=config.decoding_which_epochs,
         decoding_metric=config.decoding_metric,
         decoding_n_splits=config.decoding_n_splits,

--- a/mne_bids_pipeline/steps/sensor/_06_make_cov.py
+++ b/mne_bids_pipeline/steps/sensor/_06_make_cov.py
@@ -382,7 +382,6 @@ def get_config(
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
         ch_types=config.ch_types,
-        run_source_estimation=config.run_source_estimation,
         noise_cov=_sanitize_callable(config.noise_cov),
         conditions=config.conditions,
         contrasts=config.contrasts,

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -26,6 +26,7 @@ from mne_bids_pipeline._config_utils import (
     get_sessions,
     get_subjects,
     get_subjects_given_session,
+    get_subjects_sessions,
 )
 from mne_bids_pipeline._decoding import _handle_csp_args
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
@@ -545,7 +546,7 @@ def average_time_by_time_decoding(
             f"resamples. CI must not be used for statistical inference here, "
             f"as it is not corrected for multiple testing."
         )
-        if len(get_subjects(cfg)) > 1:
+        if len(cfg.subjects) > 1:
             caption += (
                 f" Time periods with decoding performance significantly above "
                 f"chance, if any, were derived with a one-tailed "
@@ -565,7 +566,7 @@ def average_time_by_time_decoding(
             plt.close(fig)
 
         # Plot t-values used to form clusters
-        if len(get_subjects(cfg)) > 1:
+        if len(cfg.subjects) > 1:
             fig = plot_time_by_time_decoding_t_values(decoding_data=decoding_data)
             t_threshold = np.round(decoding_data["cluster_t_threshold"], 3).item()
             caption = (
@@ -1052,6 +1053,7 @@ def get_config(
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
         subjects=get_subjects(config),
+        subjects_sessions=get_subjects_sessions(config),
         allow_missing_sessions=config.allow_missing_sessions,
         conditions=_get_task_conditions_dict(conditions=config.conditions, task=task),
         contrasts=_get_task_contrasts(contrasts=config.contrasts, task=task),
@@ -1077,12 +1079,8 @@ def get_config(
         interpolate_bads_grand_average=config.interpolate_bads_grand_average,
         ch_types=config.ch_types,
         eeg_reference=get_eeg_reference(config),
-        sessions=get_sessions(config),
-        exclude_subjects=config.exclude_subjects,
         report_evoked_n_time_points=config.report_evoked_n_time_points,
         cluster_permutation_p_threshold=config.cluster_permutation_p_threshold,
-        # TODO: needed because get_datatype gets called again...
-        data_type=config.data_type,
         **_bids_kwargs(config=config),
     )
     return cfg

--- a/mne_bids_pipeline/steps/sensor/_99_group_average.py
+++ b/mne_bids_pipeline/steps/sensor/_99_group_average.py
@@ -1053,7 +1053,6 @@ def get_config(
     cfg = SimpleNamespace(
         subjects=get_subjects(config),
         allow_missing_sessions=config.allow_missing_sessions,
-        task_is_rest=config.task_is_rest,
         conditions=_get_task_conditions_dict(conditions=config.conditions, task=task),
         contrasts=_get_task_contrasts(contrasts=config.contrasts, task=task),
         epochs_tmin=_get_task_float(config.epochs_tmin, task=task),

--- a/mne_bids_pipeline/steps/source/_03_setup_source_space.py
+++ b/mne_bids_pipeline/steps/source/_03_setup_source_space.py
@@ -80,7 +80,6 @@ def get_config(
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
         spacing=config.spacing,
-        use_template_mri=config.use_template_mri,
         fs_subject=get_fs_subject(config=config, subject=subject, session=session),
         fs_subjects_dir=get_fs_subjects_dir(config),
     )

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -17,6 +17,7 @@ from mne_bids_pipeline._config_utils import (
     get_sessions,
     get_subjects,
     get_subjects_given_session,
+    get_subjects_sessions,
     sanitize_cond_name,
 )
 from mne_bids_pipeline._logging import gen_log_kwargs, logger
@@ -237,21 +238,12 @@ def get_config(
         conditions=config.conditions,
         inverse_method=config.inverse_method,
         fs_subjects_dir=get_fs_subjects_dir(config),
-        ch_types=config.ch_types,
         subjects=get_subjects(config=config),
-        exclude_subjects=config.exclude_subjects,
-        sessions=get_sessions(config),
+        subjects_sessions=get_subjects_sessions(config),
         allow_missing_sessions=config.allow_missing_sessions,
-        # main() re-resolves the FreeSurfer subject per session by handing cfg to
-        # get_fs_subject(), which reads these two raw options rather than the
-        # fs_subjects_dir we already resolved above
-        subjects_dir=get_fs_subjects_dir(config),
-        use_template_mri=config.use_template_mri,
         contrasts=config.contrasts,
         report_stc_n_time_points=config.report_stc_n_time_points,
         smoothing_steps=config.smoothing_steps,
-        # TODO: needed because get_datatype gets called again...
-        data_type=config.data_type,
         **_bids_kwargs(config=config),
     )
     return cfg
@@ -285,7 +277,9 @@ def main(*, config: SimpleNamespace) -> None:
                 cfg=cfg,
                 exec_params=exec_params,
                 subject=subject,
-                fs_subject=get_fs_subject(config=cfg, subject=subject, session=session),
+                fs_subject=get_fs_subject(
+                    config=config, subject=subject, session=session
+                ),
                 session=session,
                 task=task,
             )

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -234,17 +234,14 @@ def get_config(
     config: SimpleNamespace,
 ) -> SimpleNamespace:
     cfg = SimpleNamespace(
-        task_is_rest=config.task_is_rest,
         conditions=config.conditions,
         inverse_method=config.inverse_method,
         fs_subjects_dir=get_fs_subjects_dir(config),
-        subjects_dir=get_fs_subjects_dir(config),
         ch_types=config.ch_types,
         subjects=get_subjects(config=config),
         exclude_subjects=config.exclude_subjects,
         sessions=get_sessions(config),
         allow_missing_sessions=config.allow_missing_sessions,
-        use_template_mri=config.use_template_mri,
         contrasts=config.contrasts,
         report_stc_n_time_points=config.report_stc_n_time_points,
         smoothing_steps=config.smoothing_steps,

--- a/mne_bids_pipeline/steps/source/_99_group_average.py
+++ b/mne_bids_pipeline/steps/source/_99_group_average.py
@@ -242,6 +242,11 @@ def get_config(
         exclude_subjects=config.exclude_subjects,
         sessions=get_sessions(config),
         allow_missing_sessions=config.allow_missing_sessions,
+        # main() re-resolves the FreeSurfer subject per session by handing cfg to
+        # get_fs_subject(), which reads these two raw options rather than the
+        # fs_subjects_dir we already resolved above
+        subjects_dir=get_fs_subjects_dir(config),
+        use_template_mri=config.use_template_mri,
         contrasts=config.contrasts,
         report_stc_n_time_points=config.report_stc_n_time_points,
         smoothing_steps=config.smoothing_steps,

--- a/mne_bids_pipeline/tests/test_documented.py
+++ b/mne_bids_pipeline/tests/test_documented.py
@@ -24,6 +24,8 @@ from mne_bids_pipeline._config_utils import (
     get_fs_subject,
     get_mf_cal_fname,
     get_mf_ctc_fname,
+    get_mf_reference_run_task,
+    get_runs_tasks,
 )
 from mne_bids_pipeline._docs import _EXECUTION_OPTIONS, _ParseConfigSteps
 from mne_bids_pipeline._import_data import _import_data_kwargs
@@ -129,10 +131,7 @@ def test_config_options_used_in_steps() -> None:
     del pcs
 
     # Some explicit ignores
-    ignores = {
-        # Triaged in get_config itself
-        "source/_04_make_forward": ["mri_landmarks_kind", "mri_t1_path_generator"],
-    }
+    ignores: dict[str, list[str]] = {}
     # Parse some helper functions to find nested config uses
     helpers: dict[str, set[str]] = {}
     for func, count, nested in (
@@ -148,6 +147,8 @@ def test_config_options_used_in_steps() -> None:
         (_add_epochs_image_kwargs, 1, ()),
         (get_mf_cal_fname, 3, ()),
         (get_mf_ctc_fname, 3, ()),
+        (get_mf_reference_run_task, 2, ()),
+        (get_runs_tasks, 2, (get_mf_reference_run_task,)),
         (_get_rank, 1, ()),
     ):
         this_key = f"{func.__name__}("
@@ -183,6 +184,10 @@ def test_config_options_used_in_steps() -> None:
                 continue
             # cfg.<var> in step source?
             if re.search(rf"\bcfg\.{var}\b", step_src):
+                continue
+            # config.<var> used (not just passed through as a kwarg like
+            # <var>=config.<var>, which the lookbehind for "=" excludes)?
+            if re.search(rf"(?<!=)\bconfig\.{var}\b", step_src):
                 continue
             # config.<var> in main() source (need to avoid looking at get_config, etc.)?
             if re.search(rf"\bconfig\.{var}\b", step_main_src):

--- a/mne_bids_pipeline/tests/test_documented.py
+++ b/mne_bids_pipeline/tests/test_documented.py
@@ -1,42 +1,29 @@
 """Test that all config values are documented."""
 
 import ast
-import importlib
-import inspect
 import logging
 import os
 import re
 import sys
 from collections.abc import Generator
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 import yaml
 
 from mne_bids_pipeline._config_import import _get_default_config, _import_config
 from mne_bids_pipeline._config_template import create_template_config
-from mne_bids_pipeline._config_utils import (
-    _get_decoding_proc,
-    _get_rank,
-    _get_task_contrasts,
-    _limit_which_clean,
-    _restrict_analyze_channels,
-    get_fs_subject,
-    get_mf_cal_fname,
-    get_mf_ctc_fname,
-    get_mf_reference_run_task,
-    get_runs_tasks,
+from mne_bids_pipeline._config_utils import _bids_kwargs, _get_step_modules
+from mne_bids_pipeline._docs import (
+    _EXECUTION_OPTIONS,
+    _FORCE_EMPTY,
+    _ParseConfigSteps,
+    get_kwargs_helper_fields,
+    get_step_cfg_fields,
+    get_step_reads,
 )
-from mne_bids_pipeline._docs import _EXECUTION_OPTIONS, _ParseConfigSteps
-from mne_bids_pipeline._import_data import _import_data_kwargs
 from mne_bids_pipeline._logging import _log_context
-from mne_bids_pipeline._report import (
-    _all_conditions,
-    add_csp_grand_average,
-)
-from mne_bids_pipeline.steps.preprocessing._07_make_epochs import (
-    _add_epochs_image_kwargs,
-)
 from mne_bids_pipeline.tests.datasets import DATASET_OPTIONS
 from mne_bids_pipeline.tests.test_run import TEST_SUITE
 
@@ -107,6 +94,9 @@ def test_config_options_passed_to_any_steps() -> None:
         config_names.add(key)
     for key in _EXECUTION_OPTIONS:
         config_names.remove(key)
+    # a stale entry here would silently blank out a step list forever
+    stale = sorted(set(_FORCE_EMPTY) - config_names - set(_EXECUTION_OPTIONS))
+    assert stale == [], f"No longer config options, drop from _FORCE_EMPTY: {stale}"
     pcs = _ParseConfigSteps(force_empty=())
     missing_from_config = sorted(set(pcs.steps) - config_names)
     assert missing_from_config == [], f"Missing from config: {missing_from_config}"
@@ -118,99 +108,68 @@ def test_config_options_passed_to_any_steps() -> None:
     assert "sensor/_03_decoding_time_by_time" in pcs.steps["cov_rank"]
 
 
-def test_config_options_used_in_steps() -> None:
-    """Test that config options passed to a given step are referenced in that step."""
-    # Find our mapping from config vars from get_config() to steps...
-    pcs = _ParseConfigSteps()  # allow the force_empty defaults here
-    # ... and invert it so it maps steps to get_config() vars
-    step_vars: dict[str, set[str]] = {}
-    for key, steps in pcs.steps.items():
-        for step in steps:
-            step_vars.setdefault(step, set())
-            step_vars[step].add(key)
-    del pcs
+def _step_modules() -> dict[ModuleType, str]:
+    """Get each step module and its "group/name" label, without duplicates."""
+    modules = sum(_get_step_modules().values(), ())  # "all" repeats other groups
+    return {
+        module: "/".join(module.__name__.split(".")[-2:])
+        for module in dict.fromkeys(modules)
+    }
 
-    # Some explicit ignores
-    ignores: dict[str, list[str]] = {}
-    # Parse some helper functions to find nested config uses
-    helpers: dict[str, set[str]] = {}
-    for func, count, nested in (
-        # These "count" values can be updated when the helper functions change,
-        # but it's nice to make sure we're getting what we expect otherwise
-        (_import_data_kwargs, 27, ()),
-        (_limit_which_clean, 3, ()),
-        (_restrict_analyze_channels, 3, ()),
-        (_get_decoding_proc, 2, (_get_rank,)),
-        (_all_conditions, 2, (_get_task_contrasts,)),
-        (add_csp_grand_average, 9, ()),
-        (get_fs_subject, 1, ()),
-        (_add_epochs_image_kwargs, 1, ()),
-        (get_mf_cal_fname, 3, ()),
-        (get_mf_ctc_fname, 3, ()),
-        (get_mf_reference_run_task, 2, ()),
-        (get_runs_tasks, 2, (get_mf_reference_run_task,)),
-        (_get_rank, 1, ()),
-    ):
-        this_key = f"{func.__name__}("
-        helpers[this_key] = set()
-        for this_func in (func,) + nested:
-            spec = inspect.getfullargspec(this_func)
-            kind = "cfg" if "cfg" in (spec.args + spec.kwonlyargs) else "config"
-            this_src = inspect.getsource(this_func)
-            vars_ = set(re.findall(rf"\b{kind}\.([a-z_]+)\b", this_src))
-            helpers[this_key].update(vars_)
-        assert len(helpers[this_key]) == count, (
-            f"{this_key} has {len(helpers[this_key])} vars, expected {count}, does the "
-            "'count' need to be updated due to code changes?"
-        )
 
-    # Now let's go through each step and ensure each config var is used
+def _format_errors(errors: list[tuple[str, str]], what: str, hint: str) -> str:
+    use_len = max(len(err[0]) for err in errors)
+    error_str = "\n".join(f"- {err[0].ljust(use_len)} : {err[1]}" for err in errors)
+    return f"{len(errors)} {what}:\n\n{error_str}\n\n{hint}"
+
+
+def test_cfg_fields_used_in_steps() -> None:
+    """Test that every cfg field a step builds is actually read by that step."""
+    # `_bids_kwargs` is deliberately all-or-nothing: it is the BIDS identity of
+    # the data, and the steps that use any of it get all of it. That is the same
+    # reasoning behind listing those options in `_FORCE_EMPTY` -- see the comment
+    # there. Everything else has to earn its place in `cfg`.
+    bids_fields = get_kwargs_helper_fields(_bids_kwargs)
     errors = []
-    for step in step_vars:
-        # Get the step source
-        step_mod = importlib.import_module(
-            f"mne_bids_pipeline.steps.{step.replace('/', '.')}"
+    for module, step in _step_modules().items():
+        unread = get_step_cfg_fields(module) - get_step_reads(module) - bids_fields
+        errors.extend(
+            (f"mne_bids_pipeline/steps/{step}.py", var) for var in sorted(unread)
         )
-        step_main = step_mod.main
-        step_src = inspect.getsource(step_mod)
-        step_src = "\n".join(line.split("#")[0] for line in step_src.splitlines())
-        # find the main() call and its source
-        step_main_src = inspect.getsource(step_main)
-        step_main_src = "\n".join(
-            line.split("#")[0] for line in step_main_src.splitlines()
-        )
-        for var in sorted(step_vars[step]):
-            if var in ignores.get(step, []):
-                continue
-            # cfg.<var> in step source?
-            if re.search(rf"\bcfg\.{var}\b", step_src):
-                continue
-            # config.<var> used (not just passed through as a kwarg like
-            # <var>=config.<var>, which the lookbehind for "=" excludes)?
-            if re.search(rf"(?<!=)\bconfig\.{var}\b", step_src):
-                continue
-            # config.<var> in main() source (need to avoid looking at get_config, etc.)?
-            if re.search(rf"\bconfig\.{var}\b", step_main_src):
-                continue
-            # do any helpers use it?
-            helpers_use = False
-            for helper, helper_vars in helpers.items():
-                if helper in step_src and var in helper_vars:
-                    helpers_use = True
-                    break
-            if helpers_use:
-                continue
-            errors.append((f"mne_bids_pipeline/steps/{step}.py", var))
     if errors:  # pragma: no cover
-        use_len = max(len(err[0]) for err in errors)
-        error_str = "\n".join(f"- {err[0].ljust(use_len)} : {err[1]}" for err in errors)
-        error_str += (
-            "\n\nIf this is a false alarm and a config var truly used, update this "
-            "test by expanding the list of 'helpers', adding the variable to the "
-            "'ignores' dict, or otherwise improve this test to be smarter."
-        )
         raise AssertionError(
-            f"{len(errors)} config option(s) not used in steps:\n\n{error_str}"
+            _format_errors(
+                errors,
+                "cfg field(s) passed to a step that never reads them",
+                "Passing a config option a step does not use makes the docs claim a "
+                "dependency that is not real, and needlessly invalidates that step's "
+                "cache when the option changes. Drop the field from get_config(), or "
+                "if it really is used, teach _docs.get_step_reads() how to see it.",
+            )
+        )
+
+
+def test_cfg_fields_passed_to_steps() -> None:
+    """Test that every cfg field a step reads is actually built by that step."""
+    # `get_tasks()` returns early on `config.all_tasks`, which `_bids_kwargs`
+    # always supplies, so the `config.task` fallback inside it is unreachable
+    # when it is handed a cfg rather than the real config.
+    guarded = {"task"}
+    errors = []
+    for module, step in _step_modules().items():
+        missing = get_step_reads(module) - get_step_cfg_fields(module) - guarded
+        errors.extend(
+            (f"mne_bids_pipeline/steps/{step}.py", var) for var in sorted(missing)
+        )
+    if errors:  # pragma: no cover
+        raise AssertionError(
+            _format_errors(
+                errors,
+                "cfg field(s) read by a step that never builds them",
+                "This is an AttributeError waiting to happen: the step reads "
+                "cfg.<field> but its get_config() never sets it. Add it to "
+                "get_config(), or stop reading it.",
+            )
         )
 
 

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -423,6 +423,12 @@ def test_session_specific_mri(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Test of (faked) session-specific MRIs."""
+    # The BIDS side of this dataset is ~1.8G, and the pipeline only ever reads it
+    # (everything it writes goes under deriv_root, set below), so symlink rather
+    # than copy -- copying it does not fit in a typical /tmp tmpfs. The FreeSurfer
+    # derivatives below are copied for real, because source/_01_make_bem_surfaces
+    # can write BEM surfaces into subjects_dir, which through a symlink would
+    # corrupt the user's cached dataset.
     dataset = "MNE-funloc-data"
     test_options = TEST_SUITE[dataset]
     config = test_options.get("config", f"config_{dataset}.py")
@@ -454,13 +460,11 @@ def test_session_specific_mri(
                 # `raw.info["subject_info"]["his_id"]` is not necessary because MNE-BIDS
                 # overwrites it with the value in `participants.tsv` anyway.
                 else:
-                    shutil.copyfile(
-                        src=walk_root / _file, dst=dst_dir / offset / bp.basename
-                    )
+                    os.symlink(walk_root / _file, dst_dir / offset / bp.basename)
     # emptyroom
     src_dir = config_obj.bids_root / "sub-emptyroom"
     dst_dir = new_bids_path.root / "sub-emptyroom"
-    shutil.copytree(src=src_dir, dst=dst_dir)
+    shutil.copytree(src=src_dir, dst=dst_dir, copy_function=os.symlink)
     # root-level files (dataset description, etc)
     src_dir = config_obj.bids_root
     dst_dir = new_bids_path.root
@@ -468,7 +472,7 @@ def test_session_specific_mri(
     for _file in files:
         # in theory we should rewrite `participants.tsv` to remove the `sub-02` line,
         # but in practice it will just get ignored so we won't bother.
-        shutil.copyfile(src=_file, dst=dst_dir / _file.name)
+        os.symlink(_file, dst_dir / _file.name)
     # derivatives (freesurfer files)
     src_dir = config_obj.bids_root / "derivatives" / "freesurfer" / "subjects"
     dst_dir = new_bids_path.root / "derivatives" / "freesurfer" / "subjects"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,19 +106,11 @@ count = ""
 
 [tool.coverage.run]
 source = ["mne_bids_pipeline"]
-# Most of the pipeline runs inside joblib/loky or dask workers, which are
-# separate processes. Without these, everything executed in a worker is invisible
-# to coverage, which is why some steps used to look far less covered than they
-# are (and why a few test configs pinned n_jobs=1 just to be measurable).
-#
-# patch=subprocess makes coverage.py hand its config down to child processes,
-# which its .pth hook then picks up; parallel keeps each process writing its own
-# data file; sigterm saves data for workers that are terminated rather than
-# exiting cleanly (dask shuts its workers down that way).
-patch = ["subprocess", "_exit"]
+# Measure loky/dask workers, too; reports need `coverage combine --append`.
+patch = ["subprocess", "_exit"]  # fork/execv raise on Windows
 parallel = true
 concurrency = ["multiprocessing", "thread"]
-sigterm = true
+sigterm = true  # dask kills workers rather than letting them exit
 
 [tool.coverage.report]
 exclude_also = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,29 @@ interactive = 3
 enable-colors = ""
 count = ""
 
+[tool.coverage.run]
+source = ["mne_bids_pipeline"]
+# Most of the pipeline runs inside joblib/loky or dask workers, which are
+# separate processes. Without these, everything executed in a worker is invisible
+# to coverage, which is why some steps used to look far less covered than they
+# are (and why a few test configs pinned n_jobs=1 just to be measurable).
+#
+# patch=subprocess makes coverage.py hand its config down to child processes,
+# which its .pth hook then picks up; parallel keeps each process writing its own
+# data file; sigterm saves data for workers that are terminated rather than
+# exiting cleanly (dask shuts its workers down that way).
+patch = ["subprocess", "_exit"]
+parallel = true
+concurrency = ["multiprocessing", "thread"]
+sigterm = true
+
+[tool.coverage.report]
+exclude_also = [
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
+  "@overload",
+]
+
 [tool.hatch.version]
 source = "vcs"
 raw-options = { version_scheme = "release-branch-semver" }
@@ -120,17 +143,21 @@ exclude = [
   "ignore_words.txt",
 ]
 
-[tool.pytest]
+[tool.pytest.ini_options]
 addopts = [
-  "--cov-report=",
   "--cov=mne_bids_pipeline",
+  "--cov-report=xml",
   "--durations=10",
   "--junit-xml=junit-results.xml",
+  "--strict-markers",
   "--tb=short",
   "-ra",
-  "-vv"
+  "-vv",
 ]
 junit_family = "xunit2"
+markers = [
+  "dataset_test: a test that downloads and processes a real BIDS dataset",
+]
 testpaths = ["mne_bids_pipeline"]
 
 [tool.ruff]


### PR DESCRIPTION
`_ParseConfigSteps` has steadily grown more and more unwieldy because it's a bit of a hodgepodge of functions to look at, plus which those call, etc. This started out as a plain refactor (facilitated by Claude Fable 5) to recurse through all function calls with a `seen` set. However, once that was done, it became simpler and easier to traverse stuff we ignored before, like `_bids_kwargs`. Then it became easier to split these up and limit them. So now this PR also limits the config options passed to options much better than it did before, coming closer to the ideal "options are passed to steps if and only if they are (potentially) used by the given step". This turned up a number of violations, now fixed.

In theory this should come back green... :crossed_fingers: 