### PR TITLE
ENH: Add flow diagram to reports

### DIFF
--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -6,6 +6,7 @@
 
 - Added [`ignore_warnings`][mne_bids_pipeline._config.ignore_warnings] config option to allow users to specify warnings to ignore when calling `read_raw_bids` (#1224 by @larsoner)
 - Added tracking of the current step in the terminal title (#1266 by @larsoner)
+- Added a "Pipeline flow" section to the reports with an auto-generated diagram of the steps that ran for a subject and the files they passed to one another (#1289 by @larsoner)
 
 ### :warning: Behavior changes
 

--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -6,7 +6,7 @@
 
 - Added [`ignore_warnings`][mne_bids_pipeline._config.ignore_warnings] config option to allow users to specify warnings to ignore when calling `read_raw_bids` (#1224 by @larsoner)
 - Added tracking of the current step in the terminal title (#1266 by @larsoner)
-- Added a "Pipeline flow" section to the reports with an auto-generated diagram of the steps that ran for a subject and the files they passed to one another (#1289 by @larsoner)
+- Added a "Pipeline flow" section to the reports with an auto-generated diagram of the steps that ran for a subject and the files they passed to one another (#1291 by @larsoner)
 
 ### :warning: Behavior changes
 

--- a/docs/source/features/gen_steps.py
+++ b/docs/source/features/gen_steps.py
@@ -4,7 +4,8 @@
 import importlib
 from pathlib import Path
 
-from mne_bids_pipeline._config_utils import _get_step_modules
+from mne_bids_pipeline._config_utils import _get_step_modules, _get_step_title
+from mne_bids_pipeline._run import _short_step_path
 
 autogen_header = f"""\
 [//a]: # (AUTO-GENERATED, TO CHANGE EDIT {"/".join(Path(__file__).parts[-4:])})\
@@ -116,7 +117,8 @@ for di, (dir_, modules) in enumerate(step_modules.items(), 1):
         continue  # this is an alias
     dir_module = importlib.import_module(f"mne_bids_pipeline.steps.{dir_}")
     assert dir_module.__doc__ is not None
-    dir_header = dir_module.__doc__.split("\n")[0].rstrip(".")
+    dir_header = _get_step_title(dir_module)
+    assert dir_header is not None
     dir_body_list = dir_module.__doc__.split("\n", maxsplit=1)
     dir_body = dir_body_list[1].strip() if len(dir_body_list) > 1 else ""
     icon = icon_map[dir_header]
@@ -131,10 +133,10 @@ for di, (dir_, modules) in enumerate(step_modules.items(), 1):
     lines.append(f"`{dir_name}` | {step_title} |")
     for module in modules:
         assert module.__file__ is not None
-        assert module.__doc__ is not None
-        step_name = f"{dir_name}/{Path(module.__file__).name}"[:-3]
-        step_title = module.__doc__.split("\n")[0]
-        lines.append(f"`{step_name}` | {step_title} |")
+        step_name = _short_step_path(Path(module.__file__))
+        step_title = _get_step_title(module)
+        assert step_title is not None
+        lines.append(f"`{step_name}` | {step_title}. |")
     lines.append("")
 
     # Overview
@@ -153,9 +155,9 @@ flowchart TD"""
     prev_idx = None
     title_map = {}
     for mi, module in enumerate(modules, 1):
-        assert module.__doc__ is not None
         assert module.__name__ is not None
-        step_title = module.__doc__.split("\n")[0].rstrip(".")
+        step_title = _get_step_title(module)
+        assert step_title is not None
         idx = module.__name__.split(".")[-1].split("_")[1]  # 01, 05a, etc.
         # Need to quote the title to deal with parens, and sanitize quotes
         step_title = step_title.replace('"', "'")

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -919,6 +919,12 @@ def _validate_contrasts(
                 raise ValueError("Contrasts must be tuples or well-formed dicts")
 
 
+def _get_step_title(module: ModuleType | None) -> str | None:
+    """Get a step's human-readable title: its docstring's first line, no period."""
+    doc = getattr(module, "__doc__", None) or ""
+    return doc.strip().split("\n")[0].rstrip(".") or None
+
+
 def _get_step_modules() -> dict[str, tuple[ModuleType, ...]]:
     from .steps import freesurfer, init, preprocessing, sensor, source
 

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -1,0 +1,116 @@
+"""Recording of the files that each pipeline step reads and writes."""
+
+import json
+import pathlib
+from collections.abc import Mapping
+
+from filelock import FileLock
+from mne_bids import BIDSPath
+
+from .typing import TypedDict
+
+_FLOW_DIRNAME = ".pipeline_flow"
+_FLOW_VERSION = 1
+
+
+class FlowEntryT(TypedDict):
+    """One recorded call of a pipeline step's worker function."""
+
+    step: str
+    func: str
+    subject: str | None
+    session: str | None
+    run: str | None
+    task: str | None
+    in_files: dict[str, str]
+    out_files: dict[str, str]
+
+
+def _flow_dir(deriv_root: pathlib.Path) -> pathlib.Path:
+    return pathlib.Path(deriv_root) / _FLOW_DIRNAME
+
+
+def _flow_fname(*, deriv_root: pathlib.Path, subject: str | None) -> pathlib.Path:
+    # One file per subject keeps the read-modify-write cheap and keeps parallel
+    # subjects off each other's lock.
+    stem = "dataset" if subject is None else f"sub-{subject}"
+    return _flow_dir(deriv_root) / f"{stem}.json"
+
+
+def _flow_entry_key(entry: FlowEntryT) -> str:
+    keys = ("step", "func", "subject", "session", "run", "task")
+    return "|".join(str(entry[key] or "") for key in keys)  # type: ignore[literal-required]
+
+
+def _read_flow_file(fname: pathlib.Path) -> dict[str, FlowEntryT]:
+    if not fname.is_file():
+        return dict()
+    with FileLock(f"{fname}.lock"):
+        try:
+            content = json.loads(fname.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            content = dict()
+    if content.get("version", None) != _FLOW_VERSION:
+        return dict()
+    entries: dict[str, FlowEntryT] = content["entries"]
+    return entries
+
+
+def _write_flow_entry(
+    *, deriv_root: pathlib.Path, entry: FlowEntryT, only_if_new: bool = False
+) -> None:
+    """Merge a single recorded step call into the on-disk recording."""
+    fname = _flow_fname(deriv_root=deriv_root, subject=entry["subject"])
+    fname.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(f"{fname}.lock"):
+        entries: dict[str, FlowEntryT] = dict()
+        if fname.is_file():
+            try:
+                content = json.loads(fname.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                content = dict()
+            if content.get("version", None) == _FLOW_VERSION:
+                entries = content["entries"]
+        key = _flow_entry_key(entry)
+        if only_if_new and key in entries:
+            return
+        entries[key] = entry
+        fname.write_text(
+            json.dumps(dict(version=_FLOW_VERSION, entries=entries), indent=1),
+            encoding="utf-8",
+        )
+
+
+def _read_flow_entries(
+    *, deriv_root: pathlib.Path, subject: str, session: str | None
+) -> list[FlowEntryT]:
+    """Get the recorded step calls relevant for one report."""
+    fnames = [_flow_fname(deriv_root=deriv_root, subject=None)]
+    if subject == "average":
+        # Group steps read individual subjects' files, so the group report needs every
+        # subject's recording to attribute those inputs to the steps that made them.
+        fnames += sorted(_flow_dir(deriv_root).glob("sub-*.json"))
+    else:
+        fnames.append(_flow_fname(deriv_root=deriv_root, subject=subject))
+    entries: list[FlowEntryT] = list()
+    for fname in fnames:
+        for entry in _read_flow_file(fname).values():
+            if entry["session"] in (None, session):
+                entries.append(entry)
+    entries.sort(key=_flow_entry_key)
+    return entries
+
+
+def _flow_files(files: Mapping[str, object] | None) -> dict[str, str]:
+    """Normalize an in_files/out_files mapping to plain path strings."""
+    out: dict[str, str] = dict()
+    for key, value in (files or dict()).items():
+        if key == "__unknown_inputs__":
+            continue
+        if isinstance(value, tuple):  # out_files carry (path, hash) pairs
+            value = value[0]
+        if isinstance(value, BIDSPath):
+            value = value.fpath
+        if isinstance(value, str | pathlib.Path):
+            out[key] = str(value)
+    return out

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -27,10 +27,14 @@ class FlowEntryT(TypedDict):
 
     step: str
     func: str
+    title: str | None
     subject: str | None
     session: str | None
     run: str | None
     task: str | None
+    duration: float | None  # None (with finished/cached) until the call completes
+    finished: str | None
+    cached: bool | None
     in_files: dict[str, str]
     out_files: dict[str, str]
 
@@ -244,14 +248,44 @@ def _edge_lines(paths: Sequence[str]) -> list[str]:
     return lines
 
 
+def _node_tooltip(entries: Sequence[FlowEntryT], out_paths: Sequence[str]) -> list[str]:
+    """Summarize a step's recorded calls for its hover tooltip."""
+    lines: list[str] = list()
+    titles = [title for entry in entries if (title := entry.get("title"))]
+    if titles:
+        lines.append(titles[0])
+    timed = [entry for entry in entries if entry.get("duration") is not None]
+    if timed:
+        total = sum(entry["duration"] or 0.0 for entry in timed)
+        took = f"{total:.1f} s" if total < 60 else f"{total / 60:.1f} min"
+        calls = f" over {len(timed)} calls" if len(timed) > 1 else ""
+        n_cached = sum(bool(entry.get("cached")) for entry in timed)
+        if n_cached == len(timed):
+            note = " (from cache)"
+        elif n_cached:
+            note = f" ({n_cached}/{len(timed)} from cache)"
+        else:
+            note = ""
+        lines.append(f"took {took}{calls}{note}")
+        stamps = [stamp for entry in timed if (stamp := entry.get("finished"))]
+        if stamps:
+            lines.append(f"finished {max(stamps)}")
+    if out_paths:
+        lines.append("writes:")
+        lines.extend(out_paths)
+    return lines
+
+
 def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _Graph:
     """Build the step graph implied by a set of recorded step calls."""
     produced_by: dict[str, set[str]] = dict()
     step_paths: dict[str, set[str]] = dict()
+    step_entries: dict[str, list[FlowEntryT]] = dict()
     for entry in entries:
         for path in entry["out_files"].values():
             produced_by.setdefault(path, set()).add(entry["step"])
         step_paths.setdefault(entry["step"], set()).update(entry["out_files"].values())
+        step_entries.setdefault(entry["step"], []).append(entry)
 
     edge_paths: dict[tuple[str, str], set[str]] = dict()
     for entry in entries:
@@ -277,7 +311,9 @@ def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _Graph:
             node = _Node(
                 id=_node_id(step),
                 lines=_step_lines(step),
-                paths=sorted(step_paths.get(step, set())),
+                paths=_node_tooltip(
+                    step_entries.get(step, []), sorted(step_paths.get(step, set()))
+                ),
                 klass=f"mbp-flow-cat-{category}" if category else "",
             )
         graph.nodes.append(node)

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -100,12 +100,10 @@ def _write_flow_entry(
         ):
             # A cache hit replays the same computation, so keep when the original
             # run happened and how long it took rather than the cache-check timing
-            entry = dict(  # type: ignore[assignment]
-                entry,
-                duration=old["duration"],
-                finished=old["finished"],
-                cached=old["cached"],
-            )
+            entry = entry.copy()
+            entry["duration"] = old["duration"]
+            entry["finished"] = old["finished"]
+            entry["cached"] = old["cached"]
         entries[key] = entry
         have_roots.update(roots or dict())
         content = dict(version=_FLOW_VERSION, roots=have_roots, entries=entries)

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -269,9 +269,13 @@ def _build_flow_graph(
 
     edge_paths: dict[tuple[str, str], set[str]] = dict()
     for entry in entries:
+        # Distant bands get their own copy of the source node (recognizable by its
+        # styling) rather than one edge spanning the whole diagram
+        rank = _GROUP_RANKS.get(entry["step"].partition("/")[0], 0)
+        source_id = _SOURCE_ID if rank < 2 else f"{_SOURCE_ID}@{rank}"
         for path in entry["in_files"].values():
             # Files nobody produced came from outside the pipeline (raw BIDS data).
-            for src in produced_by.get(path, {_SOURCE_ID}):
+            for src in produced_by.get(path, {source_id}):
                 if src == entry["step"]:  # e.g. a reference run feeding later runs
                     continue
                 edge_paths.setdefault((src, entry["step"]), set()).add(path)
@@ -279,12 +283,13 @@ def _build_flow_graph(
     graph = _Graph()
     used_steps = {step for edge in edge_paths for step in edge}
     for step in sorted(used_steps):
-        if step == _SOURCE_ID:
+        if step.startswith(_SOURCE_ID):
             node = _Node(
                 id=_node_id(step),
                 lines=[_SOURCE_LABEL],
                 paths=[f"<{name}> = {path}" for name, path in sorted(roots.items())],
                 klass="mbp-flow-source",
+                rank=int(step.partition("@")[2] or 0),
             )
         else:
             group = step.partition("/")[0]

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -5,7 +5,6 @@ recordings into the step dependency graph and its labels. The generic layout and
 SVG rendering live in ``_graph.py``.
 """
 
-import json
 import pathlib
 import re
 from collections.abc import Sequence
@@ -15,6 +14,7 @@ from filelock import FileLock
 from mne_bids import get_entities_from_fname
 
 from ._graph import _ID_PREFIX, _Edge, _Graph, _graph_html, _layout_graph, _Node
+from ._io import _read_json, _write_json
 from ._logging import _collapse_runs, _shorten_paths
 from .typing import TypedDict
 
@@ -65,8 +65,8 @@ def _parse_flow_file(fname: pathlib.Path) -> dict[str, Any]:
     if not fname.is_file():
         return dict()
     try:
-        content = json.loads(fname.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
+        content = _read_json(fname)
+    except ValueError:  # includes JSONDecodeError
         return dict()
     return content if content.get("version", None) == _FLOW_VERSION else dict()
 
@@ -108,13 +108,8 @@ def _write_flow_entry(
             )
         entries[key] = entry
         have_roots.update(roots or dict())
-        fname.write_text(
-            json.dumps(
-                dict(version=_FLOW_VERSION, roots=have_roots, entries=entries),
-                indent=1,
-            ),
-            encoding="utf-8",
-        )
+        content = dict(version=_FLOW_VERSION, roots=have_roots, entries=entries)
+        _write_json(fname, content, indent=1)
     return entry
 
 

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -1,8 +1,15 @@
-"""Recording of the files that each pipeline step reads and writes."""
+"""Auto-generated pipeline flow diagrams for the HTML reports.
+
+Steps record what they read and wrote (see ``_run.py``); this module turns those
+recordings into a layered DAG and emits it as a self-contained SVG.
+"""
 
 import json
 import pathlib
-from collections.abc import Mapping
+import re
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from xml.sax.saxutils import escape, quoteattr
 
 from filelock import FileLock
 from mne_bids import BIDSPath
@@ -11,6 +18,9 @@ from .typing import TypedDict
 
 _FLOW_DIRNAME = ".pipeline_flow"
 _FLOW_VERSION = 1
+_SOURCE_ID = "__bids_input__"
+_SOURCE_LABEL = "BIDS raw data"
+_ID_PREFIX = "mbp-flow"
 
 
 class FlowEntryT(TypedDict):
@@ -24,6 +34,9 @@ class FlowEntryT(TypedDict):
     task: str | None
     in_files: dict[str, str]
     out_files: dict[str, str]
+
+
+# -- Storage -----------------------------------------------------------------
 
 
 def _flow_dir(deriv_root: pathlib.Path) -> pathlib.Path:
@@ -99,6 +112,521 @@ def _read_flow_entries(
                 entries.append(entry)
     entries.sort(key=_flow_entry_key)
     return entries
+
+
+# -- Graph -------------------------------------------------------------------
+
+
+@dataclass
+class _FlowNode:
+    id: str
+    lines: list[str]
+    paths: list[str]
+    layer: int = 0
+    x: float = 0.0
+    y: float = 0.0
+    width: float = 0.0
+    dummy: bool = False
+
+
+@dataclass
+class _FlowEdge:
+    id: str
+    src: str
+    dst: str
+    lines: list[str]
+    paths: list[str]
+    points: list[tuple[float, float]] = field(default_factory=list)
+
+
+@dataclass
+class _FlowGraph:
+    nodes: list[_FlowNode] = field(default_factory=list)
+    edges: list[_FlowEdge] = field(default_factory=list)
+    width: float = 0.0
+    height: float = 0.0
+
+
+def _node_id(step: str) -> str:
+    return f"{_ID_PREFIX}-node-{re.sub(r'[^A-Za-z0-9_-]+', '-', step)}"
+
+
+def _step_lines(step: str) -> list[str]:
+    group, _, name = step.partition("/")
+    return [group, name] if name else [group]
+
+
+def _fname_bits(path: str) -> tuple[str | None, str | None, str | None]:
+    """Get the (processing, suffix, extension) descriptors of a filename."""
+    name = pathlib.Path(path).name
+    stem, _, _ = name.partition(".")
+    extension = name[len(stem) :] or None
+    parts = stem.split("_")
+    if not any("-" in part for part in parts):  # not a BIDS-style name
+        return None, None, extension
+    processing = None
+    for part in parts:
+        key, sep, value = part.partition("-")
+        if sep and key == "proc":
+            processing = value
+    suffix = parts[-1] if "-" not in parts[-1] else None
+    return processing, suffix, extension
+
+
+def _fname_run(path: str) -> str | None:
+    for part in pathlib.Path(path).name.split("_"):
+        key, sep, value = part.partition("-")
+        if sep and key == "run":
+            return value
+    return None
+
+
+def _collapse_runs(runs: Iterable[str]) -> str:
+    """Turn a set of run labels into something like ``runs 01–03, 07``."""
+    runs = sorted(set(runs))
+    if not runs:
+        return ""
+    label = "run" if len(runs) == 1 else "runs"
+    try:
+        numbers = sorted(int(run) for run in runs)
+    except ValueError:
+        return f"{label} {', '.join(runs)}"
+    width = max(len(run) for run in runs)
+    groups: list[list[int]] = [[numbers[0]]]
+    for number in numbers[1:]:
+        if number == groups[-1][-1] + 1:
+            groups[-1].append(number)
+        else:
+            groups.append([number])
+    chunks = [
+        f"{group[0]:0{width}d}"
+        if len(group) == 1
+        else f"{group[0]:0{width}d}–{group[-1]:0{width}d}"
+        for group in groups
+    ]
+    return f"{label} {', '.join(chunks)}"
+
+
+def _edge_lines(paths: Sequence[str]) -> list[str]:
+    """Get a compact semantic descriptor for a set of files."""
+    processings: set[str] = set()
+    suffixes: set[str] = set()
+    extensions: set[str] = set()
+    runs: set[str] = set()
+    for path in paths:
+        processing, suffix, extension = _fname_bits(path)
+        if processing is not None:
+            processings.add(f"proc-{processing}")
+        if suffix is not None:
+            suffixes.add(suffix)
+        elif extension is not None:
+            extensions.add(extension)
+        run = _fname_run(path)
+        if run is not None:
+            runs.add(run)
+    descriptors = sorted(processings) + sorted(suffixes) + sorted(extensions)
+    if len(descriptors) > 3:  # e.g. one proc- entity per contrast; keep the label sane
+        descriptors = descriptors[:3] + [f"+{len(descriptors) - 3} more"]
+    lines = [" ".join(descriptors)] if descriptors else [f"{len(paths)} files"]
+    run_line = _collapse_runs(runs)
+    if run_line:
+        lines.append(run_line)
+    return lines
+
+
+def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _FlowGraph:
+    """Build the step graph implied by a set of recorded step calls."""
+    produced_by: dict[str, set[str]] = dict()
+    step_paths: dict[str, set[str]] = dict()
+    for entry in entries:
+        for path in entry["out_files"].values():
+            produced_by.setdefault(path, set()).add(entry["step"])
+        step_paths.setdefault(entry["step"], set()).update(entry["out_files"].values())
+
+    edge_paths: dict[tuple[str, str], set[str]] = dict()
+    for entry in entries:
+        for path in entry["in_files"].values():
+            # Files nobody produced came from outside the pipeline (raw BIDS data).
+            for src in produced_by.get(path, {_SOURCE_ID}):
+                if src == entry["step"]:  # e.g. a reference run feeding later runs
+                    continue
+                edge_paths.setdefault((src, entry["step"]), set()).add(path)
+
+    graph = _FlowGraph()
+    used_steps = {step for edge in edge_paths for step in edge}
+    for step in sorted(used_steps):
+        if step == _SOURCE_ID:
+            node = _FlowNode(id=_node_id(step), lines=[_SOURCE_LABEL], paths=[])
+        else:
+            node = _FlowNode(
+                id=_node_id(step),
+                lines=_step_lines(step),
+                paths=sorted(step_paths.get(step, set())),
+            )
+        graph.nodes.append(node)
+    for ii, (src, dst) in enumerate(sorted(edge_paths)):
+        paths = sorted(edge_paths[(src, dst)])
+        graph.edges.append(
+            _FlowEdge(
+                id=f"{_ID_PREFIX}-edge-{ii}",
+                src=_node_id(src),
+                dst=_node_id(dst),
+                lines=_edge_lines(paths),
+                paths=paths,
+            )
+        )
+    return graph
+
+
+# -- Layout ------------------------------------------------------------------
+
+_FONT_SIZE = 12.0
+_CHAR_WIDTH = 6.6  # rough advance width of the report's body font at _FONT_SIZE
+_LINE_HEIGHT = 15.0
+_NODE_PAD_X = 12.0
+_NODE_GAP = 26.0
+_ROW_HEIGHT = 150.0
+_MARGIN = 10.0
+_ROW_MID = 21.0  # where a routing point sits within its row
+
+
+def _text_width(lines: Sequence[str]) -> float:
+    return max((len(line) for line in lines), default=0) * _CHAR_WIDTH
+
+
+def _node_height(node: _FlowNode) -> float:
+    return 0.0 if node.dummy else len(node.lines) * _LINE_HEIGHT + 12.0
+
+
+def _assign_layers(graph: _FlowGraph) -> None:
+    layers = {node.id: 0 for node in graph.nodes}
+    # Longest-path layering by relaxation; the pass limit also bounds the (never
+    # expected, but possible if a step both reads and writes a shared file) cycle.
+    for _ in range(len(graph.nodes)):
+        changed = False
+        for edge in graph.edges:
+            if layers[edge.dst] < layers[edge.src] + 1:
+                layers[edge.dst] = layers[edge.src] + 1
+                changed = True
+        if not changed:
+            break
+    for node in graph.nodes:
+        node.layer = layers[node.id]
+
+
+def _order_layers(
+    nodes: Sequence[_FlowNode], chains: Sequence[Sequence[str]]
+) -> list[list[_FlowNode]]:
+    n_layers = max((node.layer for node in nodes), default=0) + 1
+    layers: list[list[_FlowNode]] = [[] for _ in range(n_layers)]
+    for node in nodes:
+        layers[node.layer].append(node)
+    neighbors: dict[str, list[str]] = {node.id: [] for node in nodes}
+    for chain in chains:
+        for src, dst in zip(chain[:-1], chain[1:]):
+            neighbors[src].append(dst)
+            neighbors[dst].append(src)
+    for _ in range(4):
+        index = {
+            node.id: ii for layer in layers for ii, node in enumerate(layer)
+        }  # barycenter positions
+        for layer in layers:
+            layer.sort(
+                key=lambda node: (
+                    sum(index[other] for other in neighbors[node.id])
+                    / max(len(neighbors[node.id]), 1),
+                    node.id,
+                )
+            )
+    return layers
+
+
+def _layout_flow_graph(graph: _FlowGraph) -> _FlowGraph:
+    """Place nodes on a fixed-height grid of layers."""
+    _assign_layers(graph)
+    nodes = {node.id: node for node in graph.nodes}
+    for node in graph.nodes:
+        node.width = _text_width(node.lines) + 2 * _NODE_PAD_X
+    # Route edges that skip layers through dummy nodes, so they reserve horizontal
+    # space and neither they nor their labels run over the nodes in between.
+    routes: dict[str, list[_FlowNode]] = dict()
+    for edge in graph.edges:
+        routes[edge.id] = [
+            _FlowNode(
+                id=f"{edge.id}-p{layer}",
+                lines=[],
+                paths=[],
+                layer=layer,
+                width=max(_text_width(edge.lines) + 12, 30.0),
+                dummy=True,
+            )
+            for layer in range(nodes[edge.src].layer + 1, nodes[edge.dst].layer)
+        ]
+    all_nodes = graph.nodes + [node for route in routes.values() for node in route]
+    chains = [
+        [edge.src] + [node.id for node in routes[edge.id]] + [edge.dst]
+        for edge in graph.edges
+    ]
+    layers = _order_layers(all_nodes, chains)
+    widths = [
+        sum(node.width for node in layer) + _NODE_GAP * max(len(layer) - 1, 0)
+        for layer in layers
+    ]
+    graph.width = max(widths, default=0.0) + 2 * _MARGIN
+    for li, layer in enumerate(layers):
+        x = (graph.width - widths[li]) / 2
+        for node in layer:
+            node.x = x + node.width / 2
+            node.y = _MARGIN + li * _ROW_HEIGHT
+            node.y += _ROW_MID if node.dummy else _node_height(node) / 2
+            x += node.width + _NODE_GAP
+    for edge in graph.edges:
+        src, dst = nodes[edge.src], nodes[edge.dst]
+        edge.points = (
+            [(src.x, src.y + _node_height(src) / 2)]
+            + [(node.x, node.y) for node in routes[edge.id]]
+            + [(dst.x, dst.y - _node_height(dst) / 2)]
+        )
+    graph.height = (
+        max((node.y + _node_height(node) / 2 for node in graph.nodes), default=0.0)
+        + _MARGIN
+    )
+    return graph
+
+
+# -- SVG ---------------------------------------------------------------------
+
+_CSS = """
+.mbp-flow-wrap { overflow-x: auto; }
+svg.mbp-flow { font-size: 12px; color: inherit; }
+svg.mbp-flow text { fill: currentColor; }
+svg.mbp-flow .mbp-flow-box {
+  fill: var(--bs-tertiary-bg, #f3f3f3);
+  stroke: currentColor;
+  stroke-width: 1;
+}
+svg.mbp-flow .mbp-flow-source .mbp-flow-box { stroke-dasharray: 4 3; }
+svg.mbp-flow .mbp-flow-line {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.2;
+  opacity: 0.65;
+}
+svg.mbp-flow .mbp-flow-arrow { fill: currentColor; opacity: 0.65; }
+svg.mbp-flow .mbp-flow-label-bg { fill: var(--bs-body-bg, #ffffff); stroke: none; }
+svg.mbp-flow .mbp-flow-edge text { font-size: 10.5px; opacity: 0.85; }
+svg.mbp-flow .mbp-flow-node, svg.mbp-flow .mbp-flow-edge { transition: opacity 0.1s; }
+svg.mbp-flow.mbp-flow-hovering .mbp-flow-node,
+svg.mbp-flow.mbp-flow-hovering .mbp-flow-edge { opacity: 0.15; }
+svg.mbp-flow.mbp-flow-hovering .mbp-flow-hl { opacity: 1; }
+"""
+
+# No links on the nodes: mne.Report derives its anchors from content titles, and
+# nothing maps a pipeline step to the titles it happens to add to the report.
+_JS = """
+(function () {
+  var root = document.getElementById("%(svg_id)s");
+  if (!root) { return; }
+  var clear = function () {
+    root.classList.remove("mbp-flow-hovering");
+    root.querySelectorAll(".mbp-flow-hl").forEach(function (el) {
+      el.classList.remove("mbp-flow-hl");
+    });
+  };
+  root.querySelectorAll(".mbp-flow-node").forEach(function (node) {
+    node.addEventListener("mouseenter", function () {
+      clear();
+      var attrs = ["data-flow-ancestors", "data-flow-descendants", "data-flow-edges"];
+      var ids = [node.id];
+      attrs.forEach(function (attr) {
+        ids = ids.concat((node.getAttribute(attr) || "").split(" "));
+      });
+      ids.forEach(function (id) {
+        var el = id ? root.querySelector("#" + id) : null;
+        if (el) { el.classList.add("mbp-flow-hl"); }
+      });
+      root.classList.add("mbp-flow-hovering");
+    });
+    node.addEventListener("mouseleave", clear);
+    node.addEventListener("focus", clear);
+  });
+})();
+"""
+
+
+def _reachable(
+    graph: _FlowGraph, *, reverse: bool
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Get the node and edge ids reachable from every node."""
+    adjacent: dict[str, list[tuple[str, str]]] = {node.id: [] for node in graph.nodes}
+    for edge in graph.edges:
+        src, dst = (edge.dst, edge.src) if reverse else (edge.src, edge.dst)
+        adjacent[src].append((dst, edge.id))
+    nodes: dict[str, set[str]] = dict()
+    edges: dict[str, set[str]] = dict()
+    for node in graph.nodes:
+        seen_nodes: set[str] = set()
+        seen_edges: set[str] = set()
+        stack = [node.id]
+        while stack:
+            for other, edge_id in adjacent[stack.pop()]:
+                seen_edges.add(edge_id)
+                if other not in seen_nodes:
+                    seen_nodes.add(other)
+                    stack.append(other)
+        nodes[node.id] = seen_nodes
+        edges[node.id] = seen_edges
+    return nodes, edges
+
+
+def _edge_path(
+    points: Sequence[tuple[float, float]], *, frac: float = 0.5
+) -> tuple[str, tuple[float, float]]:
+    """Get the SVG path through an edge's routing points and its label anchor.
+
+    The anchor is the point on the curve ``frac`` of the way down the gap it spans.
+    """
+    d = f"M {points[0][0]:.1f} {points[0][1]:.1f}"
+    for (x0, y0), (x1, y1) in zip(points[:-1], points[1:]):
+        # Vertical control handles, so consecutive segments join smoothly
+        ym = (y0 + y1) / 2
+        d += f" C {x0:.1f} {ym:.1f}, {x1:.1f} {ym:.1f}, {x1:.1f} {y1:.1f}"
+    if len(points) > 2:  # the routing points sit clear of the nodes, so label there
+        return d, points[len(points) // 2]
+    (x0, y0), (x1, y1) = points
+    ym = (y0 + y1) / 2
+
+    def at(t: float) -> tuple[float, float]:
+        weights = ((1 - t) ** 3, 3 * (1 - t) ** 2 * t, 3 * (1 - t) * t**2, t**3)
+        return (
+            sum(w * x for w, x in zip(weights, (x0, x0, x1, x1))),
+            sum(w * y for w, y in zip(weights, (y0, ym, ym, y1))),
+        )
+
+    target = y0 + frac * (y1 - y0)
+    lo, hi = 0.0, 1.0
+    for _ in range(24):  # the curve is monotonic in y, so just bisect for the height
+        mid = (lo + hi) / 2
+        lo, hi = (mid, hi) if at(mid)[1] < target else (lo, mid)
+    return d, at((lo + hi) / 2)
+
+
+def _svg_title(paths: Sequence[str], *, limit: int = 20) -> str:
+    if not paths:
+        return ""
+    lines = list(paths[:limit])
+    if len(paths) > limit:
+        lines.append(f"… and {len(paths) - limit} more")
+    return f"<title>{escape(chr(10).join(lines))}</title>"
+
+
+def _svg_text(lines: Sequence[str], *, x: float, y: float, klass: str) -> str:
+    top = y - (len(lines) - 1) * _LINE_HEIGHT / 2 + _FONT_SIZE / 3
+    spans = "".join(
+        f'<tspan x="{x:.1f}" y="{top + ii * _LINE_HEIGHT:.1f}">{escape(line)}</tspan>'
+        for ii, line in enumerate(lines)
+    )
+    return f'<text class="{klass}" text-anchor="middle">{spans}</text>'
+
+
+def _flow_svg(graph: _FlowGraph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
+    """Render a laid-out graph as a single self-contained SVG element."""
+    ancestors, ancestor_edges = _reachable(graph, reverse=True)
+    descendants, descendant_edges = _reachable(graph, reverse=False)
+
+    # Stagger the labels of edges that fan out of (or into) a common node, otherwise
+    # they all land at the same height and overlap.
+    fan: dict[str, int] = dict()
+    for edge in graph.edges:
+        for key in (f"src-{edge.src}", f"dst-{edge.dst}"):
+            fan[key] = fan.get(key, 0) + 1
+    groups: dict[str, list[_FlowEdge]] = dict()
+    for edge in graph.edges:
+        key = f"src-{edge.src}" if fan[f"src-{edge.src}"] > 1 else f"dst-{edge.dst}"
+        groups.setdefault(key, []).append(edge)
+    fracs: dict[str, float] = dict()
+    for key, group in groups.items():
+        far = -1 if key.startswith("src-") else 0  # the end that is not shared
+        n_levels = min(len(group), 4)
+        for ii, edge in enumerate(sorted(group, key=lambda e: e.points[far][0])):
+            level = ii % n_levels
+            fracs[edge.id] = (
+                0.5 if n_levels == 1 else 0.28 + 0.44 * level / (n_levels - 1)
+            )
+
+    edge_html: list[str] = list()
+    for edge in graph.edges:
+        d, (mx, my) = _edge_path(edge.points, frac=fracs[edge.id])
+        width = _text_width(edge.lines) + 10
+        height = len(edge.lines) * _LINE_HEIGHT
+        edge_html.append(
+            f'<g id="{edge.id}" class="mbp-flow-edge">'
+            f'<path class="mbp-flow-line" d="{d}" '
+            f'marker-end="url(#{_ID_PREFIX}-arrow)" />'
+            f'<rect class="mbp-flow-label-bg" rx="3" x="{mx - width / 2:.1f}" '
+            f'y="{my - height / 2:.1f}" width="{width:.1f}" height="{height:.1f}" />'
+            f"{_svg_text(edge.lines, x=mx, y=my, klass='mbp-flow-edge-label')}"
+            f"{_svg_title(edge.paths)}</g>"
+        )
+
+    node_html: list[str] = list()
+    for node in graph.nodes:
+        height = _node_height(node)
+        klass = "mbp-flow-node"
+        if node.id == _node_id(_SOURCE_ID):
+            klass += " mbp-flow-source"
+        related = {
+            "ancestors": ancestors[node.id],
+            "descendants": descendants[node.id],
+            "edges": ancestor_edges[node.id] | descendant_edges[node.id],
+        }
+        attrs = " ".join(
+            f"data-flow-{key}={quoteattr(' '.join(sorted(value)))}"
+            for key, value in related.items()
+        )
+        node_html.append(
+            f'<g id="{node.id}" class="{klass}" {attrs}>'
+            f'<rect class="mbp-flow-box" rx="4" x="{node.x - node.width / 2:.1f}" '
+            f'y="{node.y - height / 2:.1f}" width="{node.width:.1f}" '
+            f'height="{height:.1f}" />'
+            f"{_svg_text(node.lines, x=node.x, y=node.y, klass='mbp-flow-node-label')}"
+            f"{_svg_title(node.paths)}</g>"
+        )
+
+    return (
+        f'<svg id="{svg_id}" class="mbp-flow" xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {graph.width:.0f} {graph.height:.0f}" '
+        f'width="{graph.width:.0f}" height="{graph.height:.0f}" '
+        f'role="img" aria-label="Pipeline flow diagram">'
+        f"<style>{_CSS}</style>"
+        f'<defs><marker id="{_ID_PREFIX}-arrow" viewBox="0 0 8 8" refX="7" refY="4" '
+        f'markerWidth="6" markerHeight="6" orient="auto-start-reverse">'
+        f'<path class="mbp-flow-arrow" d="M 0 0 L 8 4 L 0 8 z" /></marker></defs>'
+        f'<g class="mbp-flow-edges">{"".join(edge_html)}</g>'
+        f'<g class="mbp-flow-nodes">{"".join(node_html)}</g>'
+        f"</svg>"
+    )
+
+
+def _flow_html(graph: _FlowGraph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
+    """Render a laid-out graph plus its hover-highlighting behavior."""
+    return (
+        f'<div class="mbp-flow-wrap">{_flow_svg(graph, svg_id=svg_id)}</div>'
+        f"<script>{_JS % dict(svg_id=svg_id)}</script>"
+    )
+
+
+def _report_flow_html(
+    *, deriv_root: pathlib.Path, subject: str, session: str | None
+) -> str | None:
+    """Get the flow diagram HTML for one report, or None if nothing was recorded."""
+    entries = _read_flow_entries(
+        deriv_root=deriv_root, subject=subject, session=session
+    )
+    graph = _build_flow_graph(entries)
+    if not graph.edges:
+        return None
+    return _flow_html(_layout_flow_graph(graph))
 
 
 def _flow_files(files: Mapping[str, object] | None) -> dict[str, str]:

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -151,6 +151,16 @@ _CATEGORIES = {
     "sensor": "sensor",
     "source": "source",
 }
+# Layout bands: stages never interleave in the diagram even where dependencies
+# would allow it (e.g. BEM steps that need only FreeSurfer outputs); freesurfer
+# sits next to source, its only consumer, to keep cross-band edges short
+_GROUP_RANKS = {
+    "init": 0,
+    "preprocessing": 1,
+    "sensor": 2,
+    "freesurfer": 3,
+    "source": 4,
+}
 # Categorical hues (validated for CVD + the report's white surface); identity is
 # never color-alone since every node names its category in text
 _FLOW_CSS = """
@@ -277,7 +287,8 @@ def _build_flow_graph(
                 klass="mbp-flow-source",
             )
         else:
-            category = _CATEGORIES.get(step.partition("/")[0], "")
+            group = step.partition("/")[0]
+            category = _CATEGORIES.get(group, "")
             node = _Node(
                 id=_node_id(step),
                 lines=_step_lines(step),
@@ -286,6 +297,7 @@ def _build_flow_graph(
                     _shorten_paths(sorted(step_paths.get(step, set())), roots),
                 ),
                 klass=f"mbp-flow-cat-{category}" if category else "",
+                rank=_GROUP_RANKS.get(group, 0),
             )
         graph.nodes.append(node)
     for ii, (src, dst) in enumerate(sorted(edge_paths)):

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -69,13 +69,18 @@ def _read_flow_file(fname: pathlib.Path) -> dict[str, FlowEntryT]:
 
 
 def _write_flow_entry(
-    *, deriv_root: pathlib.Path, entry: FlowEntryT, only_if_new: bool = False
+    *,
+    deriv_root: pathlib.Path,
+    entry: FlowEntryT,
+    roots: dict[str, str] | None = None,
+    only_if_new: bool = False,
 ) -> None:
     """Merge a single recorded step call into the on-disk recording."""
     fname = _flow_fname(deriv_root=deriv_root, subject=entry["subject"])
     fname.parent.mkdir(parents=True, exist_ok=True)
     with FileLock(f"{fname}.lock"):
         entries: dict[str, FlowEntryT] = dict()
+        have_roots: dict[str, str] = dict()
         if fname.is_file():
             try:
                 content = json.loads(fname.read_text(encoding="utf-8"))
@@ -83,20 +88,22 @@ def _write_flow_entry(
                 content = dict()
             if content.get("version", None) == _FLOW_VERSION:
                 entries = content["entries"]
+                have_roots = content.get("roots", dict())
         key = _flow_entry_key(entry)
         if only_if_new and key in entries:
             return
         entries[key] = entry
+        have_roots.update(roots or dict())
         fname.write_text(
-            json.dumps(dict(version=_FLOW_VERSION, entries=entries), indent=1),
+            json.dumps(
+                dict(version=_FLOW_VERSION, roots=have_roots, entries=entries),
+                indent=1,
+            ),
             encoding="utf-8",
         )
 
 
-def _read_flow_entries(
-    *, deriv_root: pathlib.Path, subject: str, session: str | None
-) -> list[FlowEntryT]:
-    """Get the recorded step calls relevant for one report."""
+def _flow_fnames(*, deriv_root: pathlib.Path, subject: str) -> list[pathlib.Path]:
     fnames = [_flow_fname(deriv_root=deriv_root, subject=None)]
     if subject == "average":
         # Group steps read individual subjects' files, so the group report needs every
@@ -104,8 +111,15 @@ def _read_flow_entries(
         fnames += sorted(_flow_dir(deriv_root).glob("sub-*.json"))
     else:
         fnames.append(_flow_fname(deriv_root=deriv_root, subject=subject))
+    return fnames
+
+
+def _read_flow_entries(
+    *, deriv_root: pathlib.Path, subject: str, session: str | None
+) -> list[FlowEntryT]:
+    """Get the recorded step calls relevant for one report."""
     entries: list[FlowEntryT] = list()
-    for fname in fnames:
+    for fname in _flow_fnames(deriv_root=deriv_root, subject=subject):
         for entry in _read_flow_file(fname).values():
             if entry["session"] in (None, session):
                 entries.append(entry)
@@ -113,7 +127,32 @@ def _read_flow_entries(
     return entries
 
 
+def _read_flow_roots(*, deriv_root: pathlib.Path, subject: str) -> dict[str, str]:
+    """Get the recorded root directories (bids_root etc.) relevant for one report."""
+    roots: dict[str, str] = dict()
+    for fname in _flow_fnames(deriv_root=deriv_root, subject=subject):
+        if not fname.is_file():
+            continue
+        with FileLock(f"{fname}.lock"):
+            try:
+                content = json.loads(fname.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                continue
+        if content.get("version", None) == _FLOW_VERSION:
+            roots.update(content.get("roots", dict()))
+    return roots
+
+
 # -- Graph -------------------------------------------------------------------
+
+# Color categories for the step groups; init/freesurfer share one (dataset setup)
+_CATEGORIES = {
+    "init": "init",
+    "freesurfer": "init",
+    "preprocessing": "preproc",
+    "sensor": "sensor",
+    "source": "source",
+}
 
 
 def _node_id(step: str) -> str:
@@ -227,12 +266,19 @@ def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _Graph:
     used_steps = {step for edge in edge_paths for step in edge}
     for step in sorted(used_steps):
         if step == _SOURCE_ID:
-            node = _Node(id=_node_id(step), lines=[_SOURCE_LABEL], paths=[])
+            node = _Node(
+                id=_node_id(step),
+                lines=[_SOURCE_LABEL],
+                paths=[],
+                klass="mbp-flow-source",
+            )
         else:
+            category = _CATEGORIES.get(step.partition("/")[0], "")
             node = _Node(
                 id=_node_id(step),
                 lines=_step_lines(step),
                 paths=sorted(step_paths.get(step, set())),
+                klass=f"mbp-flow-cat-{category}" if category else "",
             )
         graph.nodes.append(node)
     for ii, (src, dst) in enumerate(sorted(edge_paths)):
@@ -249,6 +295,20 @@ def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _Graph:
     return graph
 
 
+def _shorten_paths(paths: Sequence[str], roots: dict[str, str]) -> list[str]:
+    """Rewrite absolute paths as ``<root_name>/...`` for readability."""
+    subs = sorted(roots.items(), key=lambda kv: -len(kv[1]))  # deriv may be in bids
+    out: list[str] = list()
+    for path in paths:
+        for name, root in subs:
+            root = root.rstrip("/")
+            if path == root or path.startswith(f"{root}/"):
+                path = f"<{name}>{path[len(root) :]}"
+                break
+        out.append(path)
+    return out
+
+
 def _report_flow_html(
     *, deriv_root: pathlib.Path, subject: str, session: str | None
 ) -> str | None:
@@ -259,9 +319,20 @@ def _report_flow_html(
     graph = _build_flow_graph(entries)
     if not graph.edges:
         return None
+    roots = _read_flow_roots(deriv_root=deriv_root, subject=subject)
+    roots["deriv_root"] = str(deriv_root)
+    for node in graph.nodes:
+        node.paths = _shorten_paths(node.paths, roots)
+    for edge in graph.edges:
+        edge.paths = _shorten_paths(edge.paths, roots)
+    source = next(
+        (node for node in graph.nodes if node.id == _node_id(_SOURCE_ID)), None
+    )
+    if source is not None:
+        source.paths = [f"<{name}> = {path}" for name, path in sorted(roots.items())]
     # No links on the nodes: mne.Report derives its anchors from content titles, and
     # nothing maps a pipeline step to the titles it happens to add to the report.
-    return _graph_html(_layout_graph(graph), source_id=_node_id(_SOURCE_ID))
+    return _graph_html(_layout_graph(graph))
 
 
 def _flow_files(files: Mapping[str, object] | None) -> dict[str, str]:

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -225,6 +225,8 @@ def _edge_lines(paths: Sequence[str]) -> list[str]:
         if run is not None:
             runs.add(run)
     descriptors = sorted(processings) + sorted(suffixes) + sorted(extensions)
+    # e.g. proc- entities built from contrast names get long; the tooltip has the rest
+    descriptors = [d if len(d) <= 24 else f"{d[:23]}…" for d in descriptors]
     if len(descriptors) > 3:  # e.g. one proc- entity per contrast; keep the label sane
         descriptors = descriptors[:3] + [f"+{len(descriptors) - 3} more"]
     lines = [" ".join(descriptors)] if descriptors else [f"{len(paths)} files"]
@@ -547,11 +549,13 @@ def _flow_svg(graph: _FlowGraph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
     fracs: dict[str, float] = dict()
     for key, group in groups.items():
         far = -1 if key.startswith("src-") else 0  # the end that is not shared
-        n_levels = min(len(group), 4)
+        # Curves converge at the shared end, so edges that wrap onto a reused level
+        # collide there; only wrap for fans too big to give every edge its own level
+        n_levels = min(len(group), 6)
         for ii, edge in enumerate(sorted(group, key=lambda e: e.points[far][0])):
             level = ii % n_levels
             fracs[edge.id] = (
-                0.5 if n_levels == 1 else 0.28 + 0.44 * level / (n_levels - 1)
+                0.5 if n_levels == 1 else 0.15 + 0.7 * level / (n_levels - 1)
             )
 
     edge_html: list[str] = list()

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -8,13 +8,14 @@ SVG rendering live in ``_graph.py``.
 import json
 import pathlib
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from typing import Any
 
 from filelock import FileLock
 from mne_bids import get_entities_from_fname
 
 from ._graph import _ID_PREFIX, _Edge, _Graph, _graph_html, _layout_graph, _Node
+from ._logging import _collapse_runs, _shorten_paths
 from .typing import TypedDict
 
 _FLOW_DIRNAME = ".pipeline_flow"
@@ -80,6 +81,8 @@ def _write_flow_entry(
     """Merge a step call into the on-disk recording; get back the stored entry."""
     fname = _flow_fname(deriv_root=deriv_root, subject=entry["subject"])
     fname.parent.mkdir(parents=True, exist_ok=True)
+    # Steps parallelize over runs within a subject, so concurrent worker processes
+    # read-modify-write the same file; the lock prevents lost/torn updates
     with FileLock(f"{fname}.lock"):
         content = _parse_flow_file(fname)
         entries: dict[str, FlowEntryT] = content.get("entries", dict())
@@ -192,32 +195,6 @@ def _fname_bits(path: str) -> tuple[str | None, str | None, str | None, str | No
     return entities.get("processing"), suffix, extension, entities.get("run")
 
 
-def _collapse_runs(runs: Iterable[str]) -> str:
-    """Turn a set of run labels into something like ``runs 01–03, 07``."""
-    runs = sorted(set(runs))
-    if not runs:
-        return ""
-    label = "run" if len(runs) == 1 else "runs"
-    try:
-        numbers = sorted(int(run) for run in runs)
-    except ValueError:
-        return f"{label} {', '.join(runs)}"
-    width = max(len(run) for run in runs)
-    groups: list[list[int]] = [[numbers[0]]]
-    for number in numbers[1:]:
-        if number == groups[-1][-1] + 1:
-            groups[-1].append(number)
-        else:
-            groups.append([number])
-    chunks = [
-        f"{group[0]:0{width}d}"
-        if len(group) == 1
-        else f"{group[0]:0{width}d}–{group[-1]:0{width}d}"
-        for group in groups
-    ]
-    return f"{label} {', '.join(chunks)}"
-
-
 def _edge_lines(paths: Sequence[str]) -> list[str]:
     """Get a compact semantic descriptor for a set of files."""
     processings: set[str] = set()
@@ -271,20 +248,6 @@ def _node_tooltip(entries: Sequence[FlowEntryT], out_paths: Sequence[str]) -> li
         lines.append("writes:")
         lines.extend(out_paths)
     return lines
-
-
-def _shorten_paths(paths: Sequence[str], roots: dict[str, str]) -> list[str]:
-    """Rewrite absolute paths as ``<root_name>/...`` for readability."""
-    subs = sorted(roots.items(), key=lambda kv: -len(kv[1]))  # deriv may be in bids
-    out: list[str] = list()
-    for path in paths:
-        for name, root in subs:
-            root = root.rstrip("/")
-            if path == root or path.startswith(f"{root}/"):
-                path = f"<{name}>{path[len(root) :]}"
-                break
-        out.append(path)
-    return out
 
 
 def _build_flow_graph(

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -96,6 +96,22 @@ def _write_flow_entry(
         key = _flow_entry_key(entry)
         if only_if_new and key in entries:
             return
+        old = entries.get(key, None)
+        if (
+            entry["cached"]
+            and old is not None
+            and not old.get("cached", False)
+            and old.get("finished") is not None
+            and old.get("out_files") == entry["out_files"]
+        ):
+            # A cache hit replays the same computation, so keep when the original
+            # run happened and how long it took rather than the cache-check timing
+            entry = dict(  # type: ignore[assignment]
+                entry,
+                duration=old["duration"],
+                finished=old["finished"],
+                cached=old["cached"],
+            )
         entries[key] = entry
         have_roots.update(roots or dict())
         fname.write_text(
@@ -129,6 +145,32 @@ def _read_flow_entries(
                 entries.append(entry)
     entries.sort(key=_flow_entry_key)
     return entries
+
+
+def _flow_completed(
+    *, deriv_root: pathlib.Path, step: str, func: str, kwargs: Mapping[str, object]
+) -> str | None:
+    """Get when the recorded original computation of one step call completed."""
+    try:
+        key = _flow_entry_key(
+            {  # type: ignore[typeddict-item]
+                "step": step,
+                "func": func,
+                "subject": kwargs.get("subject", None),
+                "session": kwargs.get("session", None),
+                "run": kwargs.get("run", None),
+                "task": kwargs.get("task", None),
+            }
+        )
+        subject = kwargs.get("subject", None)
+        assert subject is None or isinstance(subject, str)
+        fname = _flow_fname(deriv_root=deriv_root, subject=subject)
+        old = _read_flow_file(fname).get(key, None)
+        if old is not None and not old.get("cached", False):
+            return old.get("finished", None)
+    except Exception:
+        pass  # never let a log nicety break the pipeline
+    return None
 
 
 def _read_flow_roots(*, deriv_root: pathlib.Path, subject: str) -> dict[str, str]:
@@ -255,21 +297,20 @@ def _node_tooltip(entries: Sequence[FlowEntryT], out_paths: Sequence[str]) -> li
     if titles:
         lines.append(titles[0])
     timed = [entry for entry in entries if entry.get("duration") is not None]
-    if timed:
-        total = sum(entry["duration"] or 0.0 for entry in timed)
+    # cached=True survives only when no original computation was ever recorded
+    # (e.g. the recording was deleted but the joblib cache kept), see
+    # _write_flow_entry; normally timing describes the last real computation
+    fresh = [entry for entry in timed if not entry.get("cached")]
+    if fresh:
+        total = sum(entry["duration"] or 0.0 for entry in fresh)
         took = f"{total:.1f} s" if total < 60 else f"{total / 60:.1f} min"
-        calls = f" over {len(timed)} calls" if len(timed) > 1 else ""
-        n_cached = sum(bool(entry.get("cached")) for entry in timed)
-        if n_cached == len(timed):
-            note = " (from cache)"
-        elif n_cached:
-            note = f" ({n_cached}/{len(timed)} from cache)"
-        else:
-            note = ""
-        lines.append(f"took {took}{calls}{note}")
-        stamps = [stamp for entry in timed if (stamp := entry.get("finished"))]
+        calls = f" over {len(fresh)} calls" if len(fresh) > 1 else ""
+        lines.append(f"took {took}{calls}")
+        stamps = [stamp for entry in fresh if (stamp := entry.get("finished"))]
         if stamps:
-            lines.append(f"finished {max(stamps)}")
+            lines.append(f"completed {max(stamps)}")
+    elif timed:
+        lines.append("cached (original run not recorded)")
     if out_paths:
         lines.append("writes:")
         lines.extend(out_paths)

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -8,10 +8,11 @@ SVG rendering live in ``_graph.py``.
 import json
 import pathlib
 import re
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Sequence
+from typing import Any
 
 from filelock import FileLock
-from mne_bids import BIDSPath
+from mne_bids import get_entities_from_fname
 
 from ._graph import _ID_PREFIX, _Edge, _Graph, _graph_html, _layout_graph, _Node
 from .typing import TypedDict
@@ -58,18 +59,15 @@ def _flow_entry_key(entry: FlowEntryT) -> str:
     return "|".join(str(entry[key] or "") for key in keys)  # type: ignore[literal-required]
 
 
-def _read_flow_file(fname: pathlib.Path) -> dict[str, FlowEntryT]:
+def _parse_flow_file(fname: pathlib.Path) -> dict[str, Any]:
+    """Parse one recording file; the caller holds the lock when it matters."""
     if not fname.is_file():
         return dict()
-    with FileLock(f"{fname}.lock"):
-        try:
-            content = json.loads(fname.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            content = dict()
-    if content.get("version", None) != _FLOW_VERSION:
+    try:
+        content = json.loads(fname.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
         return dict()
-    entries: dict[str, FlowEntryT] = content["entries"]
-    return entries
+    return content if content.get("version", None) == _FLOW_VERSION else dict()
 
 
 def _write_flow_entry(
@@ -78,25 +76,18 @@ def _write_flow_entry(
     entry: FlowEntryT,
     roots: dict[str, str] | None = None,
     only_if_new: bool = False,
-) -> None:
-    """Merge a single recorded step call into the on-disk recording."""
+) -> FlowEntryT:
+    """Merge a step call into the on-disk recording; get back the stored entry."""
     fname = _flow_fname(deriv_root=deriv_root, subject=entry["subject"])
     fname.parent.mkdir(parents=True, exist_ok=True)
     with FileLock(f"{fname}.lock"):
-        entries: dict[str, FlowEntryT] = dict()
-        have_roots: dict[str, str] = dict()
-        if fname.is_file():
-            try:
-                content = json.loads(fname.read_text(encoding="utf-8"))
-            except json.JSONDecodeError:
-                content = dict()
-            if content.get("version", None) == _FLOW_VERSION:
-                entries = content["entries"]
-                have_roots = content.get("roots", dict())
+        content = _parse_flow_file(fname)
+        entries: dict[str, FlowEntryT] = content.get("entries", dict())
+        have_roots: dict[str, str] = content.get("roots", dict())
         key = _flow_entry_key(entry)
-        if only_if_new and key in entries:
-            return
         old = entries.get(key, None)
+        if only_if_new and old is not None:
+            return old
         if (
             entry["cached"]
             and old is not None
@@ -121,6 +112,7 @@ def _write_flow_entry(
             ),
             encoding="utf-8",
         )
+    return entry
 
 
 def _flow_fnames(*, deriv_root: pathlib.Path, subject: str) -> list[pathlib.Path]:
@@ -134,59 +126,23 @@ def _flow_fnames(*, deriv_root: pathlib.Path, subject: str) -> list[pathlib.Path
     return fnames
 
 
-def _read_flow_entries(
+def _read_flow(
     *, deriv_root: pathlib.Path, subject: str, session: str | None
-) -> list[FlowEntryT]:
-    """Get the recorded step calls relevant for one report."""
+) -> tuple[list[FlowEntryT], dict[str, str]]:
+    """Get the recorded step calls and roots relevant for one report."""
     entries: list[FlowEntryT] = list()
-    for fname in _flow_fnames(deriv_root=deriv_root, subject=subject):
-        for entry in _read_flow_file(fname).values():
-            if entry["session"] in (None, session):
-                entries.append(entry)
-    entries.sort(key=_flow_entry_key)
-    return entries
-
-
-def _flow_completed(
-    *, deriv_root: pathlib.Path, step: str, func: str, kwargs: Mapping[str, object]
-) -> str | None:
-    """Get when the recorded original computation of one step call completed."""
-    try:
-        key = _flow_entry_key(
-            {  # type: ignore[typeddict-item]
-                "step": step,
-                "func": func,
-                "subject": kwargs.get("subject", None),
-                "session": kwargs.get("session", None),
-                "run": kwargs.get("run", None),
-                "task": kwargs.get("task", None),
-            }
-        )
-        subject = kwargs.get("subject", None)
-        assert subject is None or isinstance(subject, str)
-        fname = _flow_fname(deriv_root=deriv_root, subject=subject)
-        old = _read_flow_file(fname).get(key, None)
-        if old is not None and not old.get("cached", False):
-            return old.get("finished", None)
-    except Exception:
-        pass  # never let a log nicety break the pipeline
-    return None
-
-
-def _read_flow_roots(*, deriv_root: pathlib.Path, subject: str) -> dict[str, str]:
-    """Get the recorded root directories (bids_root etc.) relevant for one report."""
     roots: dict[str, str] = dict()
     for fname in _flow_fnames(deriv_root=deriv_root, subject=subject):
-        if not fname.is_file():
+        if not fname.is_file():  # also avoids creating lock files on pure reads
             continue
         with FileLock(f"{fname}.lock"):
-            try:
-                content = json.loads(fname.read_text(encoding="utf-8"))
-            except json.JSONDecodeError:
-                continue
-        if content.get("version", None) == _FLOW_VERSION:
-            roots.update(content.get("roots", dict()))
-    return roots
+            content = _parse_flow_file(fname)
+        for entry in content.get("entries", dict()).values():
+            if entry["session"] in (None, session):
+                entries.append(entry)
+        roots.update(content.get("roots", dict()))
+    entries.sort(key=_flow_entry_key)
+    return entries, roots
 
 
 # -- Graph -------------------------------------------------------------------
@@ -199,6 +155,19 @@ _CATEGORIES = {
     "sensor": "sensor",
     "source": "source",
 }
+# Categorical hues (validated for CVD + the report's white surface); identity is
+# never color-alone since every node names its category in text
+_FLOW_CSS = """
+svg.mbp-flow .mbp-flow-source .mbp-flow-box { stroke-dasharray: 4 3; }
+svg.mbp-flow .mbp-flow-cat-init .mbp-flow-box { stroke: #2a78d6; fill: #2a78d6; }
+svg.mbp-flow .mbp-flow-cat-preproc .mbp-flow-box { stroke: #eb6834; fill: #eb6834; }
+svg.mbp-flow .mbp-flow-cat-sensor .mbp-flow-box { stroke: #1baf7a; fill: #1baf7a; }
+svg.mbp-flow .mbp-flow-cat-source .mbp-flow-box { stroke: #eda100; fill: #eda100; }
+svg.mbp-flow [class*=" mbp-flow-cat-"] .mbp-flow-box {
+  fill-opacity: 0.12;
+  stroke-width: 1.2;
+}
+"""
 
 
 def _node_id(step: str) -> str:
@@ -210,29 +179,17 @@ def _step_lines(step: str) -> list[str]:
     return [group, name] if name else [group]
 
 
-def _fname_bits(path: str) -> tuple[str | None, str | None, str | None]:
-    """Get the (processing, suffix, extension) descriptors of a filename."""
+def _fname_bits(path: str) -> tuple[str | None, str | None, str | None, str | None]:
+    """Get the (processing, suffix, extension, run) descriptors of a filename."""
     name = pathlib.Path(path).name
     stem, _, _ = name.partition(".")
     extension = name[len(stem) :] or None
     parts = stem.split("_")
     if not any("-" in part for part in parts):  # not a BIDS-style name
-        return None, None, extension
-    processing = None
-    for part in parts:
-        key, sep, value = part.partition("-")
-        if sep and key == "proc":
-            processing = value
+        return None, None, extension, None
+    entities = get_entities_from_fname(name, on_error="ignore")
     suffix = parts[-1] if "-" not in parts[-1] else None
-    return processing, suffix, extension
-
-
-def _fname_run(path: str) -> str | None:
-    for part in pathlib.Path(path).name.split("_"):
-        key, sep, value = part.partition("-")
-        if sep and key == "run":
-            return value
-    return None
+    return entities.get("processing"), suffix, extension, entities.get("run")
 
 
 def _collapse_runs(runs: Iterable[str]) -> str:
@@ -268,14 +225,13 @@ def _edge_lines(paths: Sequence[str]) -> list[str]:
     extensions: set[str] = set()
     runs: set[str] = set()
     for path in paths:
-        processing, suffix, extension = _fname_bits(path)
+        processing, suffix, extension, run = _fname_bits(path)
         if processing is not None:
             processings.add(f"proc-{processing}")
         if suffix is not None:
             suffixes.add(suffix)
         elif extension is not None:
             extensions.add(extension)
-        run = _fname_run(path)
         if run is not None:
             runs.add(run)
     descriptors = sorted(processings) + sorted(suffixes) + sorted(extensions)
@@ -317,8 +273,25 @@ def _node_tooltip(entries: Sequence[FlowEntryT], out_paths: Sequence[str]) -> li
     return lines
 
 
-def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _Graph:
+def _shorten_paths(paths: Sequence[str], roots: dict[str, str]) -> list[str]:
+    """Rewrite absolute paths as ``<root_name>/...`` for readability."""
+    subs = sorted(roots.items(), key=lambda kv: -len(kv[1]))  # deriv may be in bids
+    out: list[str] = list()
+    for path in paths:
+        for name, root in subs:
+            root = root.rstrip("/")
+            if path == root or path.startswith(f"{root}/"):
+                path = f"<{name}>{path[len(root) :]}"
+                break
+        out.append(path)
+    return out
+
+
+def _build_flow_graph(
+    entries: Sequence[FlowEntryT], roots: dict[str, str] | None = None
+) -> _Graph:
     """Build the step graph implied by a set of recorded step calls."""
+    roots = roots or dict()
     produced_by: dict[str, set[str]] = dict()
     step_paths: dict[str, set[str]] = dict()
     step_entries: dict[str, list[FlowEntryT]] = dict()
@@ -344,7 +317,7 @@ def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _Graph:
             node = _Node(
                 id=_node_id(step),
                 lines=[_SOURCE_LABEL],
-                paths=[],
+                paths=[f"<{name}> = {path}" for name, path in sorted(roots.items())],
                 klass="mbp-flow-source",
             )
         else:
@@ -353,7 +326,8 @@ def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _Graph:
                 id=_node_id(step),
                 lines=_step_lines(step),
                 paths=_node_tooltip(
-                    step_entries.get(step, []), sorted(step_paths.get(step, set()))
+                    step_entries.get(step, []),
+                    _shorten_paths(sorted(step_paths.get(step, set())), roots),
                 ),
                 klass=f"mbp-flow-cat-{category}" if category else "",
             )
@@ -366,62 +340,23 @@ def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _Graph:
                 src=_node_id(src),
                 dst=_node_id(dst),
                 lines=_edge_lines(paths),
-                paths=paths,
+                paths=_shorten_paths(paths, roots),
             )
         )
     return graph
-
-
-def _shorten_paths(paths: Sequence[str], roots: dict[str, str]) -> list[str]:
-    """Rewrite absolute paths as ``<root_name>/...`` for readability."""
-    subs = sorted(roots.items(), key=lambda kv: -len(kv[1]))  # deriv may be in bids
-    out: list[str] = list()
-    for path in paths:
-        for name, root in subs:
-            root = root.rstrip("/")
-            if path == root or path.startswith(f"{root}/"):
-                path = f"<{name}>{path[len(root) :]}"
-                break
-        out.append(path)
-    return out
 
 
 def _report_flow_html(
     *, deriv_root: pathlib.Path, subject: str, session: str | None
 ) -> str | None:
     """Get the flow diagram HTML for one report, or None if nothing was recorded."""
-    entries = _read_flow_entries(
-        deriv_root=deriv_root, subject=subject, session=session
-    )
-    graph = _build_flow_graph(entries)
+    entries, roots = _read_flow(deriv_root=deriv_root, subject=subject, session=session)
+    roots["deriv_root"] = str(deriv_root)
+    graph = _build_flow_graph(entries, roots)
     if not graph.edges:
         return None
-    roots = _read_flow_roots(deriv_root=deriv_root, subject=subject)
-    roots["deriv_root"] = str(deriv_root)
-    for node in graph.nodes:
-        node.paths = _shorten_paths(node.paths, roots)
-    for edge in graph.edges:
-        edge.paths = _shorten_paths(edge.paths, roots)
-    source = next(
-        (node for node in graph.nodes if node.id == _node_id(_SOURCE_ID)), None
-    )
-    if source is not None:
-        source.paths = [f"<{name}> = {path}" for name, path in sorted(roots.items())]
     # No links on the nodes: mne.Report derives its anchors from content titles, and
     # nothing maps a pipeline step to the titles it happens to add to the report.
-    return _graph_html(_layout_graph(graph))
-
-
-def _flow_files(files: Mapping[str, object] | None) -> dict[str, str]:
-    """Normalize an in_files/out_files mapping to plain path strings."""
-    out: dict[str, str] = dict()
-    for key, value in (files or dict()).items():
-        if key == "__unknown_inputs__":
-            continue
-        if isinstance(value, tuple):  # out_files carry (path, hash) pairs
-            value = value[0]
-        if isinstance(value, BIDSPath):
-            value = value.fpath
-        if isinstance(value, str | pathlib.Path):
-            out[key] = str(value)
-    return out
+    return _graph_html(
+        _layout_graph(graph), extra_css=_FLOW_CSS, label="Pipeline flow diagram"
+    )

--- a/mne_bids_pipeline/_flow.py
+++ b/mne_bids_pipeline/_flow.py
@@ -1,26 +1,25 @@
 """Auto-generated pipeline flow diagrams for the HTML reports.
 
 Steps record what they read and wrote (see ``_run.py``); this module turns those
-recordings into a layered DAG and emits it as a self-contained SVG.
+recordings into the step dependency graph and its labels. The generic layout and
+SVG rendering live in ``_graph.py``.
 """
 
 import json
 import pathlib
 import re
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
-from xml.sax.saxutils import escape, quoteattr
 
 from filelock import FileLock
 from mne_bids import BIDSPath
 
+from ._graph import _ID_PREFIX, _Edge, _Graph, _graph_html, _layout_graph, _Node
 from .typing import TypedDict
 
 _FLOW_DIRNAME = ".pipeline_flow"
 _FLOW_VERSION = 1
 _SOURCE_ID = "__bids_input__"
 _SOURCE_LABEL = "BIDS raw data"
-_ID_PREFIX = "mbp-flow"
 
 
 class FlowEntryT(TypedDict):
@@ -117,36 +116,6 @@ def _read_flow_entries(
 # -- Graph -------------------------------------------------------------------
 
 
-@dataclass
-class _FlowNode:
-    id: str
-    lines: list[str]
-    paths: list[str]
-    layer: int = 0
-    x: float = 0.0
-    y: float = 0.0
-    width: float = 0.0
-    dummy: bool = False
-
-
-@dataclass
-class _FlowEdge:
-    id: str
-    src: str
-    dst: str
-    lines: list[str]
-    paths: list[str]
-    points: list[tuple[float, float]] = field(default_factory=list)
-
-
-@dataclass
-class _FlowGraph:
-    nodes: list[_FlowNode] = field(default_factory=list)
-    edges: list[_FlowEdge] = field(default_factory=list)
-    width: float = 0.0
-    height: float = 0.0
-
-
 def _node_id(step: str) -> str:
     return f"{_ID_PREFIX}-node-{re.sub(r'[^A-Za-z0-9_-]+', '-', step)}"
 
@@ -236,7 +205,7 @@ def _edge_lines(paths: Sequence[str]) -> list[str]:
     return lines
 
 
-def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _FlowGraph:
+def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _Graph:
     """Build the step graph implied by a set of recorded step calls."""
     produced_by: dict[str, set[str]] = dict()
     step_paths: dict[str, set[str]] = dict()
@@ -254,13 +223,13 @@ def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _FlowGraph:
                     continue
                 edge_paths.setdefault((src, entry["step"]), set()).add(path)
 
-    graph = _FlowGraph()
+    graph = _Graph()
     used_steps = {step for edge in edge_paths for step in edge}
     for step in sorted(used_steps):
         if step == _SOURCE_ID:
-            node = _FlowNode(id=_node_id(step), lines=[_SOURCE_LABEL], paths=[])
+            node = _Node(id=_node_id(step), lines=[_SOURCE_LABEL], paths=[])
         else:
-            node = _FlowNode(
+            node = _Node(
                 id=_node_id(step),
                 lines=_step_lines(step),
                 paths=sorted(step_paths.get(step, set())),
@@ -269,7 +238,7 @@ def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _FlowGraph:
     for ii, (src, dst) in enumerate(sorted(edge_paths)):
         paths = sorted(edge_paths[(src, dst)])
         graph.edges.append(
-            _FlowEdge(
+            _Edge(
                 id=f"{_ID_PREFIX}-edge-{ii}",
                 src=_node_id(src),
                 dst=_node_id(dst),
@@ -278,346 +247,6 @@ def _build_flow_graph(entries: Sequence[FlowEntryT]) -> _FlowGraph:
             )
         )
     return graph
-
-
-# -- Layout ------------------------------------------------------------------
-
-_FONT_SIZE = 12.0
-_CHAR_WIDTH = 6.6  # rough advance width of the report's body font at _FONT_SIZE
-_LINE_HEIGHT = 15.0
-_NODE_PAD_X = 12.0
-_NODE_GAP = 26.0
-_ROW_HEIGHT = 150.0
-_MARGIN = 10.0
-_ROW_MID = 21.0  # where a routing point sits within its row
-
-
-def _text_width(lines: Sequence[str]) -> float:
-    return max((len(line) for line in lines), default=0) * _CHAR_WIDTH
-
-
-def _node_height(node: _FlowNode) -> float:
-    return 0.0 if node.dummy else len(node.lines) * _LINE_HEIGHT + 12.0
-
-
-def _assign_layers(graph: _FlowGraph) -> None:
-    layers = {node.id: 0 for node in graph.nodes}
-    # Longest-path layering by relaxation; the pass limit also bounds the (never
-    # expected, but possible if a step both reads and writes a shared file) cycle.
-    for _ in range(len(graph.nodes)):
-        changed = False
-        for edge in graph.edges:
-            if layers[edge.dst] < layers[edge.src] + 1:
-                layers[edge.dst] = layers[edge.src] + 1
-                changed = True
-        if not changed:
-            break
-    for node in graph.nodes:
-        node.layer = layers[node.id]
-
-
-def _order_layers(
-    nodes: Sequence[_FlowNode], chains: Sequence[Sequence[str]]
-) -> list[list[_FlowNode]]:
-    n_layers = max((node.layer for node in nodes), default=0) + 1
-    layers: list[list[_FlowNode]] = [[] for _ in range(n_layers)]
-    for node in nodes:
-        layers[node.layer].append(node)
-    neighbors: dict[str, list[str]] = {node.id: [] for node in nodes}
-    for chain in chains:
-        for src, dst in zip(chain[:-1], chain[1:]):
-            neighbors[src].append(dst)
-            neighbors[dst].append(src)
-    for _ in range(4):
-        index = {
-            node.id: ii for layer in layers for ii, node in enumerate(layer)
-        }  # barycenter positions
-        for layer in layers:
-            layer.sort(
-                key=lambda node: (
-                    sum(index[other] for other in neighbors[node.id])
-                    / max(len(neighbors[node.id]), 1),
-                    node.id,
-                )
-            )
-    return layers
-
-
-def _layout_flow_graph(graph: _FlowGraph) -> _FlowGraph:
-    """Place nodes on a fixed-height grid of layers."""
-    _assign_layers(graph)
-    nodes = {node.id: node for node in graph.nodes}
-    for node in graph.nodes:
-        node.width = _text_width(node.lines) + 2 * _NODE_PAD_X
-    # Route edges that skip layers through dummy nodes, so they reserve horizontal
-    # space and neither they nor their labels run over the nodes in between.
-    routes: dict[str, list[_FlowNode]] = dict()
-    for edge in graph.edges:
-        routes[edge.id] = [
-            _FlowNode(
-                id=f"{edge.id}-p{layer}",
-                lines=[],
-                paths=[],
-                layer=layer,
-                width=max(_text_width(edge.lines) + 12, 30.0),
-                dummy=True,
-            )
-            for layer in range(nodes[edge.src].layer + 1, nodes[edge.dst].layer)
-        ]
-    all_nodes = graph.nodes + [node for route in routes.values() for node in route]
-    chains = [
-        [edge.src] + [node.id for node in routes[edge.id]] + [edge.dst]
-        for edge in graph.edges
-    ]
-    layers = _order_layers(all_nodes, chains)
-    widths = [
-        sum(node.width for node in layer) + _NODE_GAP * max(len(layer) - 1, 0)
-        for layer in layers
-    ]
-    graph.width = max(widths, default=0.0) + 2 * _MARGIN
-    for li, layer in enumerate(layers):
-        x = (graph.width - widths[li]) / 2
-        for node in layer:
-            node.x = x + node.width / 2
-            node.y = _MARGIN + li * _ROW_HEIGHT
-            node.y += _ROW_MID if node.dummy else _node_height(node) / 2
-            x += node.width + _NODE_GAP
-    for edge in graph.edges:
-        src, dst = nodes[edge.src], nodes[edge.dst]
-        edge.points = (
-            [(src.x, src.y + _node_height(src) / 2)]
-            + [(node.x, node.y) for node in routes[edge.id]]
-            + [(dst.x, dst.y - _node_height(dst) / 2)]
-        )
-    graph.height = (
-        max((node.y + _node_height(node) / 2 for node in graph.nodes), default=0.0)
-        + _MARGIN
-    )
-    return graph
-
-
-# -- SVG ---------------------------------------------------------------------
-
-_CSS = """
-.mbp-flow-wrap { overflow-x: auto; }
-svg.mbp-flow { font-size: 12px; color: inherit; }
-svg.mbp-flow text { fill: currentColor; }
-svg.mbp-flow .mbp-flow-box {
-  fill: var(--bs-tertiary-bg, #f3f3f3);
-  stroke: currentColor;
-  stroke-width: 1;
-}
-svg.mbp-flow .mbp-flow-source .mbp-flow-box { stroke-dasharray: 4 3; }
-svg.mbp-flow .mbp-flow-line {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.2;
-  opacity: 0.65;
-}
-svg.mbp-flow .mbp-flow-arrow { fill: currentColor; opacity: 0.65; }
-svg.mbp-flow .mbp-flow-label-bg { fill: var(--bs-body-bg, #ffffff); stroke: none; }
-svg.mbp-flow .mbp-flow-edge text { font-size: 10.5px; opacity: 0.85; }
-svg.mbp-flow .mbp-flow-node, svg.mbp-flow .mbp-flow-edge { transition: opacity 0.1s; }
-svg.mbp-flow.mbp-flow-hovering .mbp-flow-node,
-svg.mbp-flow.mbp-flow-hovering .mbp-flow-edge { opacity: 0.15; }
-svg.mbp-flow.mbp-flow-hovering .mbp-flow-hl { opacity: 1; }
-"""
-
-# No links on the nodes: mne.Report derives its anchors from content titles, and
-# nothing maps a pipeline step to the titles it happens to add to the report.
-_JS = """
-(function () {
-  var root = document.getElementById("%(svg_id)s");
-  if (!root) { return; }
-  var clear = function () {
-    root.classList.remove("mbp-flow-hovering");
-    root.querySelectorAll(".mbp-flow-hl").forEach(function (el) {
-      el.classList.remove("mbp-flow-hl");
-    });
-  };
-  root.querySelectorAll(".mbp-flow-node").forEach(function (node) {
-    node.addEventListener("mouseenter", function () {
-      clear();
-      var attrs = ["data-flow-ancestors", "data-flow-descendants", "data-flow-edges"];
-      var ids = [node.id];
-      attrs.forEach(function (attr) {
-        ids = ids.concat((node.getAttribute(attr) || "").split(" "));
-      });
-      ids.forEach(function (id) {
-        var el = id ? root.querySelector("#" + id) : null;
-        if (el) { el.classList.add("mbp-flow-hl"); }
-      });
-      root.classList.add("mbp-flow-hovering");
-    });
-    node.addEventListener("mouseleave", clear);
-    node.addEventListener("focus", clear);
-  });
-})();
-"""
-
-
-def _reachable(
-    graph: _FlowGraph, *, reverse: bool
-) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
-    """Get the node and edge ids reachable from every node."""
-    adjacent: dict[str, list[tuple[str, str]]] = {node.id: [] for node in graph.nodes}
-    for edge in graph.edges:
-        src, dst = (edge.dst, edge.src) if reverse else (edge.src, edge.dst)
-        adjacent[src].append((dst, edge.id))
-    nodes: dict[str, set[str]] = dict()
-    edges: dict[str, set[str]] = dict()
-    for node in graph.nodes:
-        seen_nodes: set[str] = set()
-        seen_edges: set[str] = set()
-        stack = [node.id]
-        while stack:
-            for other, edge_id in adjacent[stack.pop()]:
-                seen_edges.add(edge_id)
-                if other not in seen_nodes:
-                    seen_nodes.add(other)
-                    stack.append(other)
-        nodes[node.id] = seen_nodes
-        edges[node.id] = seen_edges
-    return nodes, edges
-
-
-def _edge_path(
-    points: Sequence[tuple[float, float]], *, frac: float = 0.5
-) -> tuple[str, tuple[float, float]]:
-    """Get the SVG path through an edge's routing points and its label anchor.
-
-    The anchor is the point on the curve ``frac`` of the way down the gap it spans.
-    """
-    d = f"M {points[0][0]:.1f} {points[0][1]:.1f}"
-    for (x0, y0), (x1, y1) in zip(points[:-1], points[1:]):
-        # Vertical control handles, so consecutive segments join smoothly
-        ym = (y0 + y1) / 2
-        d += f" C {x0:.1f} {ym:.1f}, {x1:.1f} {ym:.1f}, {x1:.1f} {y1:.1f}"
-    if len(points) > 2:  # the routing points sit clear of the nodes, so label there
-        return d, points[len(points) // 2]
-    (x0, y0), (x1, y1) = points
-    ym = (y0 + y1) / 2
-
-    def at(t: float) -> tuple[float, float]:
-        weights = ((1 - t) ** 3, 3 * (1 - t) ** 2 * t, 3 * (1 - t) * t**2, t**3)
-        return (
-            sum(w * x for w, x in zip(weights, (x0, x0, x1, x1))),
-            sum(w * y for w, y in zip(weights, (y0, ym, ym, y1))),
-        )
-
-    target = y0 + frac * (y1 - y0)
-    lo, hi = 0.0, 1.0
-    for _ in range(24):  # the curve is monotonic in y, so just bisect for the height
-        mid = (lo + hi) / 2
-        lo, hi = (mid, hi) if at(mid)[1] < target else (lo, mid)
-    return d, at((lo + hi) / 2)
-
-
-def _svg_title(paths: Sequence[str], *, limit: int = 20) -> str:
-    if not paths:
-        return ""
-    lines = list(paths[:limit])
-    if len(paths) > limit:
-        lines.append(f"… and {len(paths) - limit} more")
-    return f"<title>{escape(chr(10).join(lines))}</title>"
-
-
-def _svg_text(lines: Sequence[str], *, x: float, y: float, klass: str) -> str:
-    top = y - (len(lines) - 1) * _LINE_HEIGHT / 2 + _FONT_SIZE / 3
-    spans = "".join(
-        f'<tspan x="{x:.1f}" y="{top + ii * _LINE_HEIGHT:.1f}">{escape(line)}</tspan>'
-        for ii, line in enumerate(lines)
-    )
-    return f'<text class="{klass}" text-anchor="middle">{spans}</text>'
-
-
-def _flow_svg(graph: _FlowGraph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
-    """Render a laid-out graph as a single self-contained SVG element."""
-    ancestors, ancestor_edges = _reachable(graph, reverse=True)
-    descendants, descendant_edges = _reachable(graph, reverse=False)
-
-    # Stagger the labels of edges that fan out of (or into) a common node, otherwise
-    # they all land at the same height and overlap.
-    fan: dict[str, int] = dict()
-    for edge in graph.edges:
-        for key in (f"src-{edge.src}", f"dst-{edge.dst}"):
-            fan[key] = fan.get(key, 0) + 1
-    groups: dict[str, list[_FlowEdge]] = dict()
-    for edge in graph.edges:
-        key = f"src-{edge.src}" if fan[f"src-{edge.src}"] > 1 else f"dst-{edge.dst}"
-        groups.setdefault(key, []).append(edge)
-    fracs: dict[str, float] = dict()
-    for key, group in groups.items():
-        far = -1 if key.startswith("src-") else 0  # the end that is not shared
-        # Curves converge at the shared end, so edges that wrap onto a reused level
-        # collide there; only wrap for fans too big to give every edge its own level
-        n_levels = min(len(group), 6)
-        for ii, edge in enumerate(sorted(group, key=lambda e: e.points[far][0])):
-            level = ii % n_levels
-            fracs[edge.id] = (
-                0.5 if n_levels == 1 else 0.15 + 0.7 * level / (n_levels - 1)
-            )
-
-    edge_html: list[str] = list()
-    for edge in graph.edges:
-        d, (mx, my) = _edge_path(edge.points, frac=fracs[edge.id])
-        width = _text_width(edge.lines) + 10
-        height = len(edge.lines) * _LINE_HEIGHT
-        edge_html.append(
-            f'<g id="{edge.id}" class="mbp-flow-edge">'
-            f'<path class="mbp-flow-line" d="{d}" '
-            f'marker-end="url(#{_ID_PREFIX}-arrow)" />'
-            f'<rect class="mbp-flow-label-bg" rx="3" x="{mx - width / 2:.1f}" '
-            f'y="{my - height / 2:.1f}" width="{width:.1f}" height="{height:.1f}" />'
-            f"{_svg_text(edge.lines, x=mx, y=my, klass='mbp-flow-edge-label')}"
-            f"{_svg_title(edge.paths)}</g>"
-        )
-
-    node_html: list[str] = list()
-    for node in graph.nodes:
-        height = _node_height(node)
-        klass = "mbp-flow-node"
-        if node.id == _node_id(_SOURCE_ID):
-            klass += " mbp-flow-source"
-        related = {
-            "ancestors": ancestors[node.id],
-            "descendants": descendants[node.id],
-            "edges": ancestor_edges[node.id] | descendant_edges[node.id],
-        }
-        attrs = " ".join(
-            f"data-flow-{key}={quoteattr(' '.join(sorted(value)))}"
-            for key, value in related.items()
-        )
-        node_html.append(
-            f'<g id="{node.id}" class="{klass}" {attrs}>'
-            f'<rect class="mbp-flow-box" rx="4" x="{node.x - node.width / 2:.1f}" '
-            f'y="{node.y - height / 2:.1f}" width="{node.width:.1f}" '
-            f'height="{height:.1f}" />'
-            f"{_svg_text(node.lines, x=node.x, y=node.y, klass='mbp-flow-node-label')}"
-            f"{_svg_title(node.paths)}</g>"
-        )
-
-    return (
-        f'<svg id="{svg_id}" class="mbp-flow" xmlns="http://www.w3.org/2000/svg" '
-        f'viewBox="0 0 {graph.width:.0f} {graph.height:.0f}" '
-        f'width="{graph.width:.0f}" height="{graph.height:.0f}" '
-        f'role="img" aria-label="Pipeline flow diagram">'
-        f"<style>{_CSS}</style>"
-        f'<defs><marker id="{_ID_PREFIX}-arrow" viewBox="0 0 8 8" refX="7" refY="4" '
-        f'markerWidth="6" markerHeight="6" orient="auto-start-reverse">'
-        f'<path class="mbp-flow-arrow" d="M 0 0 L 8 4 L 0 8 z" /></marker></defs>'
-        f'<g class="mbp-flow-edges">{"".join(edge_html)}</g>'
-        f'<g class="mbp-flow-nodes">{"".join(node_html)}</g>'
-        f"</svg>"
-    )
-
-
-def _flow_html(graph: _FlowGraph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
-    """Render a laid-out graph plus its hover-highlighting behavior."""
-    return (
-        f'<div class="mbp-flow-wrap">{_flow_svg(graph, svg_id=svg_id)}</div>'
-        f"<script>{_JS % dict(svg_id=svg_id)}</script>"
-    )
 
 
 def _report_flow_html(
@@ -630,7 +259,9 @@ def _report_flow_html(
     graph = _build_flow_graph(entries)
     if not graph.edges:
         return None
-    return _flow_html(_layout_flow_graph(graph))
+    # No links on the nodes: mne.Report derives its anchors from content titles, and
+    # nothing maps a pipeline step to the titles it happens to add to the report.
+    return _graph_html(_layout_graph(graph), source_id=_node_id(_SOURCE_ID))
 
 
 def _flow_files(files: Mapping[str, object] | None) -> dict[str, str]:

--- a/mne_bids_pipeline/_graph.py
+++ b/mne_bids_pipeline/_graph.py
@@ -3,6 +3,12 @@
 Domain-agnostic: everything here operates on ``_Node``/``_Edge``/``_Graph`` and
 could draw any small DAG. The pipeline-specific graph construction lives in
 ``_flow.py``.
+
+The layout is a from-scratch implementation of the classical Sugiyama framework
+(layering, dummy vertices routing long edges, iterative barycenter crossing
+reduction) per Sugiyama, Tagawa & Toda (1981), IEEE Trans SMC 11(2):109-125,
+https://doi.org/10.1109/TSMC.1981.4308636 — simplified to longest-path layering
+and width-aware center alignment, which suffice at this graph size.
 """
 
 from collections import Counter

--- a/mne_bids_pipeline/_graph.py
+++ b/mne_bids_pipeline/_graph.py
@@ -188,25 +188,46 @@ def _layout_graph(graph: _Graph) -> _Graph:
     for edge in graph.edges:
         real_neighbors.setdefault(edge.src, []).append(edge.dst)
         real_neighbors.setdefault(edge.dst, []).append(edge.src)
-    # Long edges route along the closer margin so their chains never compete with
-    # the nodes themselves for the center: values are (order key, desired x)
+    # Long edges route around the side of the content in the layers they traverse,
+    # so their chains never compete with the nodes themselves for the center:
+    # values are (order key, desired x)
     margin: dict[str, tuple[float, float]] = dict()
 
     def _pick_sides() -> None:
         # Recomputed each refinement pass: the endpoints move as steps settle, and
         # a side chosen from stale positions sends a chain on a needless detour.
         # The order key keeps same-side chains in one consistent relative order
-        # across layers, so they run parallel instead of braiding.
+        # across layers, so they run parallel instead of braiding. The desired x
+        # hugs the widest *traversed* layer rather than the graph margin — the
+        # graph is as wide as its widest row, which may be far from the action.
         margin.clear()
+        bounds: dict[int, tuple[float, float]] = dict()
+        for node in graph.nodes:
+            lo, hi = bounds.get(node.layer, (graph.width, 0.0))
+            bounds[node.layer] = (
+                min(lo, node.x - node.width / 2),
+                max(hi, node.x + node.width / 2),
+            )
         for edge in graph.edges:
             if len(routes[edge.id]) < 2:
                 continue
             mid = (pos[edge.src].x + pos[edge.dst].x) / 2
-            for node in routes[edge.id]:
-                if mid <= graph.width / 2:
-                    margin[node.id] = (mid - graph.width, _min_x(node))
-                else:
-                    margin[node.id] = (mid + 2 * graph.width, _max_x(graph.width, node))
+            spanned = [
+                bounds[node.layer] for node in routes[edge.id] if node.layer in bounds
+            ]
+            if mid <= graph.width / 2:
+                hull = min((lo for lo, _ in spanned), default=graph.width / 2)
+                for node in routes[edge.id]:
+                    want = hull - _NODE_GAP - node.width / 2
+                    margin[node.id] = (mid - graph.width, max(want, _min_x(node)))
+            else:
+                hull = max((hi for _, hi in spanned), default=graph.width / 2)
+                for node in routes[edge.id]:
+                    want = hull + _NODE_GAP + node.width / 2
+                    margin[node.id] = (
+                        mid + 2 * graph.width,
+                        min(want, _max_x(graph.width, node)),
+                    )
 
     def _neighbor_mean(node: _Node) -> float:
         source = neighbors if node.dummy else real_neighbors

--- a/mne_bids_pipeline/_graph.py
+++ b/mne_bids_pipeline/_graph.py
@@ -58,6 +58,7 @@ _FONT_SIZE = 12.0
 _CHAR_WIDTH = 6.6  # rough advance width of the report's body font at _FONT_SIZE
 _LINE_HEIGHT = 15.0
 _NODE_PAD_X = 12.0
+_NODE_PAD_Y = 12.0
 _NODE_GAP = 26.0
 _ROW_HEIGHT = 100.0
 _BOLD_FACTOR = 1.1  # node labels are bold, so wider than _CHAR_WIDTH estimates
@@ -70,7 +71,19 @@ def _text_width(lines: Sequence[str]) -> float:
 
 
 def _node_height(node: _Node) -> float:
-    return 0.0 if node.dummy else len(node.lines) * _LINE_HEIGHT + 12.0
+    return 0.0 if node.dummy else len(node.lines) * _LINE_HEIGHT + _NODE_PAD_Y
+
+
+def _min_sep(left: _Node, right: _Node) -> float:
+    return left.width / 2 + _NODE_GAP + right.width / 2
+
+
+def _min_x(node: _Node) -> float:
+    return _MARGIN + node.width / 2
+
+
+def _max_x(width: float, node: _Node) -> float:
+    return width - _MARGIN - node.width / 2
 
 
 def _assign_layers(graph: _Graph) -> None:
@@ -103,17 +116,12 @@ def _assign_layers(graph: _Graph) -> None:
 
 
 def _order_layers(
-    nodes: Sequence[_Node], chains: Sequence[Sequence[str]]
+    nodes: Sequence[_Node], neighbors: dict[str, list[str]]
 ) -> list[list[_Node]]:
     n_layers = max((node.layer for node in nodes), default=0) + 1
     layers: list[list[_Node]] = [[] for _ in range(n_layers)]
     for node in nodes:
         layers[node.layer].append(node)
-    neighbors: dict[str, list[str]] = {node.id: [] for node in nodes}
-    for chain in chains:
-        for src, dst in zip(chain[:-1], chain[1:]):
-            neighbors[src].append(dst)
-            neighbors[dst].append(src)
     for _ in range(4):
         index = {
             node.id: ii for layer in layers for ii, node in enumerate(layer)
@@ -121,8 +129,8 @@ def _order_layers(
         for layer in layers:
             layer.sort(
                 key=lambda node: (
-                    sum(index[other] for other in neighbors[node.id])
-                    / max(len(neighbors[node.id]), 1),
+                    sum(index[other] for other in neighbors.get(node.id, []))
+                    / max(len(neighbors.get(node.id, [])), 1),
                     node.id,
                 )
             )
@@ -132,7 +140,7 @@ def _order_layers(
 def _layout_graph(graph: _Graph) -> _Graph:
     """Place nodes on a fixed-height grid of layers."""
     _assign_layers(graph)
-    nodes = {node.id: node for node in graph.nodes}
+    pos = {node.id: node for node in graph.nodes}
     for node in graph.nodes:
         node.width = _text_width(node.lines) * _BOLD_FACTOR + 2 * _NODE_PAD_X
     # Route edges that skip layers through dummy nodes, so they reserve horizontal
@@ -148,14 +156,18 @@ def _layout_graph(graph: _Graph) -> _Graph:
                 width=max(_text_width(edge.lines) + 12, 30.0),
                 dummy=True,
             )
-            for layer in range(nodes[edge.src].layer + 1, nodes[edge.dst].layer)
+            for layer in range(pos[edge.src].layer + 1, pos[edge.dst].layer)
         ]
     all_nodes = graph.nodes + [node for route in routes.values() for node in route]
-    chains = [
-        [edge.src] + [node.id for node in routes[edge.id]] + [edge.dst]
-        for edge in graph.edges
-    ]
-    layers = _order_layers(all_nodes, chains)
+    pos.update((node.id, node) for route in routes.values() for node in route)
+    # Chain adjacency: edge endpoints link through their routing dummies
+    neighbors: dict[str, list[str]] = dict()
+    for edge in graph.edges:
+        chain = [edge.src] + [node.id for node in routes[edge.id]] + [edge.dst]
+        for prev_id, next_id in zip(chain[:-1], chain[1:]):
+            neighbors.setdefault(prev_id, []).append(next_id)
+            neighbors.setdefault(next_id, []).append(prev_id)
+    layers = _order_layers(all_nodes, neighbors)
     widths = [
         sum(node.width for node in layer) + _NODE_GAP * max(len(layer) - 1, 0)
         for layer in layers
@@ -172,59 +184,50 @@ def _layout_graph(graph: _Graph) -> _Graph:
                 x += node.width + _NODE_GAP
 
     _pack()
-    chain_neighbors: dict[str, list[str]] = dict()
-    for chain in chains:
-        for prev_id, next_id in zip(chain[:-1], chain[1:]):
-            chain_neighbors.setdefault(prev_id, []).append(next_id)
-            chain_neighbors.setdefault(next_id, []).append(prev_id)
     real_neighbors: dict[str, list[str]] = dict()
     for edge in graph.edges:
         real_neighbors.setdefault(edge.src, []).append(edge.dst)
         real_neighbors.setdefault(edge.dst, []).append(edge.src)
-    pos = {node.id: node for node in all_nodes}
     # Long edges route along the closer margin so their chains never compete with
-    # the nodes themselves for the center
-    margin_side: dict[str, float] = dict()
-    margin_order: dict[str, float] = dict()
+    # the nodes themselves for the center: values are (order key, desired x)
+    margin: dict[str, tuple[float, float]] = dict()
 
     def _pick_sides() -> None:
         # Recomputed each refinement pass: the endpoints move as steps settle, and
-        # a side chosen from stale positions sends a chain on a needless detour
-        margin_side.clear()
-        margin_order.clear()
+        # a side chosen from stale positions sends a chain on a needless detour.
+        # The order key keeps same-side chains in one consistent relative order
+        # across layers, so they run parallel instead of braiding.
+        margin.clear()
         for edge in graph.edges:
             if len(routes[edge.id]) < 2:
                 continue
             mid = (pos[edge.src].x + pos[edge.dst].x) / 2
             for node in routes[edge.id]:
-                margin_side[node.id] = -1.0 if mid <= graph.width / 2 else 1.0
-                margin_order[node.id] = mid
+                if mid <= graph.width / 2:
+                    margin[node.id] = (mid - graph.width, _min_x(node))
+                else:
+                    margin[node.id] = (mid + 2 * graph.width, _max_x(graph.width, node))
 
-    def _chain_mean(node: _Node) -> float:
-        linked = (chain_neighbors if node.dummy else real_neighbors).get(node.id)
+    def _neighbor_mean(node: _Node) -> float:
+        source = neighbors if node.dummy else real_neighbors
+        linked = source.get(node.id)
         if not linked:
             return node.x
         return sum(pos[other].x for other in linked) / len(linked)
 
     def _order_key(node: _Node) -> float:
-        if node.id in margin_side:
-            # The secondary key keeps same-side chains in one consistent relative
-            # order across layers, so they run parallel instead of braiding
-            if margin_side[node.id] < 0:
-                return -graph.width + margin_order[node.id]
-            return 2 * graph.width + margin_order[node.id]
-        return _chain_mean(node)
+        if node.id in margin:
+            return margin[node.id][0]
+        return _neighbor_mean(node)
 
     def _desired(node: _Node) -> float:
-        if node.id in margin_side:
-            if margin_side[node.id] < 0:
-                return _MARGIN + node.width / 2
-            return graph.width - _MARGIN - node.width / 2
+        if node.id in margin:
+            return margin[node.id][1]
         # A lone routing point yields to the steps (stays put, so it never pushes
         # them off-center) and settles into the leftover slack afterwards
         if node.dummy:
             return node.x
-        return _chain_mean(node)
+        return _neighbor_mean(node)
 
     for _ in range(2):
         # The ordinal barycenter above ignores geometry (a 30px dummy and a 190px
@@ -236,20 +239,18 @@ def _layout_graph(graph: _Graph) -> _Graph:
         _straighten_routes(graph, layers, _desired)
     for layer in layers:
         for ii, node in enumerate(layer):
-            if not node.dummy or node.id in margin_side:
+            if not node.dummy or node.id in margin:
                 continue
-            lo = _MARGIN + node.width / 2
+            lo = _min_x(node)
             if ii > 0:
-                left = layer[ii - 1]
-                lo = max(lo, left.x + left.width / 2 + _NODE_GAP + node.width / 2)
-            hi = graph.width - _MARGIN - node.width / 2
+                lo = max(lo, layer[ii - 1].x + _min_sep(layer[ii - 1], node))
+            hi = _max_x(graph.width, node)
             if ii < len(layer) - 1:
-                right = layer[ii + 1]
-                hi = min(hi, right.x - right.width / 2 - _NODE_GAP - node.width / 2)
+                hi = min(hi, layer[ii + 1].x - _min_sep(node, layer[ii + 1]))
             if lo <= hi:
-                node.x = min(max(_chain_mean(node), lo), hi)
+                node.x = min(max(_neighbor_mean(node), lo), hi)
     for edge in graph.edges:
-        src, dst = nodes[edge.src], nodes[edge.dst]
+        src, dst = pos[edge.src], pos[edge.dst]
         edge.points = (
             [(src.x, src.y + _node_height(src) / 2)]
             + [(node.x, node.y) for node in routes[edge.id]]
@@ -277,19 +278,15 @@ def _straighten_routes(
         for layer in layers:
             xs = [desired_fn(node) for node in layer]
             for ii, node in enumerate(layer):
-                lo = _MARGIN + node.width / 2
+                lo = _min_x(node)
                 if ii > 0:
-                    left = layer[ii - 1]
-                    sep = left.width / 2 + _NODE_GAP + node.width / 2
-                    lo = max(lo, xs[ii - 1] + sep)
+                    lo = max(lo, xs[ii - 1] + _min_sep(layer[ii - 1], node))
                 xs[ii] = max(xs[ii], lo)
             for ii in reversed(range(len(layer))):
                 node = layer[ii]
-                hi = graph.width - _MARGIN - node.width / 2
+                hi = _max_x(graph.width, node)
                 if ii < len(layer) - 1:
-                    right = layer[ii + 1]
-                    sep = right.width / 2 + _NODE_GAP + node.width / 2
-                    hi = min(hi, xs[ii + 1] - sep)
+                    hi = min(hi, xs[ii + 1] - _min_sep(node, layer[ii + 1]))
                 xs[ii] = min(xs[ii], hi)
             for node, x in zip(layer, xs):
                 node.x = x

--- a/mne_bids_pipeline/_graph.py
+++ b/mne_bids_pipeline/_graph.py
@@ -17,6 +17,7 @@ class _Node:
     id: str
     lines: list[str]
     paths: list[str]
+    klass: str = ""  # extra CSS class(es), e.g. a color category
     layer: int = 0
     x: float = 0.0
     y: float = 0.0
@@ -49,7 +50,8 @@ _CHAR_WIDTH = 6.6  # rough advance width of the report's body font at _FONT_SIZE
 _LINE_HEIGHT = 15.0
 _NODE_PAD_X = 12.0
 _NODE_GAP = 26.0
-_ROW_HEIGHT = 150.0
+_ROW_HEIGHT = 100.0
+_BOLD_FACTOR = 1.1  # node labels are bold, so wider than _CHAR_WIDTH estimates
 _MARGIN = 10.0
 _ROW_MID = 21.0  # where a routing point sits within its row
 
@@ -110,7 +112,7 @@ def _layout_graph(graph: _Graph) -> _Graph:
     _assign_layers(graph)
     nodes = {node.id: node for node in graph.nodes}
     for node in graph.nodes:
-        node.width = _text_width(node.lines) + 2 * _NODE_PAD_X
+        node.width = _text_width(node.lines) * _BOLD_FACTOR + 2 * _NODE_PAD_X
     # Route edges that skip layers through dummy nodes, so they reserve horizontal
     # space and neither they nor their labels run over the nodes in between.
     routes: dict[str, list[_Node]] = dict()
@@ -169,7 +171,18 @@ svg.mbp-flow .mbp-flow-box {
   stroke: currentColor;
   stroke-width: 1;
 }
+svg.mbp-flow .mbp-flow-node text { font-weight: 600; }
 svg.mbp-flow .mbp-flow-source .mbp-flow-box { stroke-dasharray: 4 3; }
+/* Categorical hues (validated for CVD + white surface); identity is never
+   color-alone since every node names its category in text */
+svg.mbp-flow .mbp-flow-cat-init .mbp-flow-box { stroke: #2a78d6; fill: #2a78d6; }
+svg.mbp-flow .mbp-flow-cat-preproc .mbp-flow-box { stroke: #eb6834; fill: #eb6834; }
+svg.mbp-flow .mbp-flow-cat-sensor .mbp-flow-box { stroke: #1baf7a; fill: #1baf7a; }
+svg.mbp-flow .mbp-flow-cat-source .mbp-flow-box { stroke: #eda100; fill: #eda100; }
+svg.mbp-flow [class*=" mbp-flow-cat-"] .mbp-flow-box {
+  fill-opacity: 0.12;
+  stroke-width: 1.2;
+}
 svg.mbp-flow .mbp-flow-line {
   fill: none;
   stroke: currentColor;
@@ -291,15 +304,14 @@ def _svg_text(lines: Sequence[str], *, x: float, y: float, klass: str) -> str:
     return f'<text class="{klass}" text-anchor="middle">{spans}</text>'
 
 
-def _graph_svg(
-    graph: _Graph, *, source_id: str | None = None, svg_id: str = f"{_ID_PREFIX}-svg"
-) -> str:
+def _graph_svg(graph: _Graph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
     """Render a laid-out graph as a single self-contained SVG element."""
     ancestors, ancestor_edges = _reachable(graph, reverse=True)
     descendants, descendant_edges = _reachable(graph, reverse=False)
 
-    # Stagger the labels of edges that fan out of (or into) a common node, otherwise
-    # they all land at the same height and overlap.
+    # Fanned edges get one label per distinct text (on the middlemost edge of each
+    # cluster), staggered in height — every copy of an identical label is redundant
+    # ink and they collide near the shared end, where the curves converge.
     fan: dict[str, int] = dict()
     for edge in graph.edges:
         for key in (f"src-{edge.src}", f"dst-{edge.dst}"):
@@ -311,10 +323,18 @@ def _graph_svg(
     fracs: dict[str, float] = dict()
     for key, group in groups.items():
         far = -1 if key.startswith("src-") else 0  # the end that is not shared
-        # Curves converge at the shared end, so edges that wrap onto a reused level
-        # collide there; only wrap for fans too big to give every edge its own level
-        n_levels = min(len(group), 6)
-        for ii, edge in enumerate(sorted(group, key=lambda e: e.points[far][0])):
+        clusters: dict[tuple[str, ...], list[_Edge]] = dict()
+        for edge in sorted(group, key=lambda e: e.points[far][0]):
+            clusters.setdefault(tuple(edge.lines), []).append(edge)
+        reps = []
+        for cluster in clusters.values():
+            # Routed edges label at a distant routing point, so a direct edge keeps
+            # the cluster's one label visually inside the fan
+            direct = [edge for edge in cluster if len(edge.points) == 2] or cluster
+            reps.append(direct[len(direct) // 2])
+        reps.sort(key=lambda e: e.points[far][0])
+        n_levels = min(len(reps), 6)
+        for ii, edge in enumerate(reps):
             level = ii % n_levels
             fracs[edge.id] = (
                 0.5 if n_levels == 1 else 0.15 + 0.7 * level / (n_levels - 1)
@@ -322,25 +342,30 @@ def _graph_svg(
 
     edge_html: list[str] = list()
     for edge in graph.edges:
-        d, (mx, my) = _edge_path(edge.points, frac=fracs[edge.id])
+        d, (mx, my) = _edge_path(edge.points, frac=fracs.get(edge.id, 0.5))
         width = _text_width(edge.lines) + 10
         height = len(edge.lines) * _LINE_HEIGHT
+        if edge.id in fracs:
+            label = (
+                f'<rect class="mbp-flow-label-bg" rx="3" x="{mx - width / 2:.1f}" '
+                f'y="{my - height / 2:.1f}" width="{width:.1f}" '
+                f'height="{height:.1f}" />'
+                f"{_svg_text(edge.lines, x=mx, y=my, klass='mbp-flow-edge-label')}"
+            )
+        else:
+            label = ""
         edge_html.append(
             f'<g id="{edge.id}" class="mbp-flow-edge">'
             f'<path class="mbp-flow-line" d="{d}" '
             f'marker-end="url(#{_ID_PREFIX}-arrow)" />'
-            f'<rect class="mbp-flow-label-bg" rx="3" x="{mx - width / 2:.1f}" '
-            f'y="{my - height / 2:.1f}" width="{width:.1f}" height="{height:.1f}" />'
-            f"{_svg_text(edge.lines, x=mx, y=my, klass='mbp-flow-edge-label')}"
+            f"{label}"
             f"{_svg_title(edge.paths)}</g>"
         )
 
     node_html: list[str] = list()
     for node in graph.nodes:
         height = _node_height(node)
-        klass = "mbp-flow-node"
-        if node.id == source_id:
-            klass += " mbp-flow-source"
+        klass = f"mbp-flow-node {node.klass}".strip()
         related = {
             "ancestors": ancestors[node.id],
             "descendants": descendants[node.id],
@@ -374,15 +399,9 @@ def _graph_svg(
     )
 
 
-def _graph_html(
-    graph: _Graph,
-    *,
-    source_id: str | None = None,
-    svg_id: str = f"{_ID_PREFIX}-svg",
-) -> str:
+def _graph_html(graph: _Graph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
     """Render a laid-out graph plus its hover-highlighting behavior."""
-    svg = _graph_svg(graph, source_id=source_id, svg_id=svg_id)
     return (
-        f'<div class="mbp-flow-wrap">{svg}</div>'
+        f'<div class="mbp-flow-wrap">{_graph_svg(graph, svg_id=svg_id)}</div>'
         f"<script>{_JS % dict(svg_id=svg_id)}</script>"
     )

--- a/mne_bids_pipeline/_graph.py
+++ b/mne_bids_pipeline/_graph.py
@@ -1,0 +1,388 @@
+"""Layered-DAG layout and self-contained SVG rendering.
+
+Domain-agnostic: everything here operates on ``_Node``/``_Edge``/``_Graph`` and
+could draw any small DAG. The pipeline-specific graph construction lives in
+``_flow.py``.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from xml.sax.saxutils import escape, quoteattr
+
+_ID_PREFIX = "mbp-flow"
+
+
+@dataclass
+class _Node:
+    id: str
+    lines: list[str]
+    paths: list[str]
+    layer: int = 0
+    x: float = 0.0
+    y: float = 0.0
+    width: float = 0.0
+    dummy: bool = False
+
+
+@dataclass
+class _Edge:
+    id: str
+    src: str
+    dst: str
+    lines: list[str]
+    paths: list[str]
+    points: list[tuple[float, float]] = field(default_factory=list)
+
+
+@dataclass
+class _Graph:
+    nodes: list[_Node] = field(default_factory=list)
+    edges: list[_Edge] = field(default_factory=list)
+    width: float = 0.0
+    height: float = 0.0
+
+
+# -- Layout ------------------------------------------------------------------
+
+_FONT_SIZE = 12.0
+_CHAR_WIDTH = 6.6  # rough advance width of the report's body font at _FONT_SIZE
+_LINE_HEIGHT = 15.0
+_NODE_PAD_X = 12.0
+_NODE_GAP = 26.0
+_ROW_HEIGHT = 150.0
+_MARGIN = 10.0
+_ROW_MID = 21.0  # where a routing point sits within its row
+
+
+def _text_width(lines: Sequence[str]) -> float:
+    return max((len(line) for line in lines), default=0) * _CHAR_WIDTH
+
+
+def _node_height(node: _Node) -> float:
+    return 0.0 if node.dummy else len(node.lines) * _LINE_HEIGHT + 12.0
+
+
+def _assign_layers(graph: _Graph) -> None:
+    layers = {node.id: 0 for node in graph.nodes}
+    # Longest-path layering by relaxation; the pass limit also bounds the (never
+    # expected, but possible if a step both reads and writes a shared file) cycle.
+    for _ in range(len(graph.nodes)):
+        changed = False
+        for edge in graph.edges:
+            if layers[edge.dst] < layers[edge.src] + 1:
+                layers[edge.dst] = layers[edge.src] + 1
+                changed = True
+        if not changed:
+            break
+    for node in graph.nodes:
+        node.layer = layers[node.id]
+
+
+def _order_layers(
+    nodes: Sequence[_Node], chains: Sequence[Sequence[str]]
+) -> list[list[_Node]]:
+    n_layers = max((node.layer for node in nodes), default=0) + 1
+    layers: list[list[_Node]] = [[] for _ in range(n_layers)]
+    for node in nodes:
+        layers[node.layer].append(node)
+    neighbors: dict[str, list[str]] = {node.id: [] for node in nodes}
+    for chain in chains:
+        for src, dst in zip(chain[:-1], chain[1:]):
+            neighbors[src].append(dst)
+            neighbors[dst].append(src)
+    for _ in range(4):
+        index = {
+            node.id: ii for layer in layers for ii, node in enumerate(layer)
+        }  # barycenter positions
+        for layer in layers:
+            layer.sort(
+                key=lambda node: (
+                    sum(index[other] for other in neighbors[node.id])
+                    / max(len(neighbors[node.id]), 1),
+                    node.id,
+                )
+            )
+    return layers
+
+
+def _layout_graph(graph: _Graph) -> _Graph:
+    """Place nodes on a fixed-height grid of layers."""
+    _assign_layers(graph)
+    nodes = {node.id: node for node in graph.nodes}
+    for node in graph.nodes:
+        node.width = _text_width(node.lines) + 2 * _NODE_PAD_X
+    # Route edges that skip layers through dummy nodes, so they reserve horizontal
+    # space and neither they nor their labels run over the nodes in between.
+    routes: dict[str, list[_Node]] = dict()
+    for edge in graph.edges:
+        routes[edge.id] = [
+            _Node(
+                id=f"{edge.id}-p{layer}",
+                lines=[],
+                paths=[],
+                layer=layer,
+                width=max(_text_width(edge.lines) + 12, 30.0),
+                dummy=True,
+            )
+            for layer in range(nodes[edge.src].layer + 1, nodes[edge.dst].layer)
+        ]
+    all_nodes = graph.nodes + [node for route in routes.values() for node in route]
+    chains = [
+        [edge.src] + [node.id for node in routes[edge.id]] + [edge.dst]
+        for edge in graph.edges
+    ]
+    layers = _order_layers(all_nodes, chains)
+    widths = [
+        sum(node.width for node in layer) + _NODE_GAP * max(len(layer) - 1, 0)
+        for layer in layers
+    ]
+    graph.width = max(widths, default=0.0) + 2 * _MARGIN
+    for li, layer in enumerate(layers):
+        x = (graph.width - widths[li]) / 2
+        for node in layer:
+            node.x = x + node.width / 2
+            node.y = _MARGIN + li * _ROW_HEIGHT
+            node.y += _ROW_MID if node.dummy else _node_height(node) / 2
+            x += node.width + _NODE_GAP
+    for edge in graph.edges:
+        src, dst = nodes[edge.src], nodes[edge.dst]
+        edge.points = (
+            [(src.x, src.y + _node_height(src) / 2)]
+            + [(node.x, node.y) for node in routes[edge.id]]
+            + [(dst.x, dst.y - _node_height(dst) / 2)]
+        )
+    graph.height = (
+        max((node.y + _node_height(node) / 2 for node in graph.nodes), default=0.0)
+        + _MARGIN
+    )
+    return graph
+
+
+# -- SVG ---------------------------------------------------------------------
+
+_CSS = """
+.mbp-flow-wrap { overflow-x: auto; }
+svg.mbp-flow { font-size: 12px; color: inherit; }
+svg.mbp-flow text { fill: currentColor; }
+svg.mbp-flow .mbp-flow-box {
+  fill: var(--bs-tertiary-bg, #f3f3f3);
+  stroke: currentColor;
+  stroke-width: 1;
+}
+svg.mbp-flow .mbp-flow-source .mbp-flow-box { stroke-dasharray: 4 3; }
+svg.mbp-flow .mbp-flow-line {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.2;
+  opacity: 0.65;
+}
+svg.mbp-flow .mbp-flow-arrow { fill: currentColor; opacity: 0.65; }
+svg.mbp-flow .mbp-flow-label-bg { fill: var(--bs-body-bg, #ffffff); stroke: none; }
+svg.mbp-flow .mbp-flow-edge text { font-size: 10.5px; opacity: 0.85; }
+svg.mbp-flow .mbp-flow-node, svg.mbp-flow .mbp-flow-edge { transition: opacity 0.1s; }
+svg.mbp-flow.mbp-flow-hovering .mbp-flow-node,
+svg.mbp-flow.mbp-flow-hovering .mbp-flow-edge { opacity: 0.15; }
+svg.mbp-flow.mbp-flow-hovering .mbp-flow-hl { opacity: 1; }
+"""
+
+_JS = """
+(function () {
+  var root = document.getElementById("%(svg_id)s");
+  if (!root) { return; }
+  var clear = function () {
+    root.classList.remove("mbp-flow-hovering");
+    root.querySelectorAll(".mbp-flow-hl").forEach(function (el) {
+      el.classList.remove("mbp-flow-hl");
+    });
+  };
+  root.querySelectorAll(".mbp-flow-node").forEach(function (node) {
+    node.addEventListener("mouseenter", function () {
+      clear();
+      var attrs = ["data-flow-ancestors", "data-flow-descendants", "data-flow-edges"];
+      var ids = [node.id];
+      attrs.forEach(function (attr) {
+        ids = ids.concat((node.getAttribute(attr) || "").split(" "));
+      });
+      ids.forEach(function (id) {
+        var el = id ? root.querySelector("#" + id) : null;
+        if (el) { el.classList.add("mbp-flow-hl"); }
+      });
+      root.classList.add("mbp-flow-hovering");
+    });
+    node.addEventListener("mouseleave", clear);
+    node.addEventListener("focus", clear);
+  });
+})();
+"""
+
+
+def _reachable(
+    graph: _Graph, *, reverse: bool
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """Get the node and edge ids reachable from every node."""
+    adjacent: dict[str, list[tuple[str, str]]] = {node.id: [] for node in graph.nodes}
+    for edge in graph.edges:
+        src, dst = (edge.dst, edge.src) if reverse else (edge.src, edge.dst)
+        adjacent[src].append((dst, edge.id))
+    nodes: dict[str, set[str]] = dict()
+    edges: dict[str, set[str]] = dict()
+    for node in graph.nodes:
+        seen_nodes: set[str] = set()
+        seen_edges: set[str] = set()
+        stack = [node.id]
+        while stack:
+            for other, edge_id in adjacent[stack.pop()]:
+                seen_edges.add(edge_id)
+                if other not in seen_nodes:
+                    seen_nodes.add(other)
+                    stack.append(other)
+        nodes[node.id] = seen_nodes
+        edges[node.id] = seen_edges
+    return nodes, edges
+
+
+def _edge_path(
+    points: Sequence[tuple[float, float]], *, frac: float = 0.5
+) -> tuple[str, tuple[float, float]]:
+    """Get the SVG path through an edge's routing points and its label anchor.
+
+    The anchor is the point on the curve ``frac`` of the way down the gap it spans.
+    """
+    d = f"M {points[0][0]:.1f} {points[0][1]:.1f}"
+    for (x0, y0), (x1, y1) in zip(points[:-1], points[1:]):
+        # Vertical control handles, so consecutive segments join smoothly
+        ym = (y0 + y1) / 2
+        d += f" C {x0:.1f} {ym:.1f}, {x1:.1f} {ym:.1f}, {x1:.1f} {y1:.1f}"
+    if len(points) > 2:  # the routing points sit clear of the nodes, so label there
+        return d, points[len(points) // 2]
+    (x0, y0), (x1, y1) = points
+    ym = (y0 + y1) / 2
+
+    def at(t: float) -> tuple[float, float]:
+        weights = ((1 - t) ** 3, 3 * (1 - t) ** 2 * t, 3 * (1 - t) * t**2, t**3)
+        return (
+            sum(w * x for w, x in zip(weights, (x0, x0, x1, x1))),
+            sum(w * y for w, y in zip(weights, (y0, ym, ym, y1))),
+        )
+
+    target = y0 + frac * (y1 - y0)
+    lo, hi = 0.0, 1.0
+    for _ in range(24):  # the curve is monotonic in y, so just bisect for the height
+        mid = (lo + hi) / 2
+        lo, hi = (mid, hi) if at(mid)[1] < target else (lo, mid)
+    return d, at((lo + hi) / 2)
+
+
+def _svg_title(paths: Sequence[str], *, limit: int = 20) -> str:
+    if not paths:
+        return ""
+    lines = list(paths[:limit])
+    if len(paths) > limit:
+        lines.append(f"… and {len(paths) - limit} more")
+    return f"<title>{escape(chr(10).join(lines))}</title>"
+
+
+def _svg_text(lines: Sequence[str], *, x: float, y: float, klass: str) -> str:
+    top = y - (len(lines) - 1) * _LINE_HEIGHT / 2 + _FONT_SIZE / 3
+    spans = "".join(
+        f'<tspan x="{x:.1f}" y="{top + ii * _LINE_HEIGHT:.1f}">{escape(line)}</tspan>'
+        for ii, line in enumerate(lines)
+    )
+    return f'<text class="{klass}" text-anchor="middle">{spans}</text>'
+
+
+def _graph_svg(
+    graph: _Graph, *, source_id: str | None = None, svg_id: str = f"{_ID_PREFIX}-svg"
+) -> str:
+    """Render a laid-out graph as a single self-contained SVG element."""
+    ancestors, ancestor_edges = _reachable(graph, reverse=True)
+    descendants, descendant_edges = _reachable(graph, reverse=False)
+
+    # Stagger the labels of edges that fan out of (or into) a common node, otherwise
+    # they all land at the same height and overlap.
+    fan: dict[str, int] = dict()
+    for edge in graph.edges:
+        for key in (f"src-{edge.src}", f"dst-{edge.dst}"):
+            fan[key] = fan.get(key, 0) + 1
+    groups: dict[str, list[_Edge]] = dict()
+    for edge in graph.edges:
+        key = f"src-{edge.src}" if fan[f"src-{edge.src}"] > 1 else f"dst-{edge.dst}"
+        groups.setdefault(key, []).append(edge)
+    fracs: dict[str, float] = dict()
+    for key, group in groups.items():
+        far = -1 if key.startswith("src-") else 0  # the end that is not shared
+        # Curves converge at the shared end, so edges that wrap onto a reused level
+        # collide there; only wrap for fans too big to give every edge its own level
+        n_levels = min(len(group), 6)
+        for ii, edge in enumerate(sorted(group, key=lambda e: e.points[far][0])):
+            level = ii % n_levels
+            fracs[edge.id] = (
+                0.5 if n_levels == 1 else 0.15 + 0.7 * level / (n_levels - 1)
+            )
+
+    edge_html: list[str] = list()
+    for edge in graph.edges:
+        d, (mx, my) = _edge_path(edge.points, frac=fracs[edge.id])
+        width = _text_width(edge.lines) + 10
+        height = len(edge.lines) * _LINE_HEIGHT
+        edge_html.append(
+            f'<g id="{edge.id}" class="mbp-flow-edge">'
+            f'<path class="mbp-flow-line" d="{d}" '
+            f'marker-end="url(#{_ID_PREFIX}-arrow)" />'
+            f'<rect class="mbp-flow-label-bg" rx="3" x="{mx - width / 2:.1f}" '
+            f'y="{my - height / 2:.1f}" width="{width:.1f}" height="{height:.1f}" />'
+            f"{_svg_text(edge.lines, x=mx, y=my, klass='mbp-flow-edge-label')}"
+            f"{_svg_title(edge.paths)}</g>"
+        )
+
+    node_html: list[str] = list()
+    for node in graph.nodes:
+        height = _node_height(node)
+        klass = "mbp-flow-node"
+        if node.id == source_id:
+            klass += " mbp-flow-source"
+        related = {
+            "ancestors": ancestors[node.id],
+            "descendants": descendants[node.id],
+            "edges": ancestor_edges[node.id] | descendant_edges[node.id],
+        }
+        attrs = " ".join(
+            f"data-flow-{key}={quoteattr(' '.join(sorted(value)))}"
+            for key, value in related.items()
+        )
+        node_html.append(
+            f'<g id="{node.id}" class="{klass}" {attrs}>'
+            f'<rect class="mbp-flow-box" rx="4" x="{node.x - node.width / 2:.1f}" '
+            f'y="{node.y - height / 2:.1f}" width="{node.width:.1f}" '
+            f'height="{height:.1f}" />'
+            f"{_svg_text(node.lines, x=node.x, y=node.y, klass='mbp-flow-node-label')}"
+            f"{_svg_title(node.paths)}</g>"
+        )
+
+    return (
+        f'<svg id="{svg_id}" class="mbp-flow" xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {graph.width:.0f} {graph.height:.0f}" '
+        f'width="{graph.width:.0f}" height="{graph.height:.0f}" '
+        f'role="img" aria-label="Pipeline flow diagram">'
+        f"<style>{_CSS}</style>"
+        f'<defs><marker id="{_ID_PREFIX}-arrow" viewBox="0 0 8 8" refX="7" refY="4" '
+        f'markerWidth="6" markerHeight="6" orient="auto-start-reverse">'
+        f'<path class="mbp-flow-arrow" d="M 0 0 L 8 4 L 0 8 z" /></marker></defs>'
+        f'<g class="mbp-flow-edges">{"".join(edge_html)}</g>'
+        f'<g class="mbp-flow-nodes">{"".join(node_html)}</g>'
+        f"</svg>"
+    )
+
+
+def _graph_html(
+    graph: _Graph,
+    *,
+    source_id: str | None = None,
+    svg_id: str = f"{_ID_PREFIX}-svg",
+) -> str:
+    """Render a laid-out graph plus its hover-highlighting behavior."""
+    svg = _graph_svg(graph, source_id=source_id, svg_id=svg_id)
+    return (
+        f'<div class="mbp-flow-wrap">{svg}</div>'
+        f"<script>{_JS % dict(svg_id=svg_id)}</script>"
+    )

--- a/mne_bids_pipeline/_graph.py
+++ b/mne_bids_pipeline/_graph.py
@@ -5,11 +5,13 @@ could draw any small DAG. The pipeline-specific graph construction lives in
 ``_flow.py``.
 """
 
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from xml.sax.saxutils import escape, quoteattr
 
 _ID_PREFIX = "mbp-flow"
+_SVG_ID = f"{_ID_PREFIX}-svg"
 
 
 @dataclass
@@ -172,17 +174,6 @@ svg.mbp-flow .mbp-flow-box {
   stroke-width: 1;
 }
 svg.mbp-flow .mbp-flow-node text { font-weight: 600; }
-svg.mbp-flow .mbp-flow-source .mbp-flow-box { stroke-dasharray: 4 3; }
-/* Categorical hues (validated for CVD + white surface); identity is never
-   color-alone since every node names its category in text */
-svg.mbp-flow .mbp-flow-cat-init .mbp-flow-box { stroke: #2a78d6; fill: #2a78d6; }
-svg.mbp-flow .mbp-flow-cat-preproc .mbp-flow-box { stroke: #eb6834; fill: #eb6834; }
-svg.mbp-flow .mbp-flow-cat-sensor .mbp-flow-box { stroke: #1baf7a; fill: #1baf7a; }
-svg.mbp-flow .mbp-flow-cat-source .mbp-flow-box { stroke: #eda100; fill: #eda100; }
-svg.mbp-flow [class*=" mbp-flow-cat-"] .mbp-flow-box {
-  fill-opacity: 0.12;
-  stroke-width: 1.2;
-}
 svg.mbp-flow .mbp-flow-line {
   fill: none;
   stroke: currentColor;
@@ -255,7 +246,7 @@ def _reachable(
 
 
 def _edge_path(
-    points: Sequence[tuple[float, float]], *, frac: float = 0.5
+    points: Sequence[tuple[float, float]], *, frac: float
 ) -> tuple[str, tuple[float, float]]:
     """Get the SVG path through an edge's routing points and its label anchor.
 
@@ -286,7 +277,8 @@ def _edge_path(
     return d, at((lo + hi) / 2)
 
 
-def _svg_title(paths: Sequence[str], *, limit: int = 20) -> str:
+def _svg_title(paths: Sequence[str]) -> str:
+    limit = 20
     if not paths:
         return ""
     lines = list(paths[:limit])
@@ -304,7 +296,7 @@ def _svg_text(lines: Sequence[str], *, x: float, y: float, klass: str) -> str:
     return f'<text class="{klass}" text-anchor="middle">{spans}</text>'
 
 
-def _graph_svg(graph: _Graph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
+def _graph_svg(graph: _Graph, *, extra_css: str = "", label: str = "Graph") -> str:
     """Render a laid-out graph as a single self-contained SVG element."""
     ancestors, ancestor_edges = _reachable(graph, reverse=True)
     descendants, descendant_edges = _reachable(graph, reverse=False)
@@ -312,17 +304,14 @@ def _graph_svg(graph: _Graph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
     # Fanned edges get one label per distinct text (on the middlemost edge of each
     # cluster), staggered in height — every copy of an identical label is redundant
     # ink and they collide near the shared end, where the curves converge.
-    fan: dict[str, int] = dict()
+    src_fan = Counter(edge.src for edge in graph.edges)
+    groups: dict[tuple[str, str], list[_Edge]] = dict()
     for edge in graph.edges:
-        for key in (f"src-{edge.src}", f"dst-{edge.dst}"):
-            fan[key] = fan.get(key, 0) + 1
-    groups: dict[str, list[_Edge]] = dict()
-    for edge in graph.edges:
-        key = f"src-{edge.src}" if fan[f"src-{edge.src}"] > 1 else f"dst-{edge.dst}"
+        key = ("src", edge.src) if src_fan[edge.src] > 1 else ("dst", edge.dst)
         groups.setdefault(key, []).append(edge)
     fracs: dict[str, float] = dict()
     for key, group in groups.items():
-        far = -1 if key.startswith("src-") else 0  # the end that is not shared
+        far = -1 if key[0] == "src" else 0  # the end that is not shared
         clusters: dict[tuple[str, ...], list[_Edge]] = dict()
         for edge in sorted(group, key=lambda e: e.points[far][0]):
             clusters.setdefault(tuple(edge.lines), []).append(edge)
@@ -346,19 +335,19 @@ def _graph_svg(graph: _Graph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
         width = _text_width(edge.lines) + 10
         height = len(edge.lines) * _LINE_HEIGHT
         if edge.id in fracs:
-            label = (
+            label_html = (
                 f'<rect class="mbp-flow-label-bg" rx="3" x="{mx - width / 2:.1f}" '
                 f'y="{my - height / 2:.1f}" width="{width:.1f}" '
                 f'height="{height:.1f}" />'
                 f"{_svg_text(edge.lines, x=mx, y=my, klass='mbp-flow-edge-label')}"
             )
         else:
-            label = ""
+            label_html = ""
         edge_html.append(
             f'<g id="{edge.id}" class="mbp-flow-edge">'
             f'<path class="mbp-flow-line" d="{d}" '
             f'marker-end="url(#{_ID_PREFIX}-arrow)" />'
-            f"{label}"
+            f"{label_html}"
             f"{_svg_title(edge.paths)}</g>"
         )
 
@@ -385,11 +374,11 @@ def _graph_svg(graph: _Graph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
         )
 
     return (
-        f'<svg id="{svg_id}" class="mbp-flow" xmlns="http://www.w3.org/2000/svg" '
+        f'<svg id="{_SVG_ID}" class="mbp-flow" xmlns="http://www.w3.org/2000/svg" '
         f'viewBox="0 0 {graph.width:.0f} {graph.height:.0f}" '
         f'width="{graph.width:.0f}" height="{graph.height:.0f}" '
-        f'role="img" aria-label="Pipeline flow diagram">'
-        f"<style>{_CSS}</style>"
+        f'role="img" aria-label={quoteattr(label)}>'
+        f"<style>{_CSS}{extra_css}</style>"
         f'<defs><marker id="{_ID_PREFIX}-arrow" viewBox="0 0 8 8" refX="7" refY="4" '
         f'markerWidth="6" markerHeight="6" orient="auto-start-reverse">'
         f'<path class="mbp-flow-arrow" d="M 0 0 L 8 4 L 0 8 z" /></marker></defs>'
@@ -399,9 +388,10 @@ def _graph_svg(graph: _Graph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
     )
 
 
-def _graph_html(graph: _Graph, *, svg_id: str = f"{_ID_PREFIX}-svg") -> str:
+def _graph_html(graph: _Graph, *, extra_css: str = "", label: str = "Graph") -> str:
     """Render a laid-out graph plus its hover-highlighting behavior."""
+    svg = _graph_svg(graph, extra_css=extra_css, label=label)
     return (
-        f'<div class="mbp-flow-wrap">{_graph_svg(graph, svg_id=svg_id)}</div>'
-        f"<script>{_JS % dict(svg_id=svg_id)}</script>"
+        f'<div class="mbp-flow-wrap">{svg}</div>'
+        f"<script>{_JS % dict(svg_id=_SVG_ID)}</script>"
     )

--- a/mne_bids_pipeline/_graph.py
+++ b/mne_bids_pipeline/_graph.py
@@ -26,6 +26,7 @@ class _Node:
     lines: list[str]
     paths: list[str]
     klass: str = ""  # extra CSS class(es), e.g. a color category
+    rank: int = 0  # layout band; higher ranks sit strictly below lower ones
     layer: int = 0
     x: float = 0.0
     y: float = 0.0
@@ -73,17 +74,30 @@ def _node_height(node: _Node) -> float:
 
 
 def _assign_layers(graph: _Graph) -> None:
-    layers = {node.id: 0 for node in graph.nodes}
-    # Longest-path layering by relaxation; the pass limit also bounds the (never
-    # expected, but possible if a step both reads and writes a shared file) cycle.
-    for _ in range(len(graph.nodes)):
-        changed = False
-        for edge in graph.edges:
-            if layers[edge.dst] < layers[edge.src] + 1:
-                layers[edge.dst] = layers[edge.src] + 1
-                changed = True
-        if not changed:
-            break
+    # Bands (ranks) settle top to bottom, each starting below the previous one, so
+    # e.g. pipeline stages never interleave even when dependencies would allow it;
+    # an edge from a still-unsettled (higher-rank) node is simply not a constraint
+    layers: dict[str, int] = dict()
+    base = 0
+    for rank in sorted({node.rank for node in graph.nodes}):
+        band = {node.id for node in graph.nodes if node.rank == rank}
+        for node_id in band:
+            layers[node_id] = base
+        # Longest-path layering by relaxation; the pass limit also bounds the
+        # (never expected, but possible if a step reads and writes a shared file)
+        # cycle.
+        for _ in range(len(band)):
+            changed = False
+            for edge in graph.edges:
+                src = layers.get(edge.src, None)
+                if edge.dst not in band or src is None:
+                    continue
+                if layers[edge.dst] < src + 1:
+                    layers[edge.dst] = src + 1
+                    changed = True
+            if not changed:
+                break
+        base = max(layers[node_id] for node_id in band) + 1
     for node in graph.nodes:
         node.layer = layers[node.id]
 

--- a/mne_bids_pipeline/_graph.py
+++ b/mne_bids_pipeline/_graph.py
@@ -183,14 +183,22 @@ def _layout_graph(graph: _Graph) -> _Graph:
         real_neighbors.setdefault(edge.dst, []).append(edge.src)
     pos = {node.id: node for node in all_nodes}
     # Long edges route along the closer margin so their chains never compete with
-    # the nodes themselves for the center; sides are fixed from the initial packing
+    # the nodes themselves for the center
     margin_side: dict[str, float] = dict()
-    for edge in graph.edges:
-        if len(routes[edge.id]) < 2:
-            continue
-        mid = (pos[edge.src].x + pos[edge.dst].x) / 2
-        for node in routes[edge.id]:
-            margin_side[node.id] = -1.0 if mid <= graph.width / 2 else 1.0
+    margin_order: dict[str, float] = dict()
+
+    def _pick_sides() -> None:
+        # Recomputed each refinement pass: the endpoints move as steps settle, and
+        # a side chosen from stale positions sends a chain on a needless detour
+        margin_side.clear()
+        margin_order.clear()
+        for edge in graph.edges:
+            if len(routes[edge.id]) < 2:
+                continue
+            mid = (pos[edge.src].x + pos[edge.dst].x) / 2
+            for node in routes[edge.id]:
+                margin_side[node.id] = -1.0 if mid <= graph.width / 2 else 1.0
+                margin_order[node.id] = mid
 
     def _chain_mean(node: _Node) -> float:
         linked = (chain_neighbors if node.dummy else real_neighbors).get(node.id)
@@ -200,7 +208,11 @@ def _layout_graph(graph: _Graph) -> _Graph:
 
     def _order_key(node: _Node) -> float:
         if node.id in margin_side:
-            return 0.0 if margin_side[node.id] < 0 else graph.width
+            # The secondary key keeps same-side chains in one consistent relative
+            # order across layers, so they run parallel instead of braiding
+            if margin_side[node.id] < 0:
+                return -graph.width + margin_order[node.id]
+            return 2 * graph.width + margin_order[node.id]
         return _chain_mean(node)
 
     def _desired(node: _Node) -> float:
@@ -217,6 +229,7 @@ def _layout_graph(graph: _Graph) -> _Graph:
     for _ in range(2):
         # The ordinal barycenter above ignores geometry (a 30px dummy and a 190px
         # node count the same), so refine the order by actual positions
+        _pick_sides()
         for layer in layers:
             layer.sort(key=_order_key)
         _pack()
@@ -299,6 +312,12 @@ svg.mbp-flow .mbp-flow-line {
   stroke: currentColor;
   stroke-width: 1.2;
   opacity: 0.65;
+}
+svg.mbp-flow .mbp-flow-line-casing {
+  fill: none;
+  stroke: var(--bs-body-bg, #ffffff);
+  stroke-width: 5;
+  opacity: 0.5;
 }
 svg.mbp-flow .mbp-flow-arrow { fill: currentColor; opacity: 0.65; }
 svg.mbp-flow .mbp-flow-label-bg { fill: var(--bs-body-bg, #ffffff); stroke: none; }
@@ -450,7 +469,10 @@ def _graph_svg(graph: _Graph, *, extra_css: str = "", label: str = "Graph") -> s
             )
 
     edge_html: list[str] = list()
-    for edge in graph.edges:
+    # Long chains draw first so short edges sit on top; each line carries a
+    # translucent body-background casing that breaks the lines beneath it at
+    # crossings, making the z-order legible
+    for edge in sorted(graph.edges, key=lambda edge: -len(edge.points)):
         d, (mx, my) = _edge_path(edge.points, frac=fracs.get(edge.id, 0.5))
         width = _text_width(edge.lines) + 10
         height = len(edge.lines) * _LINE_HEIGHT
@@ -465,6 +487,7 @@ def _graph_svg(graph: _Graph, *, extra_css: str = "", label: str = "Graph") -> s
             label_html = ""
         edge_html.append(
             f'<g id="{edge.id}" class="mbp-flow-edge">'
+            f'<path class="mbp-flow-line-casing" d="{d}" />'
             f'<path class="mbp-flow-line" d="{d}" '
             f'marker-end="url(#{_ID_PREFIX}-arrow)" />'
             f"{label_html}"

--- a/mne_bids_pipeline/_graph.py
+++ b/mne_bids_pipeline/_graph.py
@@ -12,7 +12,7 @@ and width-aware center alignment, which suffice at this graph size.
 """
 
 from collections import Counter
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from xml.sax.saxutils import escape, quoteattr
 
@@ -161,13 +161,80 @@ def _layout_graph(graph: _Graph) -> _Graph:
         for layer in layers
     ]
     graph.width = max(widths, default=0.0) + 2 * _MARGIN
-    for li, layer in enumerate(layers):
-        x = (graph.width - widths[li]) / 2
-        for node in layer:
-            node.x = x + node.width / 2
-            node.y = _MARGIN + li * _ROW_HEIGHT
-            node.y += _ROW_MID if node.dummy else _node_height(node) / 2
-            x += node.width + _NODE_GAP
+
+    def _pack() -> None:
+        for li, layer in enumerate(layers):
+            x = (graph.width - widths[li]) / 2
+            for node in layer:
+                node.x = x + node.width / 2
+                node.y = _MARGIN + li * _ROW_HEIGHT
+                node.y += _ROW_MID if node.dummy else _node_height(node) / 2
+                x += node.width + _NODE_GAP
+
+    _pack()
+    chain_neighbors: dict[str, list[str]] = dict()
+    for chain in chains:
+        for prev_id, next_id in zip(chain[:-1], chain[1:]):
+            chain_neighbors.setdefault(prev_id, []).append(next_id)
+            chain_neighbors.setdefault(next_id, []).append(prev_id)
+    real_neighbors: dict[str, list[str]] = dict()
+    for edge in graph.edges:
+        real_neighbors.setdefault(edge.src, []).append(edge.dst)
+        real_neighbors.setdefault(edge.dst, []).append(edge.src)
+    pos = {node.id: node for node in all_nodes}
+    # Long edges route along the closer margin so their chains never compete with
+    # the nodes themselves for the center; sides are fixed from the initial packing
+    margin_side: dict[str, float] = dict()
+    for edge in graph.edges:
+        if len(routes[edge.id]) < 2:
+            continue
+        mid = (pos[edge.src].x + pos[edge.dst].x) / 2
+        for node in routes[edge.id]:
+            margin_side[node.id] = -1.0 if mid <= graph.width / 2 else 1.0
+
+    def _chain_mean(node: _Node) -> float:
+        linked = (chain_neighbors if node.dummy else real_neighbors).get(node.id)
+        if not linked:
+            return node.x
+        return sum(pos[other].x for other in linked) / len(linked)
+
+    def _order_key(node: _Node) -> float:
+        if node.id in margin_side:
+            return 0.0 if margin_side[node.id] < 0 else graph.width
+        return _chain_mean(node)
+
+    def _desired(node: _Node) -> float:
+        if node.id in margin_side:
+            if margin_side[node.id] < 0:
+                return _MARGIN + node.width / 2
+            return graph.width - _MARGIN - node.width / 2
+        # A lone routing point yields to the steps (stays put, so it never pushes
+        # them off-center) and settles into the leftover slack afterwards
+        if node.dummy:
+            return node.x
+        return _chain_mean(node)
+
+    for _ in range(2):
+        # The ordinal barycenter above ignores geometry (a 30px dummy and a 190px
+        # node count the same), so refine the order by actual positions
+        for layer in layers:
+            layer.sort(key=_order_key)
+        _pack()
+        _straighten_routes(graph, layers, _desired)
+    for layer in layers:
+        for ii, node in enumerate(layer):
+            if not node.dummy or node.id in margin_side:
+                continue
+            lo = _MARGIN + node.width / 2
+            if ii > 0:
+                left = layer[ii - 1]
+                lo = max(lo, left.x + left.width / 2 + _NODE_GAP + node.width / 2)
+            hi = graph.width - _MARGIN - node.width / 2
+            if ii < len(layer) - 1:
+                right = layer[ii + 1]
+                hi = min(hi, right.x - right.width / 2 - _NODE_GAP - node.width / 2)
+            if lo <= hi:
+                node.x = min(max(_chain_mean(node), lo), hi)
     for edge in graph.edges:
         src, dst = nodes[edge.src], nodes[edge.dst]
         edge.points = (
@@ -180,6 +247,39 @@ def _layout_graph(graph: _Graph) -> _Graph:
         + _MARGIN
     )
     return graph
+
+
+def _straighten_routes(
+    graph: _Graph,
+    layers: Sequence[Sequence[_Node]],
+    desired_fn: Callable[[_Node], float],
+) -> None:
+    """Move every node toward its desired x while preserving order and gaps.
+
+    Forward/backward min-separation sweeps let a node push its whole run aside;
+    each layer fits inside graph.width by construction, so the backward pass
+    always finds room and nothing overlaps.
+    """
+    for _ in range(8):
+        for layer in layers:
+            xs = [desired_fn(node) for node in layer]
+            for ii, node in enumerate(layer):
+                lo = _MARGIN + node.width / 2
+                if ii > 0:
+                    left = layer[ii - 1]
+                    sep = left.width / 2 + _NODE_GAP + node.width / 2
+                    lo = max(lo, xs[ii - 1] + sep)
+                xs[ii] = max(xs[ii], lo)
+            for ii in reversed(range(len(layer))):
+                node = layer[ii]
+                hi = graph.width - _MARGIN - node.width / 2
+                if ii < len(layer) - 1:
+                    right = layer[ii + 1]
+                    sep = right.width / 2 + _NODE_GAP + node.width / 2
+                    hi = min(hi, xs[ii + 1] - sep)
+                xs[ii] = min(xs[ii], hi)
+            for node, x in zip(layer, xs):
+                node.x = x
 
 
 # -- SVG ---------------------------------------------------------------------
@@ -346,7 +446,7 @@ def _graph_svg(graph: _Graph, *, extra_css: str = "", label: str = "Graph") -> s
         for ii, edge in enumerate(reps):
             level = ii % n_levels
             fracs[edge.id] = (
-                0.5 if n_levels == 1 else 0.15 + 0.7 * level / (n_levels - 1)
+                0.5 if n_levels == 1 else 0.2 + 0.6 * level / (n_levels - 1)
             )
 
     edge_html: list[str] = list()

--- a/mne_bids_pipeline/_io.py
+++ b/mne_bids_pipeline/_io.py
@@ -8,9 +8,14 @@ from mne_bids import BIDSPath
 from .typing import PathLike
 
 
-def _write_json(fname: PathLike | BIDSPath, data: dict[str, Any] | None) -> None:
+def _write_json(
+    fname: PathLike | BIDSPath,
+    data: dict[str, Any] | None,
+    *,
+    indent: int | None = None,
+) -> None:
     with open(fname, "w", encoding="utf-8") as f:
-        json_tricks.dump(data, fp=f, allow_nan=True, sort_keys=False)
+        json_tricks.dump(data, fp=f, allow_nan=True, sort_keys=False, indent=indent)
 
 
 def _read_json(fname: PathLike | BIDSPath) -> Any:

--- a/mne_bids_pipeline/_logging.py
+++ b/mne_bids_pipeline/_logging.py
@@ -6,7 +6,7 @@ import inspect
 import logging
 import os
 import sys
-from collections.abc import Generator
+from collections.abc import Generator, Iterable, Sequence
 
 import rich.console
 import rich.theme
@@ -224,6 +224,46 @@ def gen_log_kwargs(
 
 def _linkfile(uri: str) -> str:
     return f"[link=file://{uri}]{uri}[/link]"
+
+
+def _collapse_runs(runs: Iterable[str]) -> str:
+    """Turn a set of run labels into something like ``runs 01–03, 07``."""
+    runs = sorted(set(runs))
+    if not runs:
+        return ""
+    label = "run" if len(runs) == 1 else "runs"
+    try:
+        numbers = sorted(int(run) for run in runs)
+    except ValueError:
+        return f"{label} {', '.join(runs)}"
+    width = max(len(run) for run in runs)
+    groups: list[list[int]] = [[numbers[0]]]
+    for number in numbers[1:]:
+        if number == groups[-1][-1] + 1:
+            groups[-1].append(number)
+        else:
+            groups.append([number])
+    chunks = [
+        f"{group[0]:0{width}d}"
+        if len(group) == 1
+        else f"{group[0]:0{width}d}–{group[-1]:0{width}d}"
+        for group in groups
+    ]
+    return f"{label} {', '.join(chunks)}"
+
+
+def _shorten_paths(paths: Sequence[str], roots: dict[str, str]) -> list[str]:
+    """Rewrite absolute paths as ``<root_name>/...`` for readability."""
+    subs = sorted(roots.items(), key=lambda kv: -len(kv[1]))  # deriv may be in bids
+    out: list[str] = list()
+    for path in paths:
+        for name, root in subs:
+            root = root.rstrip("/")
+            if path == root or path.startswith(f"{root}/"):
+                path = f"<{name}>{path[len(root) :]}"
+                break
+        out.append(path)
+    return out
 
 
 def _is_testing() -> bool:

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -623,11 +623,14 @@ def _add_flow_diagram(
         return
     if html is None:  # nothing recorded yet, e.g. reports from older runs
         return
+    # remove+add rather than replace=True so it stays pinned near the end, just
+    # before the config/sys-info sections that _finalize re-appends after us
+    title = "Pipeline flow"
+    report.remove(title=title, remove_all=True)
     report.add_html(
         html,
-        title="Pipeline flow",
+        title=title,
         tags=("pipeline-flow",),
-        replace=True,
     )
 
 

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -24,6 +24,7 @@ from scipy.io import loadmat
 
 from ._config_utils import _get_task_contrasts
 from ._decoding import _handle_csp_args
+from ._flow import _report_flow_html
 from ._logging import _linkfile, gen_log_kwargs, logger
 from .typing import FloatArrayT
 
@@ -570,6 +571,12 @@ def _finalize(
     task: str | None,
 ) -> None:
     """Add system information and the pipeline configuration to the report."""
+    _add_flow_diagram(
+        report=report,
+        exec_params=exec_params,
+        subject=subject,
+        session=session,
+    )
     # ensure they are always appended
     titles = ["Configuration file", "System information"]
     for title in titles:
@@ -597,6 +604,31 @@ div.accordion-body pre.my-0 code {
 """
     if css not in report.include:
         report.add_custom_css(css=css)
+
+
+def _add_flow_diagram(
+    *,
+    report: mne.Report,
+    exec_params: SimpleNamespace,
+    subject: str,
+    session: str | None,
+) -> None:
+    """Add a diagram of the steps that ran and the files they exchanged."""
+    try:
+        html = _report_flow_html(
+            deriv_root=exec_params.deriv_root, subject=subject, session=session
+        )
+    except Exception as exc:
+        logger.warning(**gen_log_kwargs(message=f"Flow diagram failed: {exc}"))
+        return
+    if html is None:  # nothing recorded yet, e.g. reports from older runs
+        return
+    report.add_html(
+        html,
+        title="Pipeline flow",
+        tags=("pipeline-flow",),
+        replace=True,
+    )
 
 
 # We make a lot of calls to this function and it takes > 1 sec generally

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import copy
+import datetime
 import functools
 import hashlib
 import inspect
@@ -168,10 +169,13 @@ class ConditionalStepMemory:
     def cache(self, func: Callable[..., Any]) -> Callable[..., Any]:
         step = _short_step_path(pathlib.Path(inspect.getfile(func)))
         func_name = func.__name__
+        module_doc = getattr(inspect.getmodule(func), "__doc__", None) or ""
+        title = module_doc.strip().split("\n")[0].rstrip(".") or None
 
         def __mbp_cached_func_wrapper__(
             *args: list[Any], **kwargs: dict[str, Any]
         ) -> bool:
+            t0 = time.time()
             in_files = out_files = None
             force_run = kwargs.pop("force_run", False)
             these_kwargs = kwargs.copy()
@@ -187,8 +191,10 @@ class ConditionalStepMemory:
                 deriv_root=self.deriv_root,
                 step=step,
                 func_name=func_name,
+                title=title,
                 kwargs=kwargs,
                 in_files=_flow_files(in_files),
+                t0=t0,
             )
             # Steps write to the report before they return, so seed the recording with
             # the inputs now or the last step to run would be missing from its own
@@ -196,7 +202,7 @@ class ConditionalStepMemory:
             record(out_files=None, only_if_new=True)
             if self.memory is None:
                 out_files = func(*args, **kwargs)
-                record(out_files=out_files)
+                record(out_files=out_files, cached=False)
                 return True
 
             # This is an implementation detail so we don't need a proper error
@@ -315,7 +321,7 @@ class ConditionalStepMemory:
                     msg = "Computation unnecessary (output files exist) …"
                     emoji = "🔍"
                     short_circuit = True
-                    record(out_files=out_files)  # `out_files` is deleted below
+                    record(out_files=out_files, cached=True)  # deleted below
             else:
                 # Ensure memorized_func.check_call_in_cache returned False
                 # as opposed to raised an error (which already sets `msg` above)
@@ -346,7 +352,7 @@ class ConditionalStepMemory:
             else:
                 with _ignore_warnings(self.ignore_warnings):
                     out_files = memorized_func(*args, **kwargs)
-            record(out_files=out_files)  # covers cache hits, forced and fresh runs
+            record(out_files=out_files, cached=done)  # cache hits, forced, and fresh
             if self.require_output:
                 assert isinstance(out_files, dict) and len(out_files), (
                     f"Internal error: step must return non-empty out_files dict, got "
@@ -370,20 +376,32 @@ def _record_flow(
     deriv_root: pathlib.Path,
     step: str,
     func_name: str,
+    title: str | None,
     kwargs: dict[str, Any],
     in_files: dict[str, str],
+    t0: float,
     out_files: Any,
+    cached: bool | None = None,
     only_if_new: bool = False,
 ) -> None:
     """Record which files a step call read and wrote, for the report flow diagram."""
     try:
+        # cached is None for the pre-run seed entry, which has not completed
+        duration = finished = None
+        if cached is not None:
+            duration = round(time.time() - t0, 3)
+            finished = datetime.datetime.now().isoformat(sep=" ", timespec="seconds")
         entry: FlowEntryT = {
             "step": step,
             "func": func_name,
+            "title": title,
             "subject": kwargs.get("subject", None),
             "session": kwargs.get("session", None),
             "run": kwargs.get("run", None),
             "task": kwargs.get("task", None),
+            "duration": duration,
+            "finished": finished,
+            "cached": cached,
             "in_files": in_files,
             "out_files": _flow_files(out_files),
         }

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -12,7 +12,7 @@ import sys
 import time
 import traceback
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from types import SimpleNamespace
 from typing import Any, Literal
 
@@ -22,7 +22,8 @@ from filelock import FileLock
 from joblib import Memory
 from mne_bids import BIDSPath
 
-from ._flow import FlowEntryT, _flow_completed, _flow_files, _write_flow_entry
+from ._config_utils import _get_step_title
+from ._flow import FlowEntryT, _write_flow_entry
 from ._logging import _is_testing, gen_log_kwargs, logger
 from .typing import InFilesPathT, InFilesT, OutFilesT
 
@@ -169,15 +170,7 @@ class ConditionalStepMemory:
     def cache(self, func: Callable[..., Any]) -> Callable[..., Any]:
         step = _short_step_path(pathlib.Path(inspect.getfile(func)))
         func_name = func.__name__
-        module_doc = getattr(inspect.getmodule(func), "__doc__", None) or ""
-        title = module_doc.strip().split("\n")[0].rstrip(".") or None
-
-        def _ran_when(kwargs: dict[str, Any]) -> str:
-            """Get ', ran <when>' for the original computation, for log messages."""
-            completed = _flow_completed(
-                deriv_root=self.deriv_root, step=step, func=func_name, kwargs=kwargs
-            )
-            return f", ran {completed[:16]}" if completed else ""
+        title = _get_step_title(inspect.getmodule(func))
 
         def __mbp_cached_func_wrapper__(
             *args: list[Any], **kwargs: dict[str, Any]
@@ -206,7 +199,10 @@ class ConditionalStepMemory:
             # Steps write to the report before they return, so seed the recording with
             # the inputs now or the last step to run would be missing from its own
             # diagram until some later run rewrites the report.
-            record(out_files=None, only_if_new=True)
+            prior = record(out_files=None, only_if_new=True)
+            # A completed prior entry means the disk already describes the original
+            # computation, so cache hits below need no rewrite at all
+            prior_done = prior is not None and prior.get("finished") is not None
             if self.memory is None:
                 out_files = func(*args, **kwargs)
                 record(out_files=out_files, cached=False)
@@ -313,7 +309,7 @@ class ConditionalStepMemory:
                     else:
                         msg = (
                             f"Computation unnecessary (cached "
-                            f"{func.__name__}(…){_ran_when(kwargs)}) …"
+                            f"{func.__name__}(…){_ran_when(prior)}) …"
                         )
                         emoji = "cache"
             # When out_files_expected is not None, we should check if the output files
@@ -329,10 +325,11 @@ class ConditionalStepMemory:
                     emoji = "🔂"
                 else:
                     short_circuit = True
-                    record(out_files=out_files, cached=True)  # deleted below
+                    if not prior_done:
+                        record(out_files=out_files, cached=True)  # deleted below
                     msg = (
                         "Computation unnecessary (output files exist"
-                        f"{_ran_when(kwargs)}) …"
+                        f"{_ran_when(prior)}) …"
                     )
                     emoji = "🔍"
             else:
@@ -365,7 +362,8 @@ class ConditionalStepMemory:
             else:
                 with _ignore_warnings(self.ignore_warnings):
                     out_files = memorized_func(*args, **kwargs)
-            record(out_files=out_files, cached=done)  # cache hits, forced, and fresh
+            if not (done and prior_done):  # cache hits with a full record skip the IO
+                record(out_files=out_files, cached=done)
             if self.require_output:
                 assert isinstance(out_files, dict) and len(out_files), (
                     f"Internal error: step must return non-empty out_files dict, got "
@@ -384,6 +382,28 @@ class ConditionalStepMemory:
         self.memory.clear()
 
 
+def _ran_when(prior: FlowEntryT | None) -> str:
+    """Get ", ran <when>" when a call's original computation is on record."""
+    if prior is not None and not prior.get("cached") and prior.get("finished"):
+        return f", ran {prior['finished'][:16]}"
+    return ""
+
+
+def _flow_files(files: Mapping[str, object] | None) -> dict[str, str]:
+    """Normalize an in_files/out_files mapping to plain path strings."""
+    out: dict[str, str] = dict()
+    for key, value in (files or dict()).items():
+        if key == "__unknown_inputs__":
+            continue
+        if isinstance(value, tuple):  # out_files carry (path, hash) pairs
+            value = value[0]
+        if isinstance(value, BIDSPath):
+            value = value.fpath
+        if isinstance(value, str | pathlib.Path):
+            out[key] = str(value)
+    return out
+
+
 def _record_flow(
     *,
     deriv_root: pathlib.Path,
@@ -396,7 +416,7 @@ def _record_flow(
     out_files: Any,
     cached: bool | None = None,
     only_if_new: bool = False,
-) -> None:
+) -> FlowEntryT | None:
     """Record which files a step call read and wrote, for the report flow diagram."""
     try:
         # cached is None for the pre-run seed entry, which has not completed
@@ -424,12 +444,13 @@ def _record_flow(
             value = getattr(kwargs.get("cfg", None), name, None)
             if value is not None:
                 roots[name] = str(value)
-        _write_flow_entry(
+        return _write_flow_entry(
             deriv_root=deriv_root, entry=entry, roots=roots, only_if_new=only_if_new
         )
     except Exception as exc:
         msg = f"Could not record pipeline flow information: {exc}"
         logger.warning(**gen_log_kwargs(message=msg, emoji="⚠️"))
+        return None
 
 
 @contextlib.contextmanager

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -21,6 +21,7 @@ from filelock import FileLock
 from joblib import Memory
 from mne_bids import BIDSPath
 
+from ._flow import FlowEntryT, _flow_files, _write_flow_entry
 from ._logging import _is_testing, gen_log_kwargs, logger
 from .typing import InFilesPathT, InFilesT, OutFilesT
 
@@ -162,8 +163,12 @@ class ConditionalStepMemory:
         self.require_output = require_output
         self.func_name = func_name
         self.sidecars = sidecars
+        self.deriv_root = exec_params.deriv_root
 
     def cache(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        step = _short_step_path(pathlib.Path(inspect.getfile(func)))
+        func_name = func.__name__
+
         def __mbp_cached_func_wrapper__(
             *args: list[Any], **kwargs: dict[str, Any]
         ) -> bool:
@@ -176,8 +181,22 @@ class ConditionalStepMemory:
             if self.get_input_fnames is not None:
                 in_files = kwargs["in_files"] = self.get_input_fnames(**these_kwargs)
             del these_kwargs
+            # Snapshot now: the worker funcs pop entries off in_files as they go
+            record = functools.partial(
+                _record_flow,
+                deriv_root=self.deriv_root,
+                step=step,
+                func_name=func_name,
+                kwargs=kwargs,
+                in_files=_flow_files(in_files),
+            )
+            # Steps write to the report before they return, so seed the recording with
+            # the inputs now or the last step to run would be missing from its own
+            # diagram until some later run rewrites the report.
+            record(out_files=None, only_if_new=True)
             if self.memory is None:
-                func(*args, **kwargs)
+                out_files = func(*args, **kwargs)
+                record(out_files=out_files)
                 return True
 
             # This is an implementation detail so we don't need a proper error
@@ -296,6 +315,7 @@ class ConditionalStepMemory:
                     msg = "Computation unnecessary (output files exist) …"
                     emoji = "🔍"
                     short_circuit = True
+                    record(out_files=out_files)  # `out_files` is deleted below
             else:
                 # Ensure memorized_func.check_call_in_cache returned False
                 # as opposed to raised an error (which already sets `msg` above)
@@ -326,6 +346,7 @@ class ConditionalStepMemory:
             else:
                 with _ignore_warnings(self.ignore_warnings):
                     out_files = memorized_func(*args, **kwargs)
+            record(out_files=out_files)  # covers cache hits, forced and fresh runs
             if self.require_output:
                 assert isinstance(out_files, dict) and len(out_files), (
                     f"Internal error: step must return non-empty out_files dict, got "
@@ -342,6 +363,34 @@ class ConditionalStepMemory:
 
     def clear(self) -> None:
         self.memory.clear()
+
+
+def _record_flow(
+    *,
+    deriv_root: pathlib.Path,
+    step: str,
+    func_name: str,
+    kwargs: dict[str, Any],
+    in_files: dict[str, str],
+    out_files: Any,
+    only_if_new: bool = False,
+) -> None:
+    """Record which files a step call read and wrote, for the report flow diagram."""
+    try:
+        entry: FlowEntryT = {
+            "step": step,
+            "func": func_name,
+            "subject": kwargs.get("subject", None),
+            "session": kwargs.get("session", None),
+            "run": kwargs.get("run", None),
+            "task": kwargs.get("task", None),
+            "in_files": in_files,
+            "out_files": _flow_files(out_files),
+        }
+        _write_flow_entry(deriv_root=deriv_root, entry=entry, only_if_new=only_if_new)
+    except Exception as exc:
+        msg = f"Could not record pipeline flow information: {exc}"
+        logger.warning(**gen_log_kwargs(message=msg, emoji="⚠️"))
 
 
 @contextlib.contextmanager

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -22,7 +22,7 @@ from filelock import FileLock
 from joblib import Memory
 from mne_bids import BIDSPath
 
-from ._flow import FlowEntryT, _flow_files, _write_flow_entry
+from ._flow import FlowEntryT, _flow_completed, _flow_files, _write_flow_entry
 from ._logging import _is_testing, gen_log_kwargs, logger
 from .typing import InFilesPathT, InFilesT, OutFilesT
 
@@ -172,6 +172,13 @@ class ConditionalStepMemory:
         module_doc = getattr(inspect.getmodule(func), "__doc__", None) or ""
         title = module_doc.strip().split("\n")[0].rstrip(".") or None
 
+        def _ran_when(kwargs: dict[str, Any]) -> str:
+            """Get ', ran <when>' for the original computation, for log messages."""
+            completed = _flow_completed(
+                deriv_root=self.deriv_root, step=step, func=func_name, kwargs=kwargs
+            )
+            return f", ran {completed[:16]}" if completed else ""
+
         def __mbp_cached_func_wrapper__(
             *args: list[Any], **kwargs: dict[str, Any]
         ) -> bool:
@@ -304,7 +311,10 @@ class ConditionalStepMemory:
                             bad_out_files = True
                             break
                     else:
-                        msg = f"Computation unnecessary (cached {func.__name__}(…)) …"
+                        msg = (
+                            f"Computation unnecessary (cached "
+                            f"{func.__name__}(…){_ran_when(kwargs)}) …"
+                        )
                         emoji = "cache"
             # When out_files_expected is not None, we should check if the output files
             # exist and stop if they do (e.g., in bem surface or coreg surface
@@ -318,10 +328,13 @@ class ConditionalStepMemory:
                     msg = "Computation forced despite existing output files …"
                     emoji = "🔂"
                 else:
-                    msg = "Computation unnecessary (output files exist) …"
-                    emoji = "🔍"
                     short_circuit = True
                     record(out_files=out_files, cached=True)  # deleted below
+                    msg = (
+                        "Computation unnecessary (output files exist"
+                        f"{_ran_when(kwargs)}) …"
+                    )
+                    emoji = "🔍"
             else:
                 # Ensure memorized_func.check_call_in_cache returned False
                 # as opposed to raised an error (which already sets `msg` above)

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -202,7 +202,7 @@ class ConditionalStepMemory:
             prior = record(out_files=None, only_if_new=True)
             # A completed prior entry means the disk already describes the original
             # computation, so cache hits below need no rewrite at all
-            prior_done = prior is not None and prior.get("finished") is not None
+            prior_done = prior.get("finished") is not None
             if self.memory is None:
                 out_files = func(*args, **kwargs)
                 record(out_files=out_files, cached=False)
@@ -383,9 +383,9 @@ class ConditionalStepMemory:
         self.memory.clear()
 
 
-def _ran_when(prior: FlowEntryT | None) -> str:
+def _ran_when(prior: Mapping[str, Any]) -> str:
     """Get ", ran <when>" when a call's original computation is on record."""
-    if prior is not None and not prior.get("cached") and prior.get("finished"):
+    if not prior.get("cached") and prior.get("finished"):
         return f", ran {prior['finished'][:16]}"
     return ""
 
@@ -417,8 +417,8 @@ def _record_flow(
     out_files: Any,
     cached: bool | None = None,
     only_if_new: bool = False,
-) -> FlowEntryT | None:
-    """Record which files a step call read and wrote, for the report flow diagram."""
+) -> Mapping[str, Any]:
+    """Record a step call's files; get back the stored entry ({} if it failed)."""
     try:
         # cached is None for the pre-run seed entry, which has not completed
         duration = finished = None
@@ -451,7 +451,7 @@ def _record_flow(
     except Exception as exc:
         msg = f"Could not record pipeline flow information: {exc}"
         logger.warning(**gen_log_kwargs(message=msg, emoji="⚠️"))
-        return None
+        return dict()
 
 
 @contextlib.contextmanager

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -387,7 +387,15 @@ def _record_flow(
             "in_files": in_files,
             "out_files": _flow_files(out_files),
         }
-        _write_flow_entry(deriv_root=deriv_root, entry=entry, only_if_new=only_if_new)
+        # Roots let the report show paths as <bids_root>/... instead of absolute
+        roots = {"deriv_root": str(deriv_root)}
+        for name in ("bids_root", "fs_subjects_dir"):
+            value = getattr(kwargs.get("cfg", None), name, None)
+            if value is not None:
+                roots[name] = str(value)
+        _write_flow_entry(
+            deriv_root=deriv_root, entry=entry, roots=roots, only_if_new=only_if_new
+        )
     except Exception as exc:
         msg = f"Could not record pipeline flow information: {exc}"
         logger.warning(**gen_log_kwargs(message=msg, emoji="⚠️"))

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -326,7 +326,8 @@ class ConditionalStepMemory:
                 else:
                     short_circuit = True
                     if not prior_done:
-                        record(out_files=out_files, cached=True)  # deleted below
+                        # must record before the `del out_files` below
+                        record(out_files=out_files, cached=True)
                     msg = (
                         "Computation unnecessary (output files exist"
                         f"{_ran_when(prior)}) …"

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -14,18 +14,20 @@ from mne_bids_pipeline._flow import (
     FlowEntryT,
     _build_flow_graph,
     _collapse_runs,
-    _flow_completed,
-    _flow_files,
-    _read_flow_entries,
-    _read_flow_roots,
+    _read_flow,
     _report_flow_html,
     _shorten_paths,
     _write_flow_entry,
 )
 from mne_bids_pipeline._graph import _graph_html, _layout_graph
 from mne_bids_pipeline._report import _add_flow_diagram
-from mne_bids_pipeline._run import _prep_out_files_path, failsafe_run
-from mne_bids_pipeline.typing import InFilesT, OutFilesT
+from mne_bids_pipeline._run import (
+    _flow_files,
+    _prep_out_files_path,
+    _ran_when,
+    failsafe_run,
+)
+from mne_bids_pipeline.typing import InFilesPathT, InFilesT, OutFilesT
 
 SVG_NS = "{http://www.w3.org/2000/svg}"
 
@@ -163,7 +165,7 @@ def test_flow_recording_roundtrip(tmp_path: pathlib.Path) -> None:
     )
     _write_flow_entry(deriv_root=tmp_path, entry=changed)
 
-    got = _read_flow_entries(deriv_root=tmp_path, subject="01", session=None)
+    got = _read_flow(deriv_root=tmp_path, subject="01", session=None)[0]
     assert len(got) == len(entries)
     assert changed in got
     assert entries[0] not in got
@@ -173,26 +175,24 @@ def test_flow_recording_roundtrip(tmp_path: pathlib.Path) -> None:
     assert (tmp_path / ".pipeline_flow" / "sub-01.json").is_file()
 
     dataset_only = [entry for entry in got if entry["subject"] is None]
-    assert _read_flow_entries(deriv_root=tmp_path, subject="02", session=None) == (
+    assert _read_flow(deriv_root=tmp_path, subject="02", session=None)[0] == (
         dataset_only
     )
     # Entries of other sessions are filtered out
     other = _entry("sensor/_01_make_evoked", session="t2")
     _write_flow_entry(deriv_root=tmp_path, entry=other)
-    assert other not in _read_flow_entries(
-        deriv_root=tmp_path, subject="01", session="t1"
-    )
-    assert other in _read_flow_entries(deriv_root=tmp_path, subject="01", session="t2")
+    assert other not in _read_flow(deriv_root=tmp_path, subject="01", session="t1")[0]
+    assert other in _read_flow(deriv_root=tmp_path, subject="01", session="t2")[0]
 
 
 def test_flow_recording_missing(tmp_path: pathlib.Path) -> None:
     """Test that an absent or unreadable recording is not fatal."""
-    assert _read_flow_entries(deriv_root=tmp_path, subject="01", session=None) == []
+    assert _read_flow(deriv_root=tmp_path, subject="01", session=None)[0] == []
     assert _report_flow_html(deriv_root=tmp_path, subject="01", session=None) is None
     fname = tmp_path / ".pipeline_flow" / "sub-01.json"
     fname.parent.mkdir()
     fname.write_text("not json")
-    assert _read_flow_entries(deriv_root=tmp_path, subject="01", session=None) == []
+    assert _read_flow(deriv_root=tmp_path, subject="01", session=None)[0] == []
 
 
 def test_flow_roots(tmp_path: pathlib.Path) -> None:
@@ -200,13 +200,15 @@ def test_flow_roots(tmp_path: pathlib.Path) -> None:
     roots = {"bids_root": "/bids"}
     for entry in _pipeline_entries():
         _write_flow_entry(deriv_root=tmp_path, entry=entry, roots=roots)
-    assert _read_flow_roots(deriv_root=tmp_path, subject="01") == roots
+    assert _read_flow(deriv_root=tmp_path, subject="01", session=None)[1] == roots
     assert _shorten_paths(
         ["/bids/sub-01_meg.fif", f"{tmp_path}/a.fif", "/elsewhere/b.fif"],
         dict(roots, deriv_root=str(tmp_path)),
     ) == ["<bids_root>/sub-01_meg.fif", "<deriv_root>/a.fif", "/elsewhere/b.fif"]
     html = _report_flow_html(deriv_root=tmp_path, subject="01", session=None)
     assert html is not None
+    assert 'aria-label="Pipeline flow diagram"' in html
+    assert "mbp-flow-cat-preproc .mbp-flow-box" in html  # category CSS included
     assert "&lt;bids_root&gt;/sub-01_task-av_run-01_meg.fif" in html
     # The source node's tooltip lists the roots themselves
     assert "&lt;bids_root&gt; = /bids" in html
@@ -406,25 +408,11 @@ def test_flow_report(tmp_path: pathlib.Path) -> None:
 _N_CALLS: list[str] = list()
 
 
-def _get_input_fnames_flow(
-    *,
-    cfg: SimpleNamespace,
-    subject: str,
-    session: str | None,
-    run: str | None,
-    task: str | None,
-) -> InFilesT:
+def _get_input_fnames_flow(*, cfg: SimpleNamespace, **kwargs: Any) -> InFilesT:
     return dict(raw=cfg.raw)
 
 
-def _get_output_fnames_flow(
-    *,
-    cfg: SimpleNamespace,
-    subject: str,
-    session: str | None,
-    run: str | None,
-    task: str | None,
-) -> InFilesT:
+def _get_output_fnames_flow(*, cfg: SimpleNamespace, **kwargs: Any) -> InFilesPathT:
     return dict(filt=cfg.out)
 
 
@@ -483,7 +471,7 @@ def flow_kwargs(tmp_path: pathlib.Path) -> dict[str, Any]:
 
 def _recorded(flow_kwargs: dict[str, Any]) -> list[FlowEntryT]:
     deriv_root = flow_kwargs["exec_params"].deriv_root
-    return _read_flow_entries(deriv_root=deriv_root, subject="01", session=None)
+    return _read_flow(deriv_root=deriv_root, subject="01", session=None)[0]
 
 
 @pytest.mark.parametrize("memory_location", (True, False))
@@ -519,17 +507,22 @@ def test_flow_recorder(flow_kwargs: dict[str, Any], memory_location: bool) -> No
     second = _check(cached=False)  # ... still recorded, as the original computation
     if memory_location:
         assert second == first  # the cache hit preserved the original timing
+    (entry,) = _recorded(flow_kwargs)
+    assert _ran_when(entry) == f", ran {second[1][:16]}"
     deriv_root = flow_kwargs["exec_params"].deriv_root
-    key = dict(step="tests/test_flow", func="_flow_step_impl", kwargs=flow_kwargs)
-    assert _flow_completed(deriv_root=deriv_root, **key) == second[1]
     if memory_location:
+        # A cache hit whose original computation is on record skips the write
+        fname = deriv_root / ".pipeline_flow" / "sub-01.json"
+        mtime = fname.stat().st_mtime_ns
+        _flow_step(**flow_kwargs)
+        assert fname.stat().st_mtime_ns == mtime
         # With the recording gone but the joblib cache kept, the original run time
         # is unknowable: the entry marks that, and the log helper returns nothing
         shutil.rmtree(deriv_root / ".pipeline_flow")
         _flow_step(**flow_kwargs)
         (entry,) = _recorded(flow_kwargs)
         assert entry["cached"] is True
-        assert _flow_completed(deriv_root=deriv_root, **key) is None
+        assert _ran_when(entry) == ""
 
 
 def test_flow_recorder_short_circuit(flow_kwargs: dict[str, Any]) -> None:

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -16,7 +16,7 @@ from mne_bids_pipeline._flow import (
     _report_flow_html,
     _write_flow_entry,
 )
-from mne_bids_pipeline._graph import _graph_html, _layout_graph
+from mne_bids_pipeline._graph import _Graph, _graph_html, _layout_graph, _Node
 from mne_bids_pipeline._logging import _collapse_runs, _shorten_paths
 from mne_bids_pipeline._run import (
     _flow_files,
@@ -27,6 +27,22 @@ from mne_bids_pipeline._run import (
 from mne_bids_pipeline.typing import InFilesPathT, InFilesT, OutFilesT
 
 SVG_NS = "{http://www.w3.org/2000/svg}"
+RUNS = ("01", "02", "03")
+BIDS = "/bids/sub-01_task-av"
+DERIV = "/deriv/sub-01_task-av"
+EPO = f"{DERIV}_epo.fif"
+
+
+def _filt_raw(run: str) -> str:
+    return f"{DERIV}_run-{run}_proc-filt_raw.fif"
+
+
+def _read01(deriv_root: pathlib.Path, session: str | None = None) -> list[FlowEntryT]:
+    return _read_flow(deriv_root=deriv_root, subject="01", session=session)[0]
+
+
+def _find_node(graph: _Graph, line: str) -> _Node:
+    return next(node for node in graph.nodes if line in node.lines)
 
 
 def _entry(
@@ -63,7 +79,7 @@ def _entry(
 def _pipeline_entries() -> list[FlowEntryT]:
     """Get a small but representative recording: 3 runs, a fan-out, a dead end."""
     entries = list()
-    for run in ("01", "02", "03"):
+    for run in RUNS:
         entries.append(
             _entry(
                 "preprocessing/_04_frequency_filter",
@@ -73,27 +89,24 @@ def _pipeline_entries() -> list[FlowEntryT]:
                 duration=2.0,
                 finished=f"2026-08-12 09:0{run[-1]}:00",
                 cached=run == "01",
-                in_files={"raw": f"/bids/sub-01_task-av_run-{run}_meg.fif"},
-                out_files={"raw": f"/deriv/sub-01_task-av_run-{run}_proc-filt_raw.fif"},
+                in_files={"raw": f"{BIDS}_run-{run}_meg.fif"},
+                out_files={"raw": _filt_raw(run)},
             )
         )
     entries.append(
         _entry(
             "preprocessing/_07_make_epochs",
             func="make_epochs",
-            in_files={
-                f"raw_{run}": f"/deriv/sub-01_task-av_run-{run}_proc-filt_raw.fif"
-                for run in ("01", "02", "03")
-            },
-            out_files={"epo": "/deriv/sub-01_task-av_epo.fif"},
+            in_files={f"raw_{run}": _filt_raw(run) for run in RUNS},
+            out_files={"epo": EPO},
         )
     )
     for step in ("sensor/_01_make_evoked", "sensor/_06_make_cov"):
         entries.append(
             _entry(
                 step,
-                in_files={"epo": "/deriv/sub-01_task-av_epo.fif"},
-                out_files={"out": f"/deriv/sub-01_task-av_{step[-3:]}.fif"},
+                in_files={"epo": EPO},
+                out_files={"out": f"{DERIV}_{step[-3:]}.fif"},
             )
         )
     # Produces something nobody reads, so it should not show up at all
@@ -127,6 +140,7 @@ def test_collapse_runs(runs: list[str], want: str) -> None:
 
 def test_flow_storage(tmp_path: pathlib.Path) -> None:
     """Test the write/read roundtrip, roots, and missing/corrupt recordings."""
+    flow_dir = tmp_path / ".pipeline_flow"
     assert _read_flow(deriv_root=tmp_path, subject="01", session=None) == ([], {})
     assert _report_flow_html(deriv_root=tmp_path, subject="01", session=None) is None
     roots = {"bids_root": "/bids"}
@@ -150,8 +164,8 @@ def test_flow_storage(tmp_path: pathlib.Path) -> None:
     assert entries[0] not in got
     # The dataset-level entry lives in its own file but is relevant to every subject
     assert sum(entry["subject"] is None for entry in got) == 1
-    assert (tmp_path / ".pipeline_flow" / "dataset.json").is_file()
-    assert (tmp_path / ".pipeline_flow" / "sub-01.json").is_file()
+    assert (flow_dir / "dataset.json").is_file()
+    assert (flow_dir / "sub-01.json").is_file()
     dataset_only = [entry for entry in got if entry["subject"] is None]
     assert _read_flow(deriv_root=tmp_path, subject="02", session=None)[0] == (
         dataset_only
@@ -159,8 +173,8 @@ def test_flow_storage(tmp_path: pathlib.Path) -> None:
     # Entries of other sessions are filtered out
     other = _entry("sensor/_01_make_evoked", session="t2")
     _write_flow_entry(deriv_root=tmp_path, entry=other)
-    assert other not in _read_flow(deriv_root=tmp_path, subject="01", session="t1")[0]
-    assert other in _read_flow(deriv_root=tmp_path, subject="01", session="t2")[0]
+    assert other not in _read01(tmp_path, "t1")
+    assert other in _read01(tmp_path, "t2")
 
     assert _shorten_paths(
         ["/bids/sub-01_meg.fif", f"{tmp_path}/a.fif", "/elsewhere/b.fif"],
@@ -168,10 +182,8 @@ def test_flow_storage(tmp_path: pathlib.Path) -> None:
     ) == ["<bids_root>/sub-01_meg.fif", "<deriv_root>/a.fif", "/elsewhere/b.fif"]
 
     # A corrupt per-subject file is skipped rather than fatal
-    (tmp_path / ".pipeline_flow" / "sub-01.json").write_text("not json")
-    assert _read_flow(deriv_root=tmp_path, subject="01", session=None)[0] == (
-        dataset_only
-    )
+    (flow_dir / "sub-01.json").write_text("not json")
+    assert _read01(tmp_path) == dataset_only
 
 
 def test_flow_graph() -> None:
@@ -196,27 +208,24 @@ def test_flow_graph() -> None:
     # The full paths are kept for the tooltips
     edge = next(edge for edge in graph.edges if edge.lines[0] == "proc-filt raw")
     assert len(edge.paths) == 3
-    assert edge.paths[0] == "/deriv/sub-01_task-av_run-01_proc-filt_raw.fif"
+    assert edge.paths[0] == _filt_raw("01")
 
     # Node tooltips: title, then timing (the cached=True run-01 call has no recorded
     # original so timing sums the other two), then the outputs
-    node = next(node for node in graph.nodes if "_04_frequency_filter" in node.lines)
+    node = _find_node(graph, "_04_frequency_filter")
     assert node.paths == [
         "Frequency filter",
         "took 4.0 s over 2 calls",
         "completed 2026-08-12 09:03:00",
         "writes:",
-        *(
-            f"/deriv/sub-01_task-av_run-{run}_proc-filt_raw.fif"
-            for run in ("01", "02", "03")
-        ),
+        *(_filt_raw(run) for run in RUNS),
     ]
     # All-cached with no recorded original: say so instead of showing check times
     entries = _pipeline_entries()
     for entry in entries:
         entry["cached"] = True
     graph = _build_flow_graph(entries)
-    node = next(node for node in graph.nodes if "_04_frequency_filter" in node.lines)
+    node = _find_node(graph, "_04_frequency_filter")
     assert node.paths[1] == "cached (original run not recorded)"
 
 
@@ -240,12 +249,7 @@ def test_flow_edge_logic() -> None:
 
     # Edges skipping a layer are routed through the layers in between
     entries = _pipeline_entries()
-    entries.append(
-        _entry(
-            "sensor/_06_make_cov",
-            in_files={"raw": "/deriv/sub-01_task-av_run-01_proc-filt_raw.fif"},
-        )
-    )
+    entries.append(_entry("sensor/_06_make_cov", in_files={"raw": _filt_raw("01")}))
     graph = _layout_graph(_build_flow_graph(entries))
     nodes = {node.id: node for node in graph.nodes}
     long_edge = next(
@@ -340,7 +344,7 @@ def test_flow_svg() -> None:
     assert len(filt.get("data-flow-edges", "").split()) == 4
 
     titles = [el.text or "" for el in svg.findall(f".//{SVG_NS}title")]
-    assert any("/deriv/sub-01_task-av_run-01_proc-filt_raw.fif" in t for t in titles)
+    assert any(_filt_raw("01") in t for t in titles)
 
     classes = [el.get("class", "") for el in node_els]
     assert sum("mbp-flow-cat-preproc" in k for k in classes) == 2
@@ -419,8 +423,7 @@ def flow_kwargs(tmp_path: pathlib.Path) -> dict[str, Any]:
 
 
 def _recorded(flow_kwargs: dict[str, Any]) -> list[FlowEntryT]:
-    deriv_root = flow_kwargs["exec_params"].deriv_root
-    return _read_flow(deriv_root=deriv_root, subject="01", session=None)[0]
+    return _read01(flow_kwargs["exec_params"].deriv_root)
 
 
 @pytest.mark.parametrize("memory_location", (True, False))

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -10,16 +10,17 @@ import pytest
 from mne_bids import BIDSPath
 
 from mne_bids_pipeline._flow import (
+    _SOURCE_ID,
     FlowEntryT,
     _build_flow_graph,
     _collapse_runs,
     _flow_files,
-    _flow_html,
-    _layout_flow_graph,
+    _node_id,
     _read_flow_entries,
     _report_flow_html,
     _write_flow_entry,
 )
+from mne_bids_pipeline._graph import _graph_html, _layout_graph
 from mne_bids_pipeline._report import _add_flow_diagram
 from mne_bids_pipeline._run import _prep_out_files_path, failsafe_run
 from mne_bids_pipeline.typing import InFilesT, OutFilesT
@@ -229,7 +230,7 @@ def test_flow_graph_no_self_edges() -> None:
 
 def test_flow_layout() -> None:
     """Test that the layout respects the topology and does not overlap."""
-    graph = _layout_flow_graph(_build_flow_graph(_pipeline_entries()))
+    graph = _layout_graph(_build_flow_graph(_pipeline_entries()))
     nodes = {node.id: node for node in graph.nodes}
     assert [node.layer for node in graph.nodes] == [0, 1, 2, 3, 3]
     for edge in graph.edges:
@@ -258,7 +259,7 @@ def test_flow_layout_long_edges() -> None:
             in_files={"raw": "/deriv/sub-01_task-av_run-01_proc-filt_raw.fif"},
         )
     )
-    graph = _layout_flow_graph(_build_flow_graph(entries))
+    graph = _layout_graph(_build_flow_graph(entries))
     nodes = {node.id: node for node in graph.nodes}
     long_edge = next(
         edge
@@ -271,8 +272,8 @@ def test_flow_layout_long_edges() -> None:
 
 def test_flow_svg() -> None:
     """Test that the emitted SVG is well-formed and self-consistent."""
-    graph = _layout_flow_graph(_build_flow_graph(_pipeline_entries()))
-    html = _flow_html(graph)
+    graph = _layout_graph(_build_flow_graph(_pipeline_entries()))
+    html = _graph_html(graph, source_id=_node_id(_SOURCE_ID))
     assert "<script>" in html
     svg = ET.fromstring(html[html.index("<svg") : html.index("</svg>") + 6])
     assert svg.get("class") == "mbp-flow"

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -302,6 +302,9 @@ def test_flow_layout() -> None:
     )
     assert layer["freesurfer _01_recon_all"] > highest
     assert layer["source _01_make_bem_surfaces"] > layer["freesurfer _01_recon_all"]
+    # Distant bands get their own copy of the BIDS source node (here for the
+    # freesurfer band's T1w input) instead of one edge spanning the diagram
+    assert sum(node.klass == "mbp-flow-source" for node in graph.nodes) == 2
 
 
 def test_flow_svg() -> None:

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -6,7 +6,6 @@ import xml.etree.ElementTree as ET
 from types import SimpleNamespace
 from typing import Any
 
-import mne
 import pytest
 from mne_bids import BIDSPath
 
@@ -20,7 +19,6 @@ from mne_bids_pipeline._flow import (
     _write_flow_entry,
 )
 from mne_bids_pipeline._graph import _graph_html, _layout_graph
-from mne_bids_pipeline._report import _add_flow_diagram
 from mne_bids_pipeline._run import (
     _flow_files,
     _prep_out_files_path,
@@ -71,7 +69,11 @@ def _pipeline_entries() -> list[FlowEntryT]:
             _entry(
                 "preprocessing/_04_frequency_filter",
                 func="filter_data",
+                title="Frequency filter",
                 run=run,
+                duration=2.0,
+                finished=f"2026-08-12 09:0{run[-1]}:00",
+                cached=run == "01",
                 in_files={"raw": f"/bids/sub-01_task-av_run-{run}_meg.fif"},
                 out_files={"raw": f"/deriv/sub-01_task-av_run-{run}_proc-filt_raw.fif"},
             )
@@ -124,37 +126,14 @@ def test_collapse_runs(runs: list[str], want: str) -> None:
     assert _collapse_runs(runs) == want
 
 
-def test_flow_files() -> None:
-    """Test normalization of the in_files/out_files mappings."""
-    bids_path = BIDSPath(
-        subject="01",
-        root="/bids",
-        datatype="meg",
-        suffix="meg",
-        extension=".fif",
-        check=False,
-    )
-    got = _flow_files(
-        {
-            "path": pathlib.Path("/deriv/a.fif"),
-            "bids": bids_path,
-            "hashed": ("/deriv/b.fif", 1234.0),
-            "__unknown_inputs__": "custom cov",
-            "junk": None,
-        }
-    )
-    assert got == {
-        "path": "/deriv/a.fif",
-        "bids": str(bids_path.fpath),
-        "hashed": "/deriv/b.fif",
-    }
-
-
-def test_flow_recording_roundtrip(tmp_path: pathlib.Path) -> None:
-    """Test that recorded entries survive a write/read cycle without duplicating."""
+def test_flow_storage(tmp_path: pathlib.Path) -> None:
+    """Test the write/read roundtrip, roots, and missing/corrupt recordings."""
+    assert _read_flow(deriv_root=tmp_path, subject="01", session=None) == ([], {})
+    assert _report_flow_html(deriv_root=tmp_path, subject="01", session=None) is None
+    roots = {"bids_root": "/bids"}
     entries = _pipeline_entries()
     for entry in entries:
-        _write_flow_entry(deriv_root=tmp_path, entry=entry)
+        _write_flow_entry(deriv_root=tmp_path, entry=entry, roots=roots)
     # Re-running a step must overwrite its own entry rather than add another
     changed = _entry(
         entries[0]["step"],
@@ -165,7 +144,8 @@ def test_flow_recording_roundtrip(tmp_path: pathlib.Path) -> None:
     )
     _write_flow_entry(deriv_root=tmp_path, entry=changed)
 
-    got = _read_flow(deriv_root=tmp_path, subject="01", session=None)[0]
+    got, got_roots = _read_flow(deriv_root=tmp_path, subject="01", session=None)
+    assert got_roots == roots
     assert len(got) == len(entries)
     assert changed in got
     assert entries[0] not in got
@@ -173,7 +153,6 @@ def test_flow_recording_roundtrip(tmp_path: pathlib.Path) -> None:
     assert sum(entry["subject"] is None for entry in got) == 1
     assert (tmp_path / ".pipeline_flow" / "dataset.json").is_file()
     assert (tmp_path / ".pipeline_flow" / "sub-01.json").is_file()
-
     dataset_only = [entry for entry in got if entry["subject"] is None]
     assert _read_flow(deriv_root=tmp_path, subject="02", session=None)[0] == (
         dataset_only
@@ -184,39 +163,20 @@ def test_flow_recording_roundtrip(tmp_path: pathlib.Path) -> None:
     assert other not in _read_flow(deriv_root=tmp_path, subject="01", session="t1")[0]
     assert other in _read_flow(deriv_root=tmp_path, subject="01", session="t2")[0]
 
-
-def test_flow_recording_missing(tmp_path: pathlib.Path) -> None:
-    """Test that an absent or unreadable recording is not fatal."""
-    assert _read_flow(deriv_root=tmp_path, subject="01", session=None)[0] == []
-    assert _report_flow_html(deriv_root=tmp_path, subject="01", session=None) is None
-    fname = tmp_path / ".pipeline_flow" / "sub-01.json"
-    fname.parent.mkdir()
-    fname.write_text("not json")
-    assert _read_flow(deriv_root=tmp_path, subject="01", session=None)[0] == []
-
-
-def test_flow_roots(tmp_path: pathlib.Path) -> None:
-    """Test that recorded roots shorten the tooltip paths."""
-    roots = {"bids_root": "/bids"}
-    for entry in _pipeline_entries():
-        _write_flow_entry(deriv_root=tmp_path, entry=entry, roots=roots)
-    assert _read_flow(deriv_root=tmp_path, subject="01", session=None)[1] == roots
     assert _shorten_paths(
         ["/bids/sub-01_meg.fif", f"{tmp_path}/a.fif", "/elsewhere/b.fif"],
         dict(roots, deriv_root=str(tmp_path)),
     ) == ["<bids_root>/sub-01_meg.fif", "<deriv_root>/a.fif", "/elsewhere/b.fif"]
-    html = _report_flow_html(deriv_root=tmp_path, subject="01", session=None)
-    assert html is not None
-    assert 'aria-label="Pipeline flow diagram"' in html
-    assert "mbp-flow-cat-preproc .mbp-flow-box" in html  # category CSS included
-    assert "&lt;bids_root&gt;/sub-01_task-av_run-01_meg.fif" in html
-    # The source node's tooltip lists the roots themselves
-    assert "&lt;bids_root&gt; = /bids" in html
-    assert f"&lt;deriv_root&gt; = {tmp_path}" in html
+
+    # A corrupt per-subject file is skipped rather than fatal
+    (tmp_path / ".pipeline_flow" / "sub-01.json").write_text("not json")
+    assert _read_flow(deriv_root=tmp_path, subject="01", session=None)[0] == (
+        dataset_only
+    )
 
 
-def test_flow_graph_build() -> None:
-    """Test that edges follow the produced/consumed relationships."""
+def test_flow_graph() -> None:
+    """Test that edges follow produced/consumed and node tooltips summarize calls."""
     graph = _build_flow_graph(_pipeline_entries())
     labels = {node.id: " ".join(node.lines) for node in graph.nodes}
     edges = {(labels[edge.src], labels[edge.dst]): edge.lines for edge in graph.edges}
@@ -239,44 +199,29 @@ def test_flow_graph_build() -> None:
     assert len(edge.paths) == 3
     assert edge.paths[0] == "/deriv/sub-01_task-av_run-01_proc-filt_raw.fif"
 
-
-def test_flow_node_tooltip() -> None:
-    """Test that node tooltips summarize title, timing, cache state, and outputs."""
-    entries = [
-        _entry(
-            "preprocessing/_04_frequency_filter",
-            title="Frequency filter",
-            run=run,
-            duration=2.0,
-            finished=f"2026-08-12 09:0{run[-1]}:00",
-            cached=run == "01",
-            in_files={"raw": f"/bids/sub-01_run-{run}_meg.fif"},
-            out_files={"raw": f"/deriv/sub-01_run-{run}_proc-filt_raw.fif"},
-        )
-        for run in ("01", "02", "03")
-    ]
-    graph = _build_flow_graph(entries)
-    node = next(node for node in graph.nodes if "preprocessing" in node.lines)
-    # The cached=True call (run 01) has no recorded original, so timing sums the rest
-    assert node.paths[:4] == [
+    # Node tooltips: title, then timing (the cached=True run-01 call has no recorded
+    # original so timing sums the other two), then the outputs
+    node = next(node for node in graph.nodes if "_04_frequency_filter" in node.lines)
+    assert node.paths == [
         "Frequency filter",
         "took 4.0 s over 2 calls",
         "completed 2026-08-12 09:03:00",
         "writes:",
-    ]
-    assert node.paths[4:] == [
-        f"/deriv/sub-01_run-{run}_proc-filt_raw.fif" for run in ("01", "02", "03")
+        *(
+            f"/deriv/sub-01_task-av_run-{run}_proc-filt_raw.fif"
+            for run in ("01", "02", "03")
+        ),
     ]
     # All-cached with no recorded original: say so instead of showing check times
-    for entry in entries:
-        entry["cached"] = True
-    graph = _build_flow_graph(entries)
-    node = next(node for node in graph.nodes if "preprocessing" in node.lines)
+    entries = [dict(entry, cached=True) for entry in _pipeline_entries()]
+    graph = _build_flow_graph(entries)  # type: ignore[arg-type]
+    node = next(node for node in graph.nodes if "_04_frequency_filter" in node.lines)
     assert node.paths[1] == "cached (original run not recorded)"
 
 
-def test_flow_graph_no_self_edges() -> None:
-    """Test that a step reading its own output does not add a self-edge."""
+def test_flow_edge_logic() -> None:
+    """Test self-edge suppression and the routing of layer-skipping edges."""
+    # A step reading its own output (e.g. a reference run) adds no self-edge
     entries = [
         _entry(
             "preprocessing/_03_maxfilter",
@@ -291,6 +236,24 @@ def test_flow_graph_no_self_edges() -> None:
         ),
     ]
     assert _build_flow_graph(entries).edges == []
+
+    # Edges skipping a layer are routed through the layers in between
+    entries = _pipeline_entries()
+    entries.append(
+        _entry(
+            "sensor/_06_make_cov",
+            in_files={"raw": "/deriv/sub-01_task-av_run-01_proc-filt_raw.fif"},
+        )
+    )
+    graph = _layout_graph(_build_flow_graph(entries))
+    nodes = {node.id: node for node in graph.nodes}
+    long_edge = next(
+        edge
+        for edge in graph.edges
+        if nodes[edge.dst].layer - nodes[edge.src].layer > 1
+    )
+    assert len(long_edge.points) == 3  # one routing point in the skipped layer
+    assert nodes[long_edge.src].y < long_edge.points[1][1] < nodes[long_edge.dst].y
 
 
 def test_flow_layout() -> None:
@@ -313,26 +276,6 @@ def test_flow_layout() -> None:
             assert right <= left
         assert spans[0][0] >= 0 and spans[-1][1] <= graph.width
     assert all(0 < node.y < graph.height for node in graph.nodes)
-
-
-def test_flow_layout_long_edges() -> None:
-    """Test that edges skipping a layer are routed through the layers in between."""
-    entries = _pipeline_entries()
-    entries.append(
-        _entry(
-            "sensor/_06_make_cov",
-            in_files={"raw": "/deriv/sub-01_task-av_run-01_proc-filt_raw.fif"},
-        )
-    )
-    graph = _layout_graph(_build_flow_graph(entries))
-    nodes = {node.id: node for node in graph.nodes}
-    long_edge = next(
-        edge
-        for edge in graph.edges
-        if nodes[edge.dst].layer - nodes[edge.src].layer > 1
-    )
-    assert len(long_edge.points) == 3  # one routing point in the skipped layer
-    assert nodes[long_edge.src].y < long_edge.points[1][1] < nodes[long_edge.dst].y
 
 
 def test_flow_svg() -> None:
@@ -380,29 +323,6 @@ def test_flow_svg() -> None:
         if el.get("class") == "mbp-flow-edge-label"
     ]
     assert len(label_els) == len(edge_els) - 1 == 3
-
-
-def test_flow_report(tmp_path: pathlib.Path) -> None:
-    """Test that the diagram makes it into a saved report."""
-    report = mne.Report(title="sub-01")
-    exec_params = SimpleNamespace(deriv_root=tmp_path)
-    _add_flow_diagram(
-        report=report, exec_params=exec_params, subject="01", session=None
-    )
-    assert report.html == []  # nothing recorded yet
-    for entry in _pipeline_entries():
-        _write_flow_entry(deriv_root=tmp_path, entry=entry)
-    for _ in range(2):  # must refresh in place as more steps run
-        _add_flow_diagram(
-            report=report, exec_params=exec_params, subject="01", session=None
-        )
-    assert len(report.html) == 1  # replaced in place rather than appended
-
-    fname = tmp_path / "report.html"
-    report.save(fname, open_browser=False)
-    content = fname.read_text(encoding="utf-8")
-    assert content.count('<svg id="mbp-flow-svg"') == 1
-    assert "_04_frequency_filter" in content
 
 
 _N_CALLS: list[str] = list()
@@ -477,6 +397,29 @@ def _recorded(flow_kwargs: dict[str, Any]) -> list[FlowEntryT]:
 @pytest.mark.parametrize("memory_location", (True, False))
 def test_flow_recorder(flow_kwargs: dict[str, Any], memory_location: bool) -> None:
     """Test that the step wrapper records files on fresh runs and on cache hits."""
+    # The wrapper snapshots in_files/out_files through _flow_files normalization
+    bids_path = BIDSPath(
+        subject="01",
+        root="/bids",
+        datatype="meg",
+        suffix="meg",
+        extension=".fif",
+        check=False,
+    )
+    assert _flow_files(
+        {
+            "path": pathlib.Path("/deriv/a.fif"),
+            "bids": bids_path,
+            "hashed": ("/deriv/b.fif", 1234.0),
+            "__unknown_inputs__": "custom cov",
+            "junk": None,
+        }
+    ) == {
+        "path": "/deriv/a.fif",
+        "bids": str(bids_path.fpath),
+        "hashed": "/deriv/b.fif",
+    }
+
     flow_kwargs["exec_params"].memory_location = memory_location
     cfg = flow_kwargs["cfg"]
     _flow_step(**flow_kwargs)
@@ -525,8 +468,11 @@ def test_flow_recorder(flow_kwargs: dict[str, Any], memory_location: bool) -> No
         assert _ran_when(entry) == ""
 
 
-def test_flow_recorder_short_circuit(flow_kwargs: dict[str, Any]) -> None:
-    """Test that a step skipped because its outputs exist is still recorded."""
+def test_flow_recorder_edge_cases(
+    flow_kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test the output-exists short circuit and recording-failure tolerance."""
+    # A step skipped because its outputs already exist is still recorded
     flow_kwargs["cfg"].out.write_text("stale")
     _flow_step_out(**flow_kwargs)
     assert _N_CALLS == []
@@ -534,11 +480,8 @@ def test_flow_recorder_short_circuit(flow_kwargs: dict[str, Any]) -> None:
     assert entry["in_files"] == {"raw": str(flow_kwargs["cfg"].raw)}
     assert entry["out_files"] == {"filt": str(flow_kwargs["cfg"].out)}
 
-
-def test_flow_recorder_failure(
-    flow_kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Test that a broken recording does not take the pipeline down with it."""
+    # A broken recording must not take the pipeline down with it
+    shutil.rmtree(flow_kwargs["exec_params"].deriv_root / ".pipeline_flow")
 
     def _boom(**kwargs: object) -> None:
         raise RuntimeError("no disk for you")

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -1,6 +1,7 @@
 """Test the pipeline flow diagram."""
 
 import pathlib
+import shutil
 import xml.etree.ElementTree as ET
 from types import SimpleNamespace
 from typing import Any
@@ -13,6 +14,7 @@ from mne_bids_pipeline._flow import (
     FlowEntryT,
     _build_flow_graph,
     _collapse_runs,
+    _flow_completed,
     _flow_files,
     _read_flow_entries,
     _read_flow_roots,
@@ -253,15 +255,22 @@ def test_flow_node_tooltip() -> None:
     ]
     graph = _build_flow_graph(entries)
     node = next(node for node in graph.nodes if "preprocessing" in node.lines)
+    # The cached=True call (run 01) has no recorded original, so timing sums the rest
     assert node.paths[:4] == [
         "Frequency filter",
-        "took 6.0 s over 3 calls (1/3 from cache)",
-        "finished 2026-08-12 09:03:00",
+        "took 4.0 s over 2 calls",
+        "completed 2026-08-12 09:03:00",
         "writes:",
     ]
     assert node.paths[4:] == [
         f"/deriv/sub-01_run-{run}_proc-filt_raw.fif" for run in ("01", "02", "03")
     ]
+    # All-cached with no recorded original: say so instead of showing check times
+    for entry in entries:
+        entry["cached"] = True
+    graph = _build_flow_graph(entries)
+    node = next(node for node in graph.nodes if "preprocessing" in node.lines)
+    assert node.paths[1] == "cached (original run not recorded)"
 
 
 def test_flow_graph_no_self_edges() -> None:
@@ -495,17 +504,32 @@ def test_flow_recorder(flow_kwargs: dict[str, Any], memory_location: bool) -> No
         "out_files": {"filt": str(cfg.out)},
     }
 
-    def _check(cached: bool) -> None:
+    def _check(cached: bool) -> tuple[float, str]:
         (entry,) = (dict(e) for e in _recorded(flow_kwargs))
-        assert entry.pop("duration") >= 0.0
-        assert entry.pop("finished") is not None
+        duration, finished = entry.pop("duration"), entry.pop("finished")
+        assert duration >= 0.0
+        assert finished is not None
         assert entry.pop("cached") is cached
         assert entry == want
+        return duration, finished
 
-    _check(cached=False)
+    first = _check(cached=False)
     _flow_step(**flow_kwargs)
     assert len(_N_CALLS) == (1 if memory_location else 2)  # cache hit the 2nd time
-    _check(cached=memory_location)  # ... and still recorded
+    second = _check(cached=False)  # ... still recorded, as the original computation
+    if memory_location:
+        assert second == first  # the cache hit preserved the original timing
+    deriv_root = flow_kwargs["exec_params"].deriv_root
+    key = dict(step="tests/test_flow", func="_flow_step_impl", kwargs=flow_kwargs)
+    assert _flow_completed(deriv_root=deriv_root, **key) == second[1]
+    if memory_location:
+        # With the recording gone but the joblib cache kept, the original run time
+        # is unknowable: the entry marks that, and the log helper returns nothing
+        shutil.rmtree(deriv_root / ".pipeline_flow")
+        _flow_step(**flow_kwargs)
+        (entry,) = _recorded(flow_kwargs)
+        assert entry["cached"] is True
+        assert _flow_completed(deriv_root=deriv_root, **key) is None
 
 
 def test_flow_recorder_short_circuit(flow_kwargs: dict[str, Any]) -> None:

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 from types import SimpleNamespace
 from typing import Any
 
+import mne
 import pytest
 from mne_bids import BIDSPath
 
@@ -19,6 +20,7 @@ from mne_bids_pipeline._flow import (
     _report_flow_html,
     _write_flow_entry,
 )
+from mne_bids_pipeline._report import _add_flow_diagram
 from mne_bids_pipeline._run import _prep_out_files_path, failsafe_run
 from mne_bids_pipeline.typing import InFilesT, OutFilesT
 
@@ -301,6 +303,29 @@ def test_flow_svg() -> None:
 
     titles = [el.text or "" for el in svg.findall(f".//{SVG_NS}title")]
     assert any("/deriv/sub-01_task-av_run-01_proc-filt_raw.fif" in t for t in titles)
+
+
+def test_flow_report(tmp_path: pathlib.Path) -> None:
+    """Test that the diagram makes it into a saved report."""
+    report = mne.Report(title="sub-01")
+    exec_params = SimpleNamespace(deriv_root=tmp_path)
+    _add_flow_diagram(
+        report=report, exec_params=exec_params, subject="01", session=None
+    )
+    assert report.html == []  # nothing recorded yet
+    for entry in _pipeline_entries():
+        _write_flow_entry(deriv_root=tmp_path, entry=entry)
+    for _ in range(2):  # must refresh in place as more steps run
+        _add_flow_diagram(
+            report=report, exec_params=exec_params, subject="01", session=None
+        )
+    assert len(report.html) == 1  # replaced in place rather than appended
+
+    fname = tmp_path / "report.html"
+    report.save(fname, open_browser=False)
+    content = fname.read_text(encoding="utf-8")
+    assert content.count('<svg id="mbp-flow-svg"') == 1
+    assert "_04_frequency_filter" in content
 
 
 _N_CALLS: list[str] = list()

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -1,6 +1,7 @@
-"""Test recording of the files that pipeline steps read and write."""
+"""Test the pipeline flow diagram."""
 
 import pathlib
+import xml.etree.ElementTree as ET
 from types import SimpleNamespace
 from typing import Any
 
@@ -9,12 +10,19 @@ from mne_bids import BIDSPath
 
 from mne_bids_pipeline._flow import (
     FlowEntryT,
+    _build_flow_graph,
+    _collapse_runs,
     _flow_files,
+    _flow_html,
+    _layout_flow_graph,
     _read_flow_entries,
+    _report_flow_html,
     _write_flow_entry,
 )
 from mne_bids_pipeline._run import _prep_out_files_path, failsafe_run
 from mne_bids_pipeline.typing import InFilesT, OutFilesT
+
+SVG_NS = "{http://www.w3.org/2000/svg}"
 
 
 def _entry(
@@ -85,6 +93,22 @@ def _pipeline_entries() -> list[FlowEntryT]:
     return entries
 
 
+@pytest.mark.parametrize(
+    "runs, want",
+    [
+        ([], ""),
+        (["01"], "run 01"),
+        (["01", "02", "03", "04", "05", "06"], "runs 01–06"),
+        (["03", "01", "02", "07"], "runs 01–03, 07"),
+        (["1", "2"], "runs 1–2"),
+        (["rest", "noise"], "runs noise, rest"),
+    ],
+)
+def test_collapse_runs(runs: list[str], want: str) -> None:
+    """Test that run labels collapse into ranges."""
+    assert _collapse_runs(runs) == want
+
+
 def test_flow_files() -> None:
     """Test normalization of the in_files/out_files mappings."""
     bids_path = BIDSPath(
@@ -151,10 +175,132 @@ def test_flow_recording_roundtrip(tmp_path: pathlib.Path) -> None:
 def test_flow_recording_missing(tmp_path: pathlib.Path) -> None:
     """Test that an absent or unreadable recording is not fatal."""
     assert _read_flow_entries(deriv_root=tmp_path, subject="01", session=None) == []
+    assert _report_flow_html(deriv_root=tmp_path, subject="01", session=None) is None
     fname = tmp_path / ".pipeline_flow" / "sub-01.json"
     fname.parent.mkdir()
     fname.write_text("not json")
     assert _read_flow_entries(deriv_root=tmp_path, subject="01", session=None) == []
+
+
+def test_flow_graph_build() -> None:
+    """Test that edges follow the produced/consumed relationships."""
+    graph = _build_flow_graph(_pipeline_entries())
+    labels = {node.id: " ".join(node.lines) for node in graph.nodes}
+    edges = {(labels[edge.src], labels[edge.dst]): edge.lines for edge in graph.edges}
+    assert edges == {
+        ("BIDS raw data", "preprocessing _04_frequency_filter"): [
+            "meg",
+            "runs 01–03",
+        ],
+        ("preprocessing _04_frequency_filter", "preprocessing _07_make_epochs"): [
+            "proc-filt raw",
+            "runs 01–03",
+        ],
+        ("preprocessing _07_make_epochs", "sensor _01_make_evoked"): ["epo"],
+        ("preprocessing _07_make_epochs", "sensor _06_make_cov"): ["epo"],
+    }
+    # init only writes a file nobody consumes, so it contributes no node
+    assert not any("init" in label for label in labels.values())
+    # The full paths are kept for the tooltips
+    edge = next(edge for edge in graph.edges if edge.lines[0] == "proc-filt raw")
+    assert len(edge.paths) == 3
+    assert edge.paths[0] == "/deriv/sub-01_task-av_run-01_proc-filt_raw.fif"
+
+
+def test_flow_graph_no_self_edges() -> None:
+    """Test that a step reading its own output does not add a self-edge."""
+    entries = [
+        _entry(
+            "preprocessing/_03_maxfilter",
+            run="01",
+            out_files={"raw": "/deriv/sub-01_run-01_proc-sss_raw.fif"},
+        ),
+        _entry(
+            "preprocessing/_03_maxfilter",
+            run="02",
+            in_files={"ref": "/deriv/sub-01_run-01_proc-sss_raw.fif"},
+            out_files={"raw": "/deriv/sub-01_run-02_proc-sss_raw.fif"},
+        ),
+    ]
+    assert _build_flow_graph(entries).edges == []
+
+
+def test_flow_layout() -> None:
+    """Test that the layout respects the topology and does not overlap."""
+    graph = _layout_flow_graph(_build_flow_graph(_pipeline_entries()))
+    nodes = {node.id: node for node in graph.nodes}
+    assert [node.layer for node in graph.nodes] == [0, 1, 2, 3, 3]
+    for edge in graph.edges:
+        src, dst = nodes[edge.src], nodes[edge.dst]
+        assert src.layer < dst.layer
+        assert src.y < dst.y
+        assert edge.points[0][1] < edge.points[-1][1]
+    for layer in range(4):
+        spans = sorted(
+            (node.x - node.width / 2, node.x + node.width / 2)
+            for node in graph.nodes
+            if node.layer == layer
+        )
+        for (_, right), (left, _) in zip(spans[:-1], spans[1:]):
+            assert right <= left
+        assert spans[0][0] >= 0 and spans[-1][1] <= graph.width
+    assert all(0 < node.y < graph.height for node in graph.nodes)
+
+
+def test_flow_layout_long_edges() -> None:
+    """Test that edges skipping a layer are routed through the layers in between."""
+    entries = _pipeline_entries()
+    entries.append(
+        _entry(
+            "sensor/_06_make_cov",
+            in_files={"raw": "/deriv/sub-01_task-av_run-01_proc-filt_raw.fif"},
+        )
+    )
+    graph = _layout_flow_graph(_build_flow_graph(entries))
+    nodes = {node.id: node for node in graph.nodes}
+    long_edge = next(
+        edge
+        for edge in graph.edges
+        if nodes[edge.dst].layer - nodes[edge.src].layer > 1
+    )
+    assert len(long_edge.points) == 3  # one routing point in the skipped layer
+    assert nodes[long_edge.src].y < long_edge.points[1][1] < nodes[long_edge.dst].y
+
+
+def test_flow_svg() -> None:
+    """Test that the emitted SVG is well-formed and self-consistent."""
+    graph = _layout_flow_graph(_build_flow_graph(_pipeline_entries()))
+    html = _flow_html(graph)
+    assert "<script>" in html
+    svg = ET.fromstring(html[html.index("<svg") : html.index("</svg>") + 6])
+    assert svg.get("class") == "mbp-flow"
+
+    groups = svg.findall(f".//{SVG_NS}g")
+    node_els = [el for el in groups if "mbp-flow-node" in el.get("class", "").split()]
+    edge_els = [el for el in groups if el.get("class") == "mbp-flow-edge"]
+    assert len(node_els) == len(graph.nodes) == 5
+    assert len(edge_els) == len(graph.edges) == 4
+    assert sum("mbp-flow-source" in el.get("class", "") for el in node_els) == 1
+    # Node links would need report anchors, which we cannot derive; see _flow.py
+    assert svg.find(f".//{SVG_NS}a") is None
+
+    ids = {el.get("id") for el in node_els + edge_els}
+    assert None not in ids
+    for el in node_els:
+        for attr in ("ancestors", "descendants", "edges"):
+            related = (el.get(f"data-flow-{attr}") or "").split()
+            assert set(related) <= ids
+    filt = next(
+        el
+        for el in node_els
+        if "_04_frequency_filter" in "".join(el.itertext())  # tspans
+    )
+    assert len(filt.get("data-flow-ancestors", "").split()) == 1  # the raw data
+    assert len(filt.get("data-flow-descendants", "").split()) == 3
+    assert len(filt.get("data-flow-edges", "").split()) == 4
+
+    titles = [el.text or "" for el in svg.findall(f".//{SVG_NS}title")]
+    assert any("/deriv/sub-01_task-av_run-01_proc-filt_raw.fif" in t for t in titles)
 
 
 _N_CALLS: list[str] = list()

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -212,8 +212,10 @@ def test_flow_graph() -> None:
         ),
     ]
     # All-cached with no recorded original: say so instead of showing check times
-    entries = [dict(entry, cached=True) for entry in _pipeline_entries()]
-    graph = _build_flow_graph(entries)  # type: ignore[arg-type]
+    entries = _pipeline_entries()
+    for entry in entries:
+        entry["cached"] = True
+    graph = _build_flow_graph(entries)
     node = next(node for node in graph.nodes if "_04_frequency_filter" in node.lines)
     assert node.paths[1] == "cached (original run not recorded)"
 
@@ -436,9 +438,10 @@ def test_flow_recorder(flow_kwargs: dict[str, Any], memory_location: bool) -> No
 
     def _check(cached: bool) -> tuple[float, str]:
         (entry,) = (dict(e) for e in _recorded(flow_kwargs))
-        duration, finished = entry.pop("duration"), entry.pop("finished")
-        assert duration >= 0.0
-        assert finished is not None
+        duration = entry.pop("duration")
+        finished = entry.pop("finished")
+        assert isinstance(duration, float) and duration >= 0.0
+        assert isinstance(finished, str)
         assert entry.pop("cached") is cached
         assert entry == want
         return duration, finished

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -278,6 +278,31 @@ def test_flow_layout() -> None:
         assert spans[0][0] >= 0 and spans[-1][1] <= graph.width
     assert all(0 < node.y < graph.height for node in graph.nodes)
 
+    # Stages never interleave: steps depending only on FreeSurfer files still land
+    # below every preprocessing/sensor step (banded ranks)
+    entries = _pipeline_entries()
+    entries += [
+        _entry(
+            "freesurfer/_01_recon_all",
+            in_files={"t1": "/bids/sub-01_T1w.nii.gz"},
+            out_files={"white": "/fs/sub-01/surf/lh.white"},
+        ),
+        _entry(
+            "source/_01_make_bem_surfaces",
+            in_files={"white": "/fs/sub-01/surf/lh.white"},
+            out_files={"bem": "/fs/sub-01/bem/inner_skull.surf"},
+        ),
+    ]
+    graph = _layout_graph(_build_flow_graph(entries))
+    layer = {" ".join(node.lines): node.layer for node in graph.nodes}
+    highest = max(
+        value
+        for key, value in layer.items()
+        if key.startswith(("preprocessing", "sensor"))
+    )
+    assert layer["freesurfer _01_recon_all"] > highest
+    assert layer["source _01_make_bem_surfaces"] > layer["freesurfer _01_recon_all"]
+
 
 def test_flow_svg() -> None:
     """Test that the emitted SVG is well-formed and self-consistent."""

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -32,20 +32,28 @@ def _entry(
     step: str,
     *,
     func: str = "func",
+    title: str | None = None,
     subject: str | None = "01",
     session: str | None = None,
     run: str | None = None,
     task: str | None = "av",
+    duration: float | None = None,
+    finished: str | None = None,
+    cached: bool | None = None,
     in_files: dict[str, str] | None = None,
     out_files: dict[str, str] | None = None,
 ) -> FlowEntryT:
     return {
         "step": step,
         "func": func,
+        "title": title,
         "subject": subject,
         "session": session,
         "run": run,
         "task": task,
+        "duration": duration,
+        "finished": finished,
+        "cached": cached,
         "in_files": in_files or dict(),
         "out_files": out_files or dict(),
     }
@@ -226,6 +234,34 @@ def test_flow_graph_build() -> None:
     edge = next(edge for edge in graph.edges if edge.lines[0] == "proc-filt raw")
     assert len(edge.paths) == 3
     assert edge.paths[0] == "/deriv/sub-01_task-av_run-01_proc-filt_raw.fif"
+
+
+def test_flow_node_tooltip() -> None:
+    """Test that node tooltips summarize title, timing, cache state, and outputs."""
+    entries = [
+        _entry(
+            "preprocessing/_04_frequency_filter",
+            title="Frequency filter",
+            run=run,
+            duration=2.0,
+            finished=f"2026-08-12 09:0{run[-1]}:00",
+            cached=run == "01",
+            in_files={"raw": f"/bids/sub-01_run-{run}_meg.fif"},
+            out_files={"raw": f"/deriv/sub-01_run-{run}_proc-filt_raw.fif"},
+        )
+        for run in ("01", "02", "03")
+    ]
+    graph = _build_flow_graph(entries)
+    node = next(node for node in graph.nodes if "preprocessing" in node.lines)
+    assert node.paths[:4] == [
+        "Frequency filter",
+        "took 6.0 s over 3 calls (1/3 from cache)",
+        "finished 2026-08-12 09:03:00",
+        "writes:",
+    ]
+    assert node.paths[4:] == [
+        f"/deriv/sub-01_run-{run}_proc-filt_raw.fif" for run in ("01", "02", "03")
+    ]
 
 
 def test_flow_graph_no_self_edges() -> None:
@@ -447,22 +483,29 @@ def test_flow_recorder(flow_kwargs: dict[str, Any], memory_location: bool) -> No
     flow_kwargs["exec_params"].memory_location = memory_location
     cfg = flow_kwargs["cfg"]
     _flow_step(**flow_kwargs)
-    want = [
-        {
-            "step": "tests/test_flow",
-            "func": "_flow_step_impl",
-            "subject": "01",
-            "session": None,
-            "run": "01",
-            "task": "av",
-            "in_files": {"raw": str(cfg.raw)},
-            "out_files": {"filt": str(cfg.out)},
-        }
-    ]
-    assert _recorded(flow_kwargs) == want
+    want = {
+        "step": "tests/test_flow",
+        "func": "_flow_step_impl",
+        "title": "Test the pipeline flow diagram",
+        "subject": "01",
+        "session": None,
+        "run": "01",
+        "task": "av",
+        "in_files": {"raw": str(cfg.raw)},
+        "out_files": {"filt": str(cfg.out)},
+    }
+
+    def _check(cached: bool) -> None:
+        (entry,) = (dict(e) for e in _recorded(flow_kwargs))
+        assert entry.pop("duration") >= 0.0
+        assert entry.pop("finished") is not None
+        assert entry.pop("cached") is cached
+        assert entry == want
+
+    _check(cached=False)
     _flow_step(**flow_kwargs)
     assert len(_N_CALLS) == (1 if memory_location else 2)  # cache hit the 2nd time
-    assert _recorded(flow_kwargs) == want  # ... and still recorded
+    _check(cached=memory_location)  # ... and still recorded
 
 
 def test_flow_recorder_short_circuit(flow_kwargs: dict[str, Any]) -> None:

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -1,0 +1,288 @@
+"""Test recording of the files that pipeline steps read and write."""
+
+import pathlib
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from mne_bids import BIDSPath
+
+from mne_bids_pipeline._flow import (
+    FlowEntryT,
+    _flow_files,
+    _read_flow_entries,
+    _write_flow_entry,
+)
+from mne_bids_pipeline._run import _prep_out_files_path, failsafe_run
+from mne_bids_pipeline.typing import InFilesT, OutFilesT
+
+
+def _entry(
+    step: str,
+    *,
+    func: str = "func",
+    subject: str | None = "01",
+    session: str | None = None,
+    run: str | None = None,
+    task: str | None = "av",
+    in_files: dict[str, str] | None = None,
+    out_files: dict[str, str] | None = None,
+) -> FlowEntryT:
+    return {
+        "step": step,
+        "func": func,
+        "subject": subject,
+        "session": session,
+        "run": run,
+        "task": task,
+        "in_files": in_files or dict(),
+        "out_files": out_files or dict(),
+    }
+
+
+def _pipeline_entries() -> list[FlowEntryT]:
+    """Get a small but representative recording: 3 runs, a fan-out, a dead end."""
+    entries = list()
+    for run in ("01", "02", "03"):
+        entries.append(
+            _entry(
+                "preprocessing/_04_frequency_filter",
+                func="filter_data",
+                run=run,
+                in_files={"raw": f"/bids/sub-01_task-av_run-{run}_meg.fif"},
+                out_files={"raw": f"/deriv/sub-01_task-av_run-{run}_proc-filt_raw.fif"},
+            )
+        )
+    entries.append(
+        _entry(
+            "preprocessing/_07_make_epochs",
+            func="make_epochs",
+            in_files={
+                f"raw_{run}": f"/deriv/sub-01_task-av_run-{run}_proc-filt_raw.fif"
+                for run in ("01", "02", "03")
+            },
+            out_files={"epo": "/deriv/sub-01_task-av_epo.fif"},
+        )
+    )
+    for step in ("sensor/_01_make_evoked", "sensor/_06_make_cov"):
+        entries.append(
+            _entry(
+                step,
+                in_files={"epo": "/deriv/sub-01_task-av_epo.fif"},
+                out_files={"out": f"/deriv/sub-01_task-av_{step[-3:]}.fif"},
+            )
+        )
+    # Produces something nobody reads, so it should not show up at all
+    entries.append(
+        _entry(
+            "init/_01_init_derivatives_dir",
+            func="init_dataset",
+            subject=None,
+            task=None,
+            out_files={"json": "/deriv/dataset_description.json"},
+        )
+    )
+    return entries
+
+
+def test_flow_files() -> None:
+    """Test normalization of the in_files/out_files mappings."""
+    bids_path = BIDSPath(
+        subject="01",
+        root="/bids",
+        datatype="meg",
+        suffix="meg",
+        extension=".fif",
+        check=False,
+    )
+    got = _flow_files(
+        {
+            "path": pathlib.Path("/deriv/a.fif"),
+            "bids": bids_path,
+            "hashed": ("/deriv/b.fif", 1234.0),
+            "__unknown_inputs__": "custom cov",
+            "junk": None,
+        }
+    )
+    assert got == {
+        "path": "/deriv/a.fif",
+        "bids": str(bids_path.fpath),
+        "hashed": "/deriv/b.fif",
+    }
+
+
+def test_flow_recording_roundtrip(tmp_path: pathlib.Path) -> None:
+    """Test that recorded entries survive a write/read cycle without duplicating."""
+    entries = _pipeline_entries()
+    for entry in entries:
+        _write_flow_entry(deriv_root=tmp_path, entry=entry)
+    # Re-running a step must overwrite its own entry rather than add another
+    changed = _entry(
+        entries[0]["step"],
+        func=entries[0]["func"],
+        run=entries[0]["run"],
+        in_files=entries[0]["in_files"],
+        out_files={"raw": "/deriv/other.fif"},
+    )
+    _write_flow_entry(deriv_root=tmp_path, entry=changed)
+
+    got = _read_flow_entries(deriv_root=tmp_path, subject="01", session=None)
+    assert len(got) == len(entries)
+    assert changed in got
+    assert entries[0] not in got
+    # The dataset-level entry lives in its own file but is relevant to every subject
+    assert sum(entry["subject"] is None for entry in got) == 1
+    assert (tmp_path / ".pipeline_flow" / "dataset.json").is_file()
+    assert (tmp_path / ".pipeline_flow" / "sub-01.json").is_file()
+
+    dataset_only = [entry for entry in got if entry["subject"] is None]
+    assert _read_flow_entries(deriv_root=tmp_path, subject="02", session=None) == (
+        dataset_only
+    )
+    # Entries of other sessions are filtered out
+    other = _entry("sensor/_01_make_evoked", session="t2")
+    _write_flow_entry(deriv_root=tmp_path, entry=other)
+    assert other not in _read_flow_entries(
+        deriv_root=tmp_path, subject="01", session="t1"
+    )
+    assert other in _read_flow_entries(deriv_root=tmp_path, subject="01", session="t2")
+
+
+def test_flow_recording_missing(tmp_path: pathlib.Path) -> None:
+    """Test that an absent or unreadable recording is not fatal."""
+    assert _read_flow_entries(deriv_root=tmp_path, subject="01", session=None) == []
+    fname = tmp_path / ".pipeline_flow" / "sub-01.json"
+    fname.parent.mkdir()
+    fname.write_text("not json")
+    assert _read_flow_entries(deriv_root=tmp_path, subject="01", session=None) == []
+
+
+_N_CALLS: list[str] = list()
+
+
+def _get_input_fnames_flow(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+    session: str | None,
+    run: str | None,
+    task: str | None,
+) -> InFilesT:
+    return dict(raw=cfg.raw)
+
+
+def _get_output_fnames_flow(
+    *,
+    cfg: SimpleNamespace,
+    subject: str,
+    session: str | None,
+    run: str | None,
+    task: str | None,
+) -> InFilesT:
+    return dict(filt=cfg.out)
+
+
+def _flow_step_impl(
+    *,
+    cfg: SimpleNamespace,
+    exec_params: SimpleNamespace,
+    subject: str,
+    session: str | None,
+    run: str | None,
+    task: str | None,
+    in_files: InFilesT,
+) -> OutFilesT:
+    _N_CALLS.append(subject)
+    in_files.pop("raw")
+    cfg.out.write_text("filtered")
+    return _prep_out_files_path(exec_params=exec_params, out_files=dict(filt=cfg.out))
+
+
+_flow_step = failsafe_run(get_input_fnames=_get_input_fnames_flow)(_flow_step_impl)
+_flow_step_out = failsafe_run(
+    get_input_fnames=_get_input_fnames_flow,
+    get_output_fnames=_get_output_fnames_flow,
+)(_flow_step_impl)
+
+
+@pytest.fixture
+def flow_kwargs(tmp_path: pathlib.Path) -> dict[str, Any]:
+    """Get kwargs for a fake pipeline step writing into a fresh derivatives dir."""
+    _N_CALLS.clear()
+    deriv_root = tmp_path / "derivatives"
+    deriv_root.mkdir()
+    raw = tmp_path / "sub-01_task-av_run-01_meg.fif"
+    raw.write_text("raw")
+    cfg = SimpleNamespace(
+        raw=raw, out=deriv_root / "sub-01_task-av_run-01_filt_raw.fif"
+    )
+    exec_params = SimpleNamespace(
+        on_error="abort",
+        deriv_root=deriv_root,
+        memory_location=True,
+        memory_subdir="joblib",
+        memory_verbose=0,
+        memory_file_method="mtime",
+        ignore_warnings=(),
+    )
+    return dict(
+        cfg=cfg,
+        exec_params=exec_params,
+        subject="01",
+        session=None,
+        run="01",
+        task="av",
+    )
+
+
+def _recorded(flow_kwargs: dict[str, Any]) -> list[FlowEntryT]:
+    deriv_root = flow_kwargs["exec_params"].deriv_root
+    return _read_flow_entries(deriv_root=deriv_root, subject="01", session=None)
+
+
+@pytest.mark.parametrize("memory_location", (True, False))
+def test_flow_recorder(flow_kwargs: dict[str, Any], memory_location: bool) -> None:
+    """Test that the step wrapper records files on fresh runs and on cache hits."""
+    flow_kwargs["exec_params"].memory_location = memory_location
+    cfg = flow_kwargs["cfg"]
+    _flow_step(**flow_kwargs)
+    want = [
+        {
+            "step": "tests/test_flow",
+            "func": "_flow_step_impl",
+            "subject": "01",
+            "session": None,
+            "run": "01",
+            "task": "av",
+            "in_files": {"raw": str(cfg.raw)},
+            "out_files": {"filt": str(cfg.out)},
+        }
+    ]
+    assert _recorded(flow_kwargs) == want
+    _flow_step(**flow_kwargs)
+    assert len(_N_CALLS) == (1 if memory_location else 2)  # cache hit the 2nd time
+    assert _recorded(flow_kwargs) == want  # ... and still recorded
+
+
+def test_flow_recorder_short_circuit(flow_kwargs: dict[str, Any]) -> None:
+    """Test that a step skipped because its outputs exist is still recorded."""
+    flow_kwargs["cfg"].out.write_text("stale")
+    _flow_step_out(**flow_kwargs)
+    assert _N_CALLS == []
+    (entry,) = _recorded(flow_kwargs)
+    assert entry["in_files"] == {"raw": str(flow_kwargs["cfg"].raw)}
+    assert entry["out_files"] == {"filt": str(flow_kwargs["cfg"].out)}
+
+
+def test_flow_recorder_failure(
+    flow_kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that a broken recording does not take the pipeline down with it."""
+
+    def _boom(**kwargs: object) -> None:
+        raise RuntimeError("no disk for you")
+
+    monkeypatch.setattr("mne_bids_pipeline._run._write_flow_entry", _boom)
+    _flow_step(**flow_kwargs)
+    assert _N_CALLS == ["01"]
+    assert _recorded(flow_kwargs) == []

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -12,13 +12,12 @@ from mne_bids import BIDSPath
 from mne_bids_pipeline._flow import (
     FlowEntryT,
     _build_flow_graph,
-    _collapse_runs,
     _read_flow,
     _report_flow_html,
-    _shorten_paths,
     _write_flow_entry,
 )
 from mne_bids_pipeline._graph import _graph_html, _layout_graph
+from mne_bids_pipeline._logging import _collapse_runs, _shorten_paths
 from mne_bids_pipeline._run import (
     _flow_files,
     _prep_out_files_path,

--- a/mne_bids_pipeline/tests/test_flow.py
+++ b/mne_bids_pipeline/tests/test_flow.py
@@ -10,14 +10,14 @@ import pytest
 from mne_bids import BIDSPath
 
 from mne_bids_pipeline._flow import (
-    _SOURCE_ID,
     FlowEntryT,
     _build_flow_graph,
     _collapse_runs,
     _flow_files,
-    _node_id,
     _read_flow_entries,
+    _read_flow_roots,
     _report_flow_html,
+    _shorten_paths,
     _write_flow_entry,
 )
 from mne_bids_pipeline._graph import _graph_html, _layout_graph
@@ -185,6 +185,24 @@ def test_flow_recording_missing(tmp_path: pathlib.Path) -> None:
     assert _read_flow_entries(deriv_root=tmp_path, subject="01", session=None) == []
 
 
+def test_flow_roots(tmp_path: pathlib.Path) -> None:
+    """Test that recorded roots shorten the tooltip paths."""
+    roots = {"bids_root": "/bids"}
+    for entry in _pipeline_entries():
+        _write_flow_entry(deriv_root=tmp_path, entry=entry, roots=roots)
+    assert _read_flow_roots(deriv_root=tmp_path, subject="01") == roots
+    assert _shorten_paths(
+        ["/bids/sub-01_meg.fif", f"{tmp_path}/a.fif", "/elsewhere/b.fif"],
+        dict(roots, deriv_root=str(tmp_path)),
+    ) == ["<bids_root>/sub-01_meg.fif", "<deriv_root>/a.fif", "/elsewhere/b.fif"]
+    html = _report_flow_html(deriv_root=tmp_path, subject="01", session=None)
+    assert html is not None
+    assert "&lt;bids_root&gt;/sub-01_task-av_run-01_meg.fif" in html
+    # The source node's tooltip lists the roots themselves
+    assert "&lt;bids_root&gt; = /bids" in html
+    assert f"&lt;deriv_root&gt; = {tmp_path}" in html
+
+
 def test_flow_graph_build() -> None:
     """Test that edges follow the produced/consumed relationships."""
     graph = _build_flow_graph(_pipeline_entries())
@@ -273,7 +291,7 @@ def test_flow_layout_long_edges() -> None:
 def test_flow_svg() -> None:
     """Test that the emitted SVG is well-formed and self-consistent."""
     graph = _layout_graph(_build_flow_graph(_pipeline_entries()))
-    html = _graph_html(graph, source_id=_node_id(_SOURCE_ID))
+    html = _graph_html(graph)
     assert "<script>" in html
     svg = ET.fromstring(html[html.index("<svg") : html.index("</svg>") + 6])
     assert svg.get("class") == "mbp-flow"
@@ -304,6 +322,17 @@ def test_flow_svg() -> None:
 
     titles = [el.text or "" for el in svg.findall(f".//{SVG_NS}title")]
     assert any("/deriv/sub-01_task-av_run-01_proc-filt_raw.fif" in t for t in titles)
+
+    classes = [el.get("class", "") for el in node_els]
+    assert sum("mbp-flow-cat-preproc" in k for k in classes) == 2
+    assert sum("mbp-flow-cat-sensor" in k for k in classes) == 2
+    # The two identically-labeled fan edges share one rendered label
+    label_els = [
+        el
+        for el in svg.findall(f".//{SVG_NS}text")
+        if el.get("class") == "mbp-flow-edge-label"
+    ]
+    assert len(label_els) == len(edge_els) - 1 == 3
 
 
 def test_flow_report(tmp_path: pathlib.Path) -> None:

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -304,10 +304,15 @@ def test_run(
         / test_options.get("dataset", dataset)
     )
     report_html_paths = sorted(deriv_path.rglob("sub-*_report.html"))
-    if "preprocessing" in steps:
+    if "preprocessing" not in steps:
+        # FreeSurfer/BEM-only runs may write no report, or an edge-less recording
+        # (e.g. coreg_surfaces consuming its own cached seghead) and no diagram
+        for report_html_path in report_html_paths[:1]:
+            content = report_html_path.read_text("utf-8")
+            assert content.count('<svg id="mbp-flow-svg"') <= 1
+    else:
         assert len(report_html_paths)
-    for report_html_path in report_html_paths[:1]:  # BEM-only runs may have none
-        content = report_html_path.read_text("utf-8")
+        content = report_html_paths[0].read_text("utf-8")
         assert content.count('<svg id="mbp-flow-svg"') == 1
         assert content.count('aria-label="Pipeline flow diagram"') == 1
         assert "mbp-flow-cat-" in content  # step-category CSS included

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -296,6 +296,26 @@ def test_run(
         # conditional is good
         assert dataset not in ("ds000248", "ds004229", "ERP_CORE_P3")
 
+    # every report gets a flow diagram, replaced in place across report saves
+    deriv_path = (
+        DATA_DIR
+        / "derivatives"
+        / "mne-bids-pipeline"
+        / test_options.get("dataset", dataset)
+    )
+    report_html_paths = sorted(deriv_path.rglob("sub-*_report.html"))
+    if "preprocessing" in steps:
+        assert len(report_html_paths)
+    for report_html_path in report_html_paths[:1]:  # BEM-only runs may have none
+        content = report_html_path.read_text("utf-8")
+        assert content.count('<svg id="mbp-flow-svg"') == 1
+        assert content.count('aria-label="Pipeline flow diagram"') == 1
+        assert "mbp-flow-cat-" in content  # step-category CSS included
+        # tooltip paths are shortened against the recorded roots, which the
+        # source node's tooltip defines
+        assert "&lt;deriv_root&gt; = " in content
+        assert "&lt;bids_root&gt;" in content
+
 
 def _make_fake_bids_dataset(
     bids_root: Path,


### PR DESCRIPTION
### Before merging …

- [x] Changelog has been updated (`docs/source/dev.md.inc`)

Iterated a bunch with Claude Fable 5 on a feature I've wanted [for a while](https://github.com/mne-tools/mne-bids-pipeline/issues/350#issuecomment-1307838525): a flow diagram calculated on the fly based on what actually ran:

<img width="1313" height="1165" alt="Screenshot 2026-08-12 at 10 41 00 AM" src="https://github.com/user-attachments/assets/235c14aa-2b85-4bd4-9e7c-39b8a77b0884" />

The mechanics behind how to construct it are pretty simple:

1. Write a JSON result for each step that can then later be parsed.
2. Read those JSONs during report phase and construct a directed acyclic graph (DAG)
3. Lay that out using custom DAG layout + SVG + a little JS for interaction

<details>
<summary><strong>Why a custom-rolled graph layout</strong></summary>

(3) above turned out to be the tricky decision point, because there are libraries for this sort of thing. But there were requirements I had:

1. Right graph type: DAG + labeled edges + multi-parent nodes.
2. Self-contained, offline-safe output.
3. No new runtime burden: pip-installable pure Python for a tool users run on their own machines.

I looked at maybe a dozen other pieces of software instead, top alternative candidates were:

- ⛔ `mermaid` (js): adds ~3.5 MB of vendored JS into every report and lacks some features (like label mouseover support that SVG gives for free)
- ⛔ `grandalf` (python): only replaces the "layout" part of the code, which is not the hardest part to sort out (and adds a dep)
- ⛔ `pygal` (python): no node-link chart type
- ⛔  `chart.js` (js): no text search, no tooltips
- ❓ `d3-dag` (js): the closest. layout-only in the browser, though; trades ~240 lines of Python rendering for embedded JavaScript.

I had Claude implement `d3-dag` and `mermaid` and they at least worked, but weren't overall better (edge labels worse for d3, mermaid no mouseovers, etc.):

<img width="1710" height="611" alt="Screenshot 2026-08-12 at 2 13 42 PM" src="https://github.com/user-attachments/assets/f23309ef-2f95-4dc5-9591-5109812b50ec" />

If our graphs get far more complex at some point it could make sense to go with `d3-dag` probably, though.

</details>

