### PR TITLE
FIX: Keep run sections in run order under parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,18 @@ jobs:
               git remote set-url origin "$CIRCLE_REPOSITORY_URL"
             fi
       - checkout
+      # Cloned here rather than in setup_bash.sh below so the install script exists
+      # before restore_cache needs to hash it into the key
+      - run:
+          name: Clone mne-tools
+          command: |
+            git clone --depth 1 https://github.com/mne-tools/mne-tools.git ~/mne-tools
+      # Keyed on the install script, so publishing a new bundle invalidates this
+      # automatically. Deliberately no prefix fallback: a partial hit would restore a
+      # stale tree, and the script skips the download when the directory exists.
       - restore_cache:
           keys:
-            - minimal-cmds-0
+            - minimal-cmds-{{ checksum "/home/circleci/mne-tools/tools/get_minimal_commands.sh" }}
       # pip's HTTP/wheel cache. The prefix-matching fallback key means a change to
       # pyproject.toml reuses the previous cache rather than starting from scratch.
       - restore_cache:
@@ -59,7 +68,7 @@ jobs:
             - pip-cache-0-
       - bash_env
       - save_cache:
-          key: minimal-cmds-0
+          key: minimal-cmds-{{ checksum "/home/circleci/mne-tools/tools/get_minimal_commands.sh" }}
           paths:
             - ~/minimal_cmds
       - run:
@@ -73,8 +82,7 @@ jobs:
       - run:
           name: Check Qt
           command: |
-            wget -q https://raw.githubusercontent.com/mne-tools/mne-tools/main/tools/check_qt_import.sh
-            bash check_qt_import.sh PySide6
+            bash ~/mne-tools/tools/check_qt_import.sh PySide6
       # Look at what we have and fail early if there is some library conflict
       - run:
           name: Check installation
@@ -86,6 +94,7 @@ jobs:
             - project
             - mne_data
             - minimal_cmds
+            - mne-tools
             - .pyenv
 
   cache_ds000117:

--- a/.circleci/setup_bash.sh
+++ b/.circleci/setup_bash.sh
@@ -35,12 +35,16 @@ fi
 echo "export RUN_TESTS=\".circleci/run_dataset_and_copy_files.sh\"" | tee -a "$BASH_ENV"
 echo "export DOWNLOAD_DATA=\"coverage run -m mne_bids_pipeline._download\"" | tee -a "$BASH_ENV"
 
-# Similar CircleCI setup to mne-python (Xvfb, minimal commands, env vars)
-wget -q https://raw.githubusercontent.com/mne-tools/mne-tools/main/tools/setup_xvfb.sh
-bash setup_xvfb.sh
+# Similar CircleCI setup to mne-python (Xvfb, minimal commands, env vars). Cloned
+# rather than fetched script-by-script so that config.yml can hash
+# get_minimal_commands.sh into the cache key; the clone is persisted to the
+# workspace, so only setup_env actually does it.
+if [ ! -d "$HOME/mne-tools" ]; then
+    git clone --depth 1 https://github.com/mne-tools/mne-tools.git "$HOME/mne-tools"
+fi
+bash "$HOME/mne-tools/tools/setup_xvfb.sh"
 sudo apt install -qq tcsh libxft2
-wget -q https://raw.githubusercontent.com/mne-tools/mne-tools/main/tools/get_minimal_commands.sh
-source get_minimal_commands.sh
+source "$HOME/mne-tools/tools/get_minimal_commands.sh"
 mkdir -p ~/mne_data
 echo "set -e" | tee -a "$BASH_ENV"
 echo 'export OPENBLAS_NUM_THREADS=2' | tee -a "$BASH_ENV"

--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -18,6 +18,7 @@
 
 ### :bug: Bug fixes
 
+- Fixed report section ordering: run-specific sections now always appear in run order, even when parallelization across runs finishes them out of order (#1293 by @larsoner)
 - Handle contrasts with too few epochs for cross-validation by saving NaN scores, excluding invalid subject-level results from group statistics, and reporting the effective sample size (#1265 by @viranovskaya)
 - Raise an informative error if [`rest_epochs_duration`][mne_bids_pipeline._config.rest_epochs_duration] is not set for resting-state data and document the parameter (#1272 by @viranovskaya)
 - Fixed bug where [`log_level`][mne_bids_pipeline._config.log_level] was not being applied to the MBPlogger (#1224 by @larsoner)

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -604,6 +604,45 @@ div.accordion-body pre.my-0 code {
 """
     if css not in report.include:
         report.add_custom_css(css=css)
+    # Parallelization over runs adds sections in completion order (gh-845)
+    _sort_run_sections(report)
+
+
+def _run_sort_key(run: str) -> tuple[int, int | str]:
+    """Sort numeric run labels numerically, before any non-numeric ones."""
+    try:
+        return (0, int(run))
+    except ValueError:
+        return (1, run)
+
+
+def _sort_run_sections(report: mne.Report) -> None:
+    """Order run-specific sections by run within each section group.
+
+    Sections that differ only by their ``run-*`` tag gather at the position the
+    first of them holds, sorted by run; everything else stays where it is.
+    """
+    anchors: dict[tuple[str, tuple[str, ...]], int] = dict()
+    keys: list[tuple[int, tuple[int, int | str], int]] = list()
+    titles, all_tags, _ = report.get_contents()
+    for idx, (title, tags) in enumerate(zip(titles, all_tags)):
+        for tag in tags:
+            if tag.startswith("run-"):
+                run = tag.removeprefix("run-")
+                break
+        else:
+            keys.append((idx, (0, 0), idx))
+            continue
+        # No need to disambiguate further: replace= targeting means the pipeline
+        # never reuses a title across sections
+        ident = (
+            title.replace(f"run-{run}", "run"),
+            tuple(sorted(tag for tag in tags if not tag.startswith("run-"))),
+        )
+        keys.append((anchors.setdefault(ident, idx), _run_sort_key(run), idx))
+    order = sorted(range(len(keys)), key=keys.__getitem__)
+    if order != list(range(len(order))):
+        report.reorder(order)
 
 
 def _add_flow_diagram(

--- a/mne_bids_pipeline/tests/test_report.py
+++ b/mne_bids_pipeline/tests/test_report.py
@@ -1,0 +1,42 @@
+"""Test report helpers."""
+
+import mne
+
+from mne_bids_pipeline._report import _sort_run_sections
+
+
+def _titles(report: mne.Report) -> list[str]:
+    return report.get_contents()[0]
+
+
+def test_sort_run_sections() -> None:
+    """Test that run sections sort by run within their group, others stay put."""
+    report = mne.Report(title="sub-01")
+    # Parallel completion order: runs finished 03, 01, 02; unrelated sections mixed
+    # in, plus a second group and a non-numeric run
+    report.add_html("<p/>", title="Data quality", tags=("data-quality",))
+    report.add_html("<p/>", title="Raw: run-03", tags=("raw", "run-03"))
+    report.add_html("<p/>", title="Raw: run-01", tags=("raw", "run-01"))
+    report.add_html("<p/>", title="Events", tags=("events",))
+    report.add_html("<p/>", title="SSP: run-02", tags=("ssp", "run-02"))
+    report.add_html("<p/>", title="Raw: run-02", tags=("raw", "run-02"))
+    report.add_html("<p/>", title="SSP: run-01", tags=("ssp", "run-01"))
+    report.add_html("<p/>", title="Raw: run-noise", tags=("raw", "run-noise"))
+
+    _sort_run_sections(report)
+    assert _titles(report) == [
+        "Data quality",
+        # The raw group gathers where its first member sat, numeric runs first
+        "Raw: run-01",
+        "Raw: run-02",
+        "Raw: run-03",
+        "Raw: run-noise",
+        "Events",
+        "SSP: run-01",
+        "SSP: run-02",
+    ]
+
+    # Already-sorted content is left alone (idempotent)
+    before = _titles(report)
+    _sort_run_sections(report)
+    assert _titles(report) == before

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -11,6 +11,7 @@ from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, TypedDict
 
+import mne
 import pandas as pd
 import pytest
 from h5io import read_hdf5
@@ -20,6 +21,7 @@ from mne_bids_pipeline._config_import import _import_config
 from mne_bids_pipeline._config_utils import _get_ssrt
 from mne_bids_pipeline._download import main as download_main
 from mne_bids_pipeline._main import main
+from mne_bids_pipeline._report import _run_sort_key
 from mne_bids_pipeline.steps.freesurfer import _01_recon_all
 from mne_bids_pipeline.steps.preprocessing._01_data_quality import (
     get_config as get_config_data_quality,
@@ -320,6 +322,21 @@ def test_run(
         # source node's tooltip defines
         assert "&lt;deriv_root&gt; = " in content
         assert "&lt;bids_root&gt;" in content
+        # run sections appear in run order regardless of parallel completion
+        # order (gh-845)
+        report = mne.open_report(report_html_paths[0].with_suffix(".h5"))
+        titles, all_tags, _ = report.get_contents()
+        by_prefix: dict[str, list[str]] = dict()
+        for title, tags in zip(titles, all_tags):
+            for tag in tags:
+                if tag.startswith("run-"):
+                    run = tag.removeprefix("run-")
+                    prefix = title.replace(f"run-{run}", "run-")
+                    by_prefix.setdefault(prefix, []).append(run)
+                    break
+        for prefix, runs in by_prefix.items():
+            keys = [_run_sort_key(run) for run in runs]
+            assert keys == sorted(keys), (prefix, runs)
 
 
 def _make_fake_bids_dataset(


### PR DESCRIPTION
Closes #845

Make report ordering deterministic regardless of parallelization by adding a step before closing the report that enforces a run-number ordering. If run 2 writes its report then run 1 gets the lock and goes to write, it'll reorder to put 1 before 2.

Drafted with Claude Fable 5 and reviewed by me.