### PR TITLE
Make warning survivable

### DIFF
--- a/mne_bids_pipeline/tests/conftest.py
+++ b/mne_bids_pipeline/tests/conftest.py
@@ -52,6 +52,9 @@ def pytest_configure(config: pytest.Config) -> None:
     ignore:The behavior of DataFrame concatenation with empty.*:FutureWarning
     # joblib on Windows sometimes
     ignore:Persisting input arguments took.*:UserWarning
+    # loky raises this in its manager thread, where an error kills the thread
+    # and deadlocks the pool, so it must stay a warning
+    always:A worker was restarted while some jobs were given.*:UserWarning
     # matplotlib needs to update
     ignore:Conversion of an array with ndim.*:DeprecationWarning
     # scipy


### PR DESCRIPTION
In tests, it's possible to hit a loky warning, and this warning being treated as an error deadlocks the run. Avoid that by allowlisting the warning. I'll also push to https://github.com/joblib/loky/pull/641 to make loky itself more robust to this.