### PR TITLE
ENH: Add support for SLURM

### DIFF
--- a/.circleci/cgroup.conf
+++ b/.circleci/cgroup.conf
@@ -1,0 +1,2 @@
+# No resource confinement in CI; "disabled" needs slurm >= 24.05 (26.04 has 25.11)
+CgroupPlugin=disabled

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -914,8 +914,17 @@ jobs:
           command: |
             google-chrome --version
       - run:
-          name: test ERP CORE N400
+          name: Start single-node SLURM
+          command: ./.circleci/setup_slurm.sh
+      - run:
+          name: test ERP CORE N400 (via SLURM-backed dask)
           command: $RUN_TESTS ERP_CORE_N400
+          environment:
+            MNE_BIDS_PIPELINE_TEST_DASK_CLUSTER: slurm
+      - run:
+          name: SLURM worker job logs
+          command: sinfo && ls -l slurm-*.out && tail -n2 slurm-*.out
+          when: always
       - *codecov_upload
       - store_test_results:
           path: ./test-results

--- a/.circleci/setup_slurm.sh
+++ b/.circleci/setup_slurm.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Single-node SLURM for CircleCI (Linux VM executor; also works without systemd).
+# Local repro (from the repo root):
+#   docker run --rm -v "$PWD/.circleci":/cc:ro ubuntu:26.04 bash -c 'apt-get update -qq \
+#     && apt-get install -qq -y sudo procps >/dev/null && useradd -m ci \
+#     && echo "ci ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/ci && runuser -u ci /cc/setup_slurm.sh'
+set -eo pipefail
+
+CPUS=$(nproc)  # VM executor nproc is the real vCPU count
+MEM=$(( $(free -m | awk '/Mem:/{print $2}') - 512 ))
+HOST=$(hostname)
+
+sudo apt-get update -qq
+sudo apt-get install -y -qq --no-install-recommends slurm-wlm munge
+sudo mkdir -p /var/spool/slurmctld /var/spool/slurmd /var/log/slurm /run/munge /etc/munge
+# the packaged slurmctld.service runs as User=slurm, matching SlurmUser in slurm.conf
+sudo chown slurm:slurm /var/spool/slurmctld /var/log/slurm
+# On a systemd VM the munge package generates a key and starts munged itself
+if ! pgrep -x munged >/dev/null; then
+    sudo dd if=/dev/urandom bs=1 count=1024 of=/etc/munge/munge.key status=none
+    sudo chown -R munge:munge /etc/munge /run/munge
+    sudo chmod 0400 /etc/munge/munge.key
+    sudo runuser -u munge -- munged
+fi
+sed -e "s/@HOST@/$HOST/g" -e "s/@CPUS@/$CPUS/g" -e "s/@MEM@/$MEM/g" \
+    "$(dirname "$0")/slurm.conf" | sudo tee /etc/slurm/slurm.conf >/dev/null
+sudo cp "$(dirname "$0")/cgroup.conf" /etc/slurm/cgroup.conf
+if [ -d /run/systemd/system ]; then
+    sudo systemctl restart slurmctld slurmd  # restart picks up our conf if autostarted
+else  # containers (local debugging) have no systemd
+    sudo slurmctld
+    sudo slurmd
+fi
+for _ in $(seq 30); do
+  [[ "$(sinfo -h -o %T 2>/dev/null)" == "idle" ]] && break
+  sleep 1
+done
+sinfo
+srun -N1 true  # fail loudly now rather than mid-test

--- a/.circleci/slurm.conf
+++ b/.circleci/slurm.conf
@@ -1,0 +1,16 @@
+# Single-node cluster for CI; @HOST@/@CPUS@/@MEM@ filled in by setup_slurm.sh
+ClusterName=ci
+SlurmctldHost=@HOST@
+SlurmUser=slurm
+AuthType=auth/munge
+StateSaveLocation=/var/spool/slurmctld
+SlurmdSpoolDir=/var/spool/slurmd
+ProctrackType=proctrack/linuxproc
+TaskPlugin=task/none
+ReturnToService=2
+SelectType=select/cons_tres
+SelectTypeParameters=CR_Core_Memory
+SlurmctldLogFile=/var/log/slurm/slurmctld.log
+SlurmdLogFile=/var/log/slurm/slurmd.log
+NodeName=@HOST@ CPUs=@CPUS@ RealMemory=@MEM@ State=UNKNOWN
+PartitionName=ci Nodes=ALL Default=YES MaxTime=INFINITE State=UP

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Structure (BIDS)](https://bids.neuroimaging.io/).
 * 👣 Data processing as a sequence of standard processing steps.
 * ⏩ Steps are cached to avoid unnecessary recomputation.
 * ⏏️ Data can be "ejected" from the pipeline at any stage. No lock-in!
-* ☁️ Runs on your laptop, on a powerful server, or on a high-performance cluster via Dask.
+* ☁️ Runs on your laptop, on a powerful server, or on a high-performance (e.g., SLURM) cluster via Dask.
 
 <!--features-list-end-->
 

--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -10,6 +10,7 @@
 - Added [`report_image_format`][mne_bids_pipeline._config.report_image_format] config option to control the encoding of images embedded in reports, e.g. `dict(raster="png")` to trade larger reports for faster processing (#1300 by @larsoner)
 - Report HDF5 and HTML files are no longer rewritten when a step did not modify the report (requires MNE-Python ≥ 1.13; older versions keep the previous always-save behavior) (#1300 by @larsoner)
 - [`report_image_format`][mne_bids_pipeline._config.report_image_format] now accepts `dict(raster="webp-lossy")`, which encodes about as fast as PNG while producing reports roughly 3× smaller (requires MNE-Python ≥ 1.13) (#1304 by @larsoner)
+- Added the [`dask_cluster`][mne_bids_pipeline._config.dask_cluster] option to attach to an external Dask cluster, e.g. on an HPC system via [dask-jobqueue](https://jobqueue.dask.org) (SLURM, PBS, SGE, …), with [`dask_worker_startup_timeout`][mne_bids_pipeline._config.dask_worker_startup_timeout] controlling how long to wait for queued workers; step log messages now also reach each Dask worker's log (e.g., the SLURM job log) (#1307 by @larsoner)
 
 ### :warning: Behavior changes
 

--- a/docs/source/examples/gen_examples.py
+++ b/docs/source/examples/gen_examples.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import logging
+import os
 import shutil
 import sys
 from collections import defaultdict
@@ -25,8 +26,10 @@ root = Path(mne_bids_pipeline.__file__).parent.resolve(strict=True)
 logger = logging.getLogger()
 
 
-def _bool_to_icon(x: bool | Iterable[Any]) -> str:
-    if x:
+def _bool_to_icon(x: bool | str | Iterable[Any]) -> str:
+    if isinstance(x, str):  # e.g. Dask: "Local" or "SLURM"
+        return x
+    elif x:
         return "✅"
     else:
         return "❌"
@@ -53,6 +56,8 @@ def _gen_demonstrated_funcs(example_config_path: Path) -> dict[str, bool]:
     if example_config_path.stem == "config_ERP_CORE":
         tasks[:] = ["N400", "ERN", "LRP", "MMN", "N2pc", "N170", "P3"]
     for task in tasks:
+        # activate config_ERP_CORE.py's SLURM gate so the table can show it
+        os.environ["MNE_BIDS_PIPELINE_TEST_DASK_CLUSTER"] = "slurm"
         with _task_context(task), _log_context(logging.ERROR):
             config = _import_config(
                 config_path=example_config_path,
@@ -85,6 +90,13 @@ def _gen_demonstrated_funcs(example_config_path: Path) -> dict[str, bool]:
         funcs["Time-frequency analysis"] = config.time_frequency_conditions
         funcs["BEM surface creation"] = config.recreate_bem
         funcs["Template MRI"] = config.use_template_mri
+        key = "Dask"
+        ep = config.exec_params
+        if ep.parallel_backend == "dask" and ep.n_jobs > 1:
+            this_dask: bool | str = "SLURM" if ep.dask_cluster is not None else "Local"
+        else:
+            this_dask = False
+        funcs[key] = funcs[key] or this_dask
     return funcs
 
 

--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -2648,6 +2648,40 @@ dask_worker_memory_limit: str = "10G"
 The maximum amount of RAM per Dask worker.
 """
 
+dask_worker_startup_timeout: float = 3600
+"""
+How long to wait (in seconds) for workers to come up before giving up, e.g. while
+[`dask_cluster`][mne_bids_pipeline._config.dask_cluster] jobs sit in the batch queue.
+Only used when `dask_cluster` is set.
+"""
+
+dask_cluster: str | Callable[[], Any] | None = None
+"""
+Attach to an external Dask cluster instead of starting workers locally, e.g., on an
+HPC system via [dask-jobqueue](https://jobqueue.dask.org). Either the address of a
+running scheduler (e.g., `"tcp://10.0.0.1:8786"`), or a callable that returns a
+[Dask cluster object](https://distributed.dask.org/en/stable/api.html#cluster) (or
+anything accepted by `distributed.Client`):
+
+```python
+def dask_cluster():
+    from dask_jobqueue import SLURMCluster
+
+    cluster = SLURMCluster(queue="cpu", cores=8, memory="32GB", walltime="02:00:00")
+    cluster.scale(jobs=4)  # or cluster.adapt(maximum_jobs=8)
+    return cluster
+```
+
+If the callable returns a cluster with no workers requested, the pipeline calls
+`cluster.scale(n_jobs)`. Compute nodes must share the filesystem holding
+[`bids_root`][mne_bids_pipeline._config.bids_root] and
+[`deriv_root`][mne_bids_pipeline._config.deriv_root] and have the same Python
+environment. Ignored if `parallel_backend` is not `'dask'`;
+[`dask_worker_memory_limit`][mne_bids_pipeline._config.dask_worker_memory_limit] and
+[`dask_temp_dir`][mne_bids_pipeline._config.dask_temp_dir] are then also ignored
+(configure these on the cluster instead).
+"""
+
 # %%
 # # Logging
 #

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -109,6 +109,8 @@ def _import_config(
         "dask_temp_dir",
         "dask_worker_memory_limit",
         "dask_open_dashboard",
+        "dask_cluster",
+        "dask_worker_startup_timeout",
         # Interaction
         "on_error",
         "interactive",

--- a/mne_bids_pipeline/_docs.py
+++ b/mne_bids_pipeline/_docs.py
@@ -24,6 +24,8 @@ _EXECUTION_OPTIONS = (
     "parallel_backend",
     "dask_open_dashboard",
     "dask_temp_dir",
+    "dask_cluster",
+    "dask_worker_startup_timeout",
     "dask_worker_memory_limit",
     "log_level",
     "mne_log_level",

--- a/mne_bids_pipeline/_logging.py
+++ b/mne_bids_pipeline/_logging.py
@@ -3,17 +3,35 @@
 import contextlib
 import datetime
 import inspect
+import io
 import logging
 import os
 import sys
 from collections.abc import Generator, Iterable, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TextIO
 
 from .typing import LogKwargsT
 
 if TYPE_CHECKING:
     # rich is ~10 ms to import and is only needed once something is logged
     import rich.console
+
+
+def _rich_safe_stdout() -> TextIO | None:
+    """Get a usable stdout, e.g. the job log of a dask (SLURM) worker.
+
+    None means "resolve ``sys.stdout`` at write time", which is what rich does by
+    default and what pytest's capturing needs.
+    """
+    stream: TextIO | None = sys.stdout
+    if stream is None:  # rich would silently write to its NULL_FILE
+        return sys.stderr
+    if isinstance(stream, io.TextIOWrapper):
+        # Flush per line so progress shows up in redirected logs, and don't let our
+        # emoji kill a worker running in a non-UTF-8 locale
+        with contextlib.suppress(Exception):
+            stream.reconfigure(line_buffering=True, errors="backslashreplace")
+    return None
 
 
 class _MBPLogger:
@@ -55,6 +73,7 @@ class _MBPLogger:
             )
         )
         self.__console = rich.console.Console(
+            file=_rich_safe_stdout(),
             soft_wrap=True,
             force_terminal=force_terminal,
             legacy_windows=legacy_windows,

--- a/mne_bids_pipeline/_parallel.py
+++ b/mne_bids_pipeline/_parallel.py
@@ -1,14 +1,16 @@
 """Parallelization."""
 
+import contextlib
 import functools
+import time
 import warnings
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any, Literal
 
 import joblib
+from mne.utils import _pl, use_log_level
 from mne.utils import logger as mne_logger
-from mne.utils import use_log_level
 
 from ._logging import _is_testing, gen_log_kwargs, logger
 
@@ -45,6 +47,12 @@ def setup_dask_client(*, exec_params: SimpleNamespace) -> None:
         return
 
     n_workers = get_n_jobs(exec_params=exec_params)
+    if exec_params.dask_cluster is not None:
+        dask_client = _external_dask_client(
+            exec_params=exec_params, n_workers=n_workers
+        )
+        return
+
     msg = f"Dask initializing with {n_workers} workers …"
     logger.info(**gen_log_kwargs(message=msg, emoji="👾"))
 
@@ -87,6 +95,50 @@ def setup_dask_client(*, exec_params: SimpleNamespace) -> None:
 
     # Update global variable
     dask_client = client
+
+
+def _external_dask_client(*, exec_params: SimpleNamespace, n_workers: int) -> Any:
+    from dask.distributed import Client
+
+    cluster = exec_params.dask_cluster
+    if callable(cluster):
+        cluster = cluster()
+        # workers not requested (e.g., SLURMCluster before scale/adapt)
+        if not getattr(cluster, "worker_spec", None) and hasattr(cluster, "scale"):
+            cluster.scale(n_workers)
+    what = cluster if isinstance(cluster, str) else type(cluster).__name__
+    msg = f"Dask connecting to external cluster {what} …"
+    logger.info(**gen_log_kwargs(message=msg, emoji="👾"))
+    client = Client(cluster, name="mne-bids-pipeline")  # type: ignore[no-untyped-call]
+    # joblib runs everything in the driver if only 1 worker core has been granted by
+    # the time a step starts, so wait for the workers we asked for (adaptive clusters
+    # start with an empty spec and are left to joblib's probe task)
+    n_requested = len(getattr(cluster, "worker_spec", ()) or ())
+    if n_requested:
+        # log every minute so a long queue wait doesn't look like a hang
+        timeout = exec_params.dask_worker_startup_timeout
+        deadline = time.monotonic() + timeout
+
+        def _n_up() -> int:
+            return len(client.scheduler_info()["workers"])  # type: ignore[no-untyped-call]
+
+        while (step_timeout := min(60.0, deadline - time.monotonic())) > 0:
+            msg = f"Waiting for {n_requested} worker{_pl(n_requested)} ({_n_up()} up) …"
+            logger.info(**gen_log_kwargs(message=msg, emoji="⏳️"))
+            with contextlib.suppress(TimeoutError):
+                client.wait_for_workers(n_workers=n_requested, timeout=step_timeout)
+            if _n_up() >= n_requested:  # checked last so `else` really means timeout
+                break
+        else:
+            raise TimeoutError(
+                f"Only {_n_up()}/{n_requested} Dask workers started within "
+                f"dask_worker_startup_timeout={timeout} s; increase it if your "
+                "queue is slow, or check the cluster's worker job logs"
+            )
+    dashboard_url = client.dashboard_link
+    msg = f"Dask client dashboard: [link={dashboard_url}]{dashboard_url}[/link]"
+    logger.info(**gen_log_kwargs(message=msg, emoji="🌎"))
+    return client
 
 
 def get_parallel_backend_name(
@@ -137,6 +189,9 @@ def get_parallel_backend(exec_params: SimpleNamespace) -> joblib.parallel_backen
         kwargs["inner_max_num_threads"] = 1
     else:
         setup_dask_client(exec_params=exec_params)
+        if exec_params.dask_cluster is not None:
+            # queued jobs can take a while to start (joblib default is 10 s)
+            kwargs["wait_for_workers_timeout"] = exec_params.dask_worker_startup_timeout
 
     return joblib.parallel_backend(backend, **kwargs)
 

--- a/mne_bids_pipeline/_run.py
+++ b/mne_bids_pipeline/_run.py
@@ -508,6 +508,10 @@ def save_logs(*, config: SimpleNamespace, logs: "Iterable[pd.Series | None]") ->
         assert isinstance(config, SimpleNamespace), type(config)
         cf_dict = dict()
         for key, val in config.__dict__.items():
+            if isinstance(val, SimpleNamespace):  # exec_params, e.g., dask_cluster
+                val = SimpleNamespace(
+                    **{k: _sanitize_callable(v) for k, v in val.__dict__.items()}
+                )
             # We need to be careful about functions, json_tricks does not work with them
             if inspect.isfunction(val):
                 new_val = ""

--- a/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
+++ b/mne_bids_pipeline/tests/configs/config_ERP_CORE.py
@@ -27,6 +27,7 @@ components from a total of 6 experimental tasks:
 """
 
 import argparse
+import os
 import sys
 
 import mne
@@ -105,6 +106,23 @@ on_rename_missing_events = "ignore"
 parallel_backend = "dask"
 dask_worker_memory_limit = "2.5G"
 n_jobs = 4
+
+# In CI we farm the workers out through a real SLURM scheduler (see the
+# test_ERP_CORE_N400 CircleCI job); this is also how you would run on an HPC system.
+# Without the env var set, Dask starts local workers as usual.
+if os.getenv("MNE_BIDS_PIPELINE_TEST_DASK_CLUSTER", "") == "slurm":
+    dask_worker_startup_timeout = 60.0  # CI's slurmd grants in seconds; fail fast
+
+    def dask_cluster():
+        """Submit each Dask worker as a 1-core SLURM job."""
+        from dask_jobqueue import SLURMCluster
+
+        cluster = SLURMCluster(
+            cores=1, processes=1, memory="2.5GB", walltime="02:00:00"
+        )
+        cluster.scale(jobs=4)
+        return cluster
+
 
 if task == "N400":
     dask_open_dashboard = True

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -270,6 +270,15 @@ def test_run(
         print()
         main()
 
+    # e.g. MNE_BIDS_PIPELINE_TEST_DASK_CLUSTER=slurm makes config_ERP_CORE.py farm
+    # workers out through dask-jobqueue (needs a live scheduler, see the SLURM CI job)
+    if os.getenv("MNE_BIDS_PIPELINE_TEST_DASK_CLUSTER", ""):
+        # guard against silently falling back to a local cluster
+        from mne_bids_pipeline import _parallel
+
+        assert _parallel.dask_client is not None
+        assert type(_parallel.dask_client.cluster).__name__ == "SLURMCluster"
+
     # post-run checks for correctness
     config_data = config_path.read_text("utf-8")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ mne_bids_pipeline = "mne_bids_pipeline._main:main"
 dev = [
   "Pygments",
   "codespell",
+  "dask-jobqueue",  # SLURM test (MNE_BIDS_PIPELINE_TEST_DASK_CLUSTER)
   "httpx >= 0.20",
   "jinja2",
   "lefthook",

--- a/uv.lock
+++ b/uv.lock
@@ -887,6 +887,19 @@ distributed = [
 ]
 
 [[package]]
+name = "dask-jobqueue"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dask" },
+    { name = "distributed" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/2a/751bb5ba28533476b1c667eac158e5aa1840c416fd61d425328ef48a894a/dask_jobqueue-0.9.0.tar.gz", hash = "sha256:494ef64b7bb3848c7d72ed334c288030caca6a09dca54cfaa3f395f4ba7f5c47", size = 56475, upload-time = "2024-08-22T09:25:21.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/77/606f138bf70b14865842b3ec9a58dc1ba97153f466e5876fe4ced980f91f/dask_jobqueue-0.9.0-py2.py3-none-any.whl", hash = "sha256:253dfc4f0b8722201a08e05b841859dfeea1f6698ff21eff0d9370e5aa8ae20f", size = 52037, upload-time = "2024-08-22T09:25:20.106Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1328,7 +1341,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -2278,6 +2291,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "codespell" },
+    { name = "dask-jobqueue" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "lefthook" },
@@ -2345,6 +2359,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "codespell" },
+    { name = "dask-jobqueue" },
     { name = "httpx", specifier = ">=0.20" },
     { name = "jinja2" },
     { name = "lefthook" },


### PR DESCRIPTION
Closes #1160

Adds support for SLURM and HPC via [`dask-jobqueue`](https://jobqueue.dask.org/en/latest/). This makes it pretty simple actually! The only real tricky part is the I/O handling to get `rich` to log the dask outputs correctly. Getting CircleCI to set up a SLURM cluster isn't too bad either (~40 lines of bash). Implemented by Claude Fable 5 and reviewed by and then iterated on by me.