### PR TITLE
Add report_image_format option

### DIFF
--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -7,6 +7,8 @@
 - Added [`ignore_warnings`][mne_bids_pipeline._config.ignore_warnings] config option to allow users to specify warnings to ignore when calling `read_raw_bids` (#1224 by @larsoner)
 - Added tracking of the current step in the terminal title (#1266 by @larsoner)
 - Added a "Pipeline flow" section to the reports with an auto-generated diagram of the steps that ran for a subject and the files they passed to one another (#1291 by @larsoner)
+- Added [`report_image_format`][mne_bids_pipeline._config.report_image_format] config option to control the encoding of images embedded in reports, e.g. `dict(raster="png")` to trade larger reports for faster processing (#1300 by @larsoner)
+- Report HDF5 and HTML files are no longer rewritten when a step did not modify the report (requires MNE-Python ≥ 1.13; older versions keep the previous always-save behavior) (#1300 by @larsoner)
 
 ### :warning: Behavior changes
 
@@ -18,6 +20,7 @@
 
 ### :bug: Bug fixes
 
+- Fixed spurious recomputation of the `init` steps on every run: the subject report was declared as a cached output but is legitimately rewritten by later steps, so its modification time always mismatched (#1300 by @larsoner)
 - Fixed report section ordering: run-specific sections now always appear in run order, even when parallelization across runs finishes them out of order (#1293 by @larsoner)
 - Handle contrasts with too few epochs for cross-validation by saving NaN scores, excluding invalid subject-level results from group statistics, and reporting the effective sample size (#1265 by @viranovskaya)
 - Raise an informative error if [`rest_epochs_duration`][mne_bids_pipeline._config.rest_epochs_duration] is not set for resting-state data and document the parameter (#1272 by @viranovskaya)

--- a/docs/source/settings/gen_settings.py
+++ b/docs/source/settings/gen_settings.py
@@ -139,10 +139,9 @@ assign_re = re.compile(
     "(?:"  #       then the rest of the line can be (in a non-capturing group):
     ".+ = .+"  #      1. a standard assignment
     "|"  #            2. or
-    r"Literal\["  #   3. the start of a multiline type annotation like "a: Literal["
+    r"\w+\["  #       3. the start of a multiline subscripted type annotation
+    #                    like "a: Literal[", "a: Annotated[", or "a: dict["
     "|"  #            4. or
-    r"Annotated\["  # 5. the start of a multiline annotated type like "a: Annotated["
-    "|"  #            6. or
     r"\("  #          7. the start of a multiline 3.9+ type annotation like "a: ("
     ")"  #        Then the end of our group
     "$",  #       and immediately the end of the line.

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -2531,6 +2531,24 @@ in the report. If `None`, it defaults to the current default in MNE-Python.
     ```
 """
 
+report_image_format: dict[
+    Literal["raster", "vector"], Literal["webp", "png", "svg"]
+] = dict(raster="webp", vector="svg")
+"""
+The formats used to store images embedded in the reports. The `"raster"` entry applies
+to inherently pixel-based content (topographic map sliders, ICA properties, epochs
+images, and similar) and can be `"webp"` or `"png"` — WebP produces the smallest
+reports, but is considerably slower to encode than PNG, which can make a difference on
+report-heavy runs. The `"vector"` entry applies to line-art figures and can
+additionally be `"svg"`. Missing keys keep their default values.
+
+???+ example "Example"
+    Trade larger reports for faster processing:
+    ```python
+    report_image_format = dict(raster="png")
+    ```
+"""
+
 report_add_epochs_image_kwargs: dict[str, Any] | None = None
 """
 Specifies the limits for the color scales of the epochs_image in the report.

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -296,6 +296,16 @@ def _check_config(config: SimpleNamespace, config_path: PathLike | None) -> None
     # Eventually all of these could be pydantic-validated, but for now we'll
     # just change the ones that are easy
 
+    # fill in missing keys; per-key value constraints are beyond the dict annotation
+    config.report_image_format = (
+        dict(raster="webp", vector="svg") | config.report_image_format
+    )
+    if config.report_image_format["raster"] == "svg":
+        raise ConfigError(
+            'report_image_format["raster"] cannot be "svg"; pixel-based report '
+            'content (sliders, topographic maps, ...) requires "webp" or "png".'
+        )
+
     config.bids_root.resolve(strict=True)
     if config.bids_root == config.deriv_root:
         raise ValueError(
@@ -573,6 +583,7 @@ def _default_factory(key: str, val: Any) -> Any:
             "channel noise": 0.3,
             "other": 0.3,
         },  # ica_class_thresholds
+        {"raster": "webp", "vector": "svg"},  # report_image_format
     ]
 
     def default_factory() -> Any:

--- a/mne_bids_pipeline/_config_utils.py
+++ b/mne_bids_pipeline/_config_utils.py
@@ -965,6 +965,7 @@ def _bids_kwargs(*, config: SimpleNamespace) -> dict[str, str | None]:
         bids_root=config.bids_root,
         deriv_root=config.deriv_root,
         all_tasks=config.all_tasks,  # we compute this once and store it for brevity
+        report_image_format=config.report_image_format,  # _open_report needs it
     )
 
 

--- a/mne_bids_pipeline/_report.py
+++ b/mne_bids_pipeline/_report.py
@@ -85,26 +85,33 @@ def _open_report(
                 "Perhaps you need to delete it? Got error:\n\n"
                 f"{indent(traceback.format_exc(), '    ')}"
             ) from None
+        # a report created before a config change would otherwise keep its old format
+        report.image_format = cfg.report_image_format["raster"]
         try:
             yield report
         finally:
-            try:
-                _finalize(
-                    cfg=cfg,
-                    report=report,
-                    exec_params=exec_params,
-                    subject=subject,
-                    session=session,
-                    run=run,
-                    task=task,
-                )
-            except Exception as exc:
-                logger.warning(f"Failed: {exc}")
-            fname_report_html = fname_report.with_suffix(".html")
-            msg = f"Saving {name}: {_linkfile(fname_report_html)}"
-            logger.info(**gen_log_kwargs(message=msg), sanitize=False)
-            report.save(fname_report, overwrite=True)
-            report.save(fname_report_html, overwrite=True, open_browser=False)
+            # MNE < 1.13 has no unsaved_changes, so fall back to always saving there
+            if getattr(report, "unsaved_changes", True):
+                try:
+                    _finalize(
+                        cfg=cfg,
+                        report=report,
+                        exec_params=exec_params,
+                        subject=subject,
+                        session=session,
+                        run=run,
+                        task=task,
+                    )
+                except Exception as exc:
+                    logger.warning(f"Failed: {exc}")
+                fname_report_html = fname_report.with_suffix(".html")
+                msg = f"Saving {name}: {_linkfile(fname_report_html)}"
+                logger.info(**gen_log_kwargs(message=msg), sanitize=False)
+                report.save(fname_report, overwrite=True)
+                report.save(fname_report_html, overwrite=True, open_browser=False)
+            else:
+                msg = f"Not saving unmodified {name}"
+                logger.debug(**gen_log_kwargs(message=msg))
 
 
 # def plot_full_epochs_decoding_scores(
@@ -525,7 +532,12 @@ def _gen_empty_report(
     if session is not None:
         title += f", ses-{session}"
 
-    report = mne.Report(title=title, raw_psd=True, verbose=False)
+    report = mne.Report(
+        title=title,
+        raw_psd=True,
+        image_format=cfg.report_image_format["raster"],
+        verbose=False,
+    )
     return report
 
 

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -300,6 +300,8 @@ class ConditionalStepMemory:
                             emoji = "✖️"
                             bad_out_files = True
                             break
+                        if this_hash == "exists":  # existence-only, see _prep_out_files
+                            continue
                         got_hash = hash_(key, fname, kind="out")[1]
                         if this_hash != got_hash:
                             msg = (
@@ -588,6 +590,7 @@ def _prep_out_files(
     exec_params: SimpleNamespace,
     out_files: InFilesT,
     check_relative: pathlib.Path | None = None,
+    exist_only: tuple[str, ...] = (),
 ) -> OutFilesT:
     for key, fname in out_files.items():
         assert isinstance(fname, BIDSPath), (
@@ -599,6 +602,7 @@ def _prep_out_files(
         exec_params=exec_params,
         out_files=out_files,
         check_relative=check_relative,
+        exist_only=exist_only,
     )
 
 
@@ -607,6 +611,7 @@ def _prep_out_files_path(
     exec_params: SimpleNamespace,
     out_files: InFilesPathT,
     check_relative: pathlib.Path | None = None,
+    exist_only: tuple[str, ...] = (),
 ) -> OutFilesT:
     if check_relative is None:
         check_relative = exec_params.deriv_root
@@ -620,12 +625,16 @@ def _prep_out_files_path(
                 f"Output BIDSPath not relative to expected root {check_relative}:"
                 f"\n{fname}"
             )
-        out_files[key] = _path_to_str_hash(
-            key,
-            fname,
-            method=exec_params.memory_file_method,
-            kind="out",
-        )
+        if key in exist_only:
+            # freely rewritten by later steps (e.g. reports): only require existence
+            out_files[key] = (str(fname), "exists")
+        else:
+            out_files[key] = _path_to_str_hash(
+                key,
+                fname,
+                method=exec_params.memory_file_method,
+                kind="out",
+            )
     return out_files
 
 

--- a/mne_bids_pipeline/steps/init/_01_init_derivatives_dir.py
+++ b/mne_bids_pipeline/steps/init/_01_init_derivatives_dir.py
@@ -89,7 +89,10 @@ def init_subject_dirs(
             session=session,
         ):
             pass
-    return _prep_out_files(exec_params=exec_params, out_files=out_files)
+    # later steps rewrite the report, so its mtime must not gate this step's cache
+    return _prep_out_files(
+        exec_params=exec_params, out_files=out_files, exist_only=("report",)
+    )
 
 
 def get_config_init_dataset(

--- a/mne_bids_pipeline/steps/preprocessing/_02_head_pos.py
+++ b/mne_bids_pipeline/steps/preprocessing/_02_head_pos.py
@@ -138,7 +138,7 @@ def run_head_pos(
         report.add_figure(
             fig=fig,
             title=f"cHPI SNR{prefix}",
-            image_format="svg",
+            image_format=cfg.report_image_format["vector"],
             section=section,
             tags=tags,
             replace=True,
@@ -148,7 +148,7 @@ def run_head_pos(
         report.add_figure(
             fig=fig,
             title=f"Head positions{prefix}",
-            image_format="svg",
+            image_format=cfg.report_image_format["vector"],
             section=section,
             tags=tags,
             replace=True,

--- a/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
+++ b/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
@@ -366,3 +366,5 @@ elif task == "P3":
     cluster_permutation_p_threshold = 0.2  # Only for testing!
 else:
     raise RuntimeError(f"Task {task} not currently supported")
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_MNE_funloc_data.py
+++ b/mne_bids_pipeline/tests/configs/config_MNE_funloc_data.py
@@ -46,3 +46,5 @@ cov_rank = dict(tol_kind="relative", tol=1e-4)
 
 # contrasts
 # contrasts = [("auditory", "visual")]
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_MNE_phantom_KIT_data.py
+++ b/mne_bids_pipeline/tests/configs/config_MNE_phantom_KIT_data.py
@@ -24,3 +24,5 @@ conditions = ["dip01", "dip13", "dip25", "dip37", "dip49"]
 
 # Decoding
 decode = True  # should be very good performance
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds000117.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000117.py
@@ -47,3 +47,5 @@ decode = True
 decoding_time_generalization = True
 
 run_source_estimation = False
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds000246.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000246.py
@@ -30,3 +30,5 @@ dask_worker_memory_limit = "3G" if sys.platform == "darwin" else "2G"
 dask_temp_dir = "./.dask-worker-space"
 dask_open_dashboard = True
 n_jobs = 2
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds000247.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000247.py
@@ -36,3 +36,5 @@ time_frequency_freq_min = 1.0
 time_frequency_freq_max = 30.0
 time_frequency_cycles = np.arange(time_frequency_freq_min, time_frequency_freq_max) / 4
 time_frequency_subtract_evoked = True
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds000248_FLASH_BEM.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000248_FLASH_BEM.py
@@ -11,3 +11,5 @@ ch_types = ["meg"]
 
 bem_mri_images = "FLASH"
 recreate_bem = True
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds000248_T1_BEM.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000248_T1_BEM.py
@@ -12,3 +12,5 @@ ch_types = ["meg"]
 bem_mri_images = "T1"
 recreate_bem = True
 freesurfer_verbose = True  # Prevent the CI from canceling the job prematurely
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds000248_base.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000248_base.py
@@ -54,3 +54,6 @@ def mri_t1_path_generator(bids_path: mne_bids.BIDSPath) -> mne_bids.BIDSPath:
     """Return the path to a T1 image."""
     # don't really do any modifications – just for testing!
     return bids_path
+
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds000248_coreg_surfaces.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000248_coreg_surfaces.py
@@ -13,3 +13,5 @@ conditions = ["Auditory"]
 ch_types = ["meg"]
 
 recreate_scalp_surface = True
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds000248_ica.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000248_ica.py
@@ -25,3 +25,5 @@ ica_n_components = 0.8
 ica_max_iterations = 500
 
 interactive = False
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds000248_no_mri.py
+++ b/mne_bids_pipeline/tests/configs/config_ds000248_no_mri.py
@@ -16,3 +16,5 @@ process_raw_clean = False
 
 use_template_mri = "fsaverage"
 adjust_coreg = True
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds001810.py
+++ b/mne_bids_pipeline/tests/configs/config_ds001810.py
@@ -67,3 +67,5 @@ epochs_custom_metadata = {
         }
     ),
 }  # number of rows are hand-set
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds001971.py
+++ b/mne_bids_pipeline/tests/configs/config_ds001971.py
@@ -47,5 +47,3 @@ decoding_csp_times = [-0.19, 0.0, 0.2, 0.4]
 
 # Just to test that MD5 works
 memory_file_method = "hash"
-
-report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds001971.py
+++ b/mne_bids_pipeline/tests/configs/config_ds001971.py
@@ -47,3 +47,5 @@ decoding_csp_times = [-0.19, 0.0, 0.2, 0.4]
 
 # Just to test that MD5 works
 memory_file_method = "hash"
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds003104.py
+++ b/mne_bids_pipeline/tests/configs/config_ds003104.py
@@ -9,3 +9,5 @@ subjects_dir = f"{bids_root}/derivatives/freesurfer/subjects"
 
 conditions = ["somato_event1"]
 ch_types = ["meg"]
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds003392.py
+++ b/mne_bids_pipeline/tests/configs/config_ds003392.py
@@ -55,3 +55,5 @@ decoding_csp_freqs = {
 
 # Noise estimation
 noise_cov = "emptyroom"
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds003775.py
+++ b/mne_bids_pipeline/tests/configs/config_ds003775.py
@@ -42,3 +42,5 @@ dask_open_dashboard = True
 log_level = "info"
 
 n_jobs = 1
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds004107.py
+++ b/mne_bids_pipeline/tests/configs/config_ds004107.py
@@ -24,3 +24,5 @@ crop_runs = (0, 120)  # to speed up computations
 spatial_filter = "ssp"
 l_freq = 1.0
 h_freq = 40.0
+
+report_image_format = dict(raster="png")

--- a/mne_bids_pipeline/tests/configs/config_ds004229.py
+++ b/mne_bids_pipeline/tests/configs/config_ds004229.py
@@ -79,3 +79,5 @@ decode = False
 
 # Noise estimation
 noise_cov = "emptyroom"
+
+report_image_format = dict(raster="png")


### PR DESCRIPTION
This is a seemingly trivial option... add a `report_image_format` option.

It turns out `webp` compression is a non-trivial amount of time in our test suite (like over 20% for some jobs locally). If it's that way in our test suite, it's possible it is in some people's pipelines, so let's add it as an option for people. And then let's use it in most tests where a few extra MB of a report is worth having our run take less time. (And the slight increase in size in the HTMLs landing in our docs are acceptable, too, I think.)

Also tacks on a report efficiency enabled by https://github.com/mne-tools/mne-python/pull/14261