### PR TITLE
Nest expensive imports to speed up startup

### DIFF
--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -13,7 +13,6 @@ from inspect import signature
 from types import SimpleNamespace
 from typing import Any
 
-import matplotlib
 import mne
 import numpy as np
 from mne_bids import get_entity_vals
@@ -274,6 +273,8 @@ def _update_with_user_config(
             logger.info(**gen_log_kwargs(message=msg, **log_kwargs))
         config.on_error = "debug"
     else:
+        import matplotlib
+
         matplotlib.use("Agg")  # do not open any window  # noqa
     if config.on_error == "debug":
         if config.n_jobs != 1:

--- a/mne_bids_pipeline/_io.py
+++ b/mne_bids_pipeline/_io.py
@@ -2,7 +2,6 @@
 
 from typing import Any
 
-import json_tricks
 from mne_bids import BIDSPath
 
 from .typing import PathLike
@@ -14,10 +13,14 @@ def _write_json(
     *,
     indent: int | None = None,
 ) -> None:
+    import json_tricks
+
     with open(fname, "w", encoding="utf-8") as f:
         json_tricks.dump(data, fp=f, allow_nan=True, sort_keys=False, indent=indent)
 
 
 def _read_json(fname: PathLike | BIDSPath) -> Any:
+    import json_tricks
+
     with open(fname, encoding="utf-8") as f:
         return json_tricks.load(f)

--- a/mne_bids_pipeline/_logging.py
+++ b/mne_bids_pipeline/_logging.py
@@ -7,11 +7,13 @@ import logging
 import os
 import sys
 from collections.abc import Generator, Iterable, Sequence
-
-import rich.console
-import rich.theme
+from typing import TYPE_CHECKING
 
 from .typing import LogKwargsT
+
+if TYPE_CHECKING:
+    # rich is ~10 ms to import and is only needed once something is logged
+    import rich.console
 
 
 class _MBPLogger:
@@ -22,7 +24,10 @@ class _MBPLogger:
     # Do lazy instantiation of _console so that pytest's output capture
     # mechanics don't get messed up
     @property
-    def _console(self) -> rich.console.Console:
+    def _console(self) -> "rich.console.Console":
+        import rich.console
+        import rich.theme
+
         if isinstance(self.__console, rich.console.Console):
             return self.__console
 

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -14,10 +14,8 @@ import traceback
 import warnings
 from collections.abc import Callable, Iterable, Mapping
 from types import SimpleNamespace
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
-import json_tricks
-import pandas as pd
 from filelock import FileLock
 from joblib import Memory
 from mne_bids import BIDSPath
@@ -26,6 +24,9 @@ from ._config_utils import _get_step_title
 from ._flow import FlowEntryT, _write_flow_entry
 from ._logging import _is_testing, gen_log_kwargs, logger
 from .typing import InFilesPathT, InFilesT, OutFilesT
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def failsafe_run(
@@ -39,7 +40,7 @@ def failsafe_run(
         @functools.wraps(func)  # Preserve "identity" of original function
         def __mne_bids_pipeline_failsafe_wrapper__(
             *args: list[Any], **kwargs: dict[str, Any]
-        ) -> pd.Series | None:
+        ) -> "pd.Series | None":
             __mne_bids_pipeline_step__ = pathlib.Path(inspect.getfile(func))  # noqa
             exec_params = kwargs["exec_params"]
             on_error = exec_params.on_error
@@ -110,6 +111,8 @@ def failsafe_run(
                     )
             if not did_run:
                 return None  # no log info to return
+            import pandas as pd
+
             log_info = pd.concat(
                 [
                     pd.Series(kwargs, dtype=object),
@@ -459,10 +462,13 @@ def _ignore_warnings(ignore_warnings: Iterable[str] | str) -> Iterable[None]:
         yield
 
 
-def save_logs(*, config: SimpleNamespace, logs: Iterable[pd.Series | None]) -> None:
+def save_logs(*, config: SimpleNamespace, logs: "Iterable[pd.Series | None]") -> None:
     usable_logs = [log for log in logs if log is not None]
     if not usable_logs:
         return
+    import json_tricks
+    import pandas as pd
+
     all_tasks = "+".join(map(str, config.all_tasks))
     fname = config.deriv_root / f"task-{all_tasks}_log.xlsx"
 


### PR DESCRIPTION
No need for changelog update. Toward https://github.com/mne-tools/mne-bids-pipeline/issues/675. Takes `mne_bids_pipeline --help` from ~1200 ms to ~900 ms.

Investigated and drafted changes with Claude Opus 5 and I reviewed changes.